### PR TITLE
Use correct version of sbt-plugin in chirper

### DIFF
--- a/samples/chirper/project/plugins.sbt
+++ b/samples/chirper/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "0.1.0-SNAPSHOT")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-SNAPSHOT")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 addSbtPlugin("com.github.ddispaltro" % "sbt-reactjs" % "0.5.2")


### PR DESCRIPTION
I think the sbt-plugin in the chirper sample has the wrong version number.