### PR TITLE
disable publish settings of root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -172,6 +172,12 @@ val otherProjects = Seq[ProjectReference](
 lazy val root = (project in file("."))
   .settings(name := "lagom")
   .settings(common: _*)
+  .settings(
+    PgpKeys.publishSigned := {},
+    publishLocal := {},
+    publishArtifact in Compile := false,
+    publish := {}
+  )
   .enablePlugins(lagom.UnidocRoot)
   .settings(UnidocRoot.settings(Nil, otherProjects): _*)
   .aggregate(apiProjects: _*)


### PR DESCRIPTION
I think following root jar is empty and unnecessary.

http://repo1.maven.org/maven2/com/lightbend/lagom/lagom_2.10/1.0.0-M1/

There are same settings in playframework and akka.
- https://github.com/akka/akka/blob/v2.4.2/project/AkkaBuild.scala#L397-L401
- https://github.com/playframework/interplay/blob/1.1.2/src/main/scala/interplay/PlayBuildBase.scala#L258-L260