### PR TITLE
Added docs source URL

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -2,6 +2,14 @@
 val PlayVersion = "2.5.0"
 val AkkaVersion = "2.4.2"
 
+val branch = {
+  val rev = "git rev-parse --abbrev-ref HEAD".!!.trim
+  if (rev == "HEAD") {
+    // not on a branch, get the hash
+    "git rev-parse HEAD".!!.trim
+  } else rev
+}
+
 lazy val docs = project
   .in(file("."))
   .enablePlugins(LightbendMarkdown)
@@ -38,6 +46,7 @@ lazy val docs = project
     ),
     markdownUseBuiltinTheme := false,
     markdownTheme := Some("lagom.LagomMarkdownTheme"),
+    markdownSourceUrl := Some(url(s"https://github.com/lagom/lagom/tree/$branch/docs/manual/")),
 
     markdownS3CredentialsHost := "downloads.typesafe.com.s3.amazonaws.com",
     markdownS3Bucket := Some("downloads.typesafe.com"),
@@ -85,7 +94,7 @@ lazy val theme = project
     scalaVersion := "2.11.7",
     resolvers += Resolver.typesafeIvyRepo("releases"),
     libraryDependencies ++= Seq(
-      "com.lightbend.markdown" %% "lightbend-markdown-server" % "1.2.0",
+      "com.lightbend.markdown" %% "lightbend-markdown-server" % LightbendMarkdownVersion,
       "org.webjars" % "jquery" % "1.9.0",
       "org.webjars" % "prettify" % "4-Mar-2013"
     ),

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -3,7 +3,7 @@ lazy val plugins = (project in file(".")).dependsOn(dev)
 lazy val dev = ProjectRef(Path.fileProperty("user.dir").getParentFile, "sbt-plugin")
 
 resolvers += Resolver.typesafeIvyRepo("releases")
-addSbtPlugin("com.lightbend.markdown" % "sbt-lightbend-markdown" % "1.2.0")
+addSbtPlugin("com.lightbend.markdown" % "sbt-lightbend-markdown" % "1.3.0")
 
 // Needed for bintray configuration code samples
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/docs/theme/src/main/scala/lagom/LagomMarkdownTheme.scala
+++ b/docs/theme/src/main/scala/lagom/LagomMarkdownTheme.scala
@@ -6,8 +6,8 @@ import play.twirl.api.Html
 
 object LagomMarkdownTheme extends MarkdownTheme {
   override def renderPage(projectName: Option[String], title: Option[String], home: String, content: Html,
-    sidebar: Option[Html], apiDocs: Seq[(String, String)]): Html =
-    html.documentation(projectName, title, home, content, sidebar, apiDocs)
+    sidebar: Option[Html], apiDocs: Seq[(String, String)], sourceUrl: Option[String]): Html =
+    html.documentation(projectName, title, home, content, sidebar, apiDocs, sourceUrl)
 
   override def renderNextLink(toc: TocTree): Html = html.nextLink(toc)
 }

--- a/docs/theme/src/main/twirl/lagom/documentation.scala.html
+++ b/docs/theme/src/main/twirl/lagom/documentation.scala.html
@@ -1,7 +1,7 @@
 @*
 * Copyright (C) 2009-2016 Lightbend Inc. <https://www.lightbend.com>
 *@
-@(projectName: Option[String], title: Option[String], home: String, content: Html, sidebar: Option[Html], apiDocs: Seq[(String, String)])
+@(projectName: Option[String], title: Option[String], home: String, content: Html, sidebar: Option[Html], apiDocs: Seq[(String, String)], sourceUrl: Option[String])
 
 <!DOCTYPE html>
 <html lang="en">
@@ -49,6 +49,11 @@
 
                         <article id="page-content">
                             @content
+
+                            @sourceUrl.map { url =>
+                                <hr />
+                                <p>Found an error in this documentation? The source code for this page can be found <a href="@url">here</a>. Please feel free to edit and contribute a pull request.</p>
+                            }
                         </article>
 
                     </div>


### PR DESCRIPTION
This puts a link at the bottom of the page to the original markdown source for the page, to encourage people that find errors to fix them.  Also the upgrade to lightbend-markdown 1.3.0 fixes the issue in the navigation where the home section is called "HOME.HTML".