### PR TITLE
use correct lagom-sbt-plugin version in chirper sample

### DIFF
--- a/samples/chirper/project/plugins.sbt
+++ b/samples/chirper/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-SNAPSHOT")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.0.0-M1")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "3.0.0")
 addSbtPlugin("com.github.ddispaltro" % "sbt-reactjs" % "0.5.2")


### PR DESCRIPTION
## Fixes

When building the chirper sample application the lagom-sbt-plugin % "1.0.0-SNAPSHOT" could not be resolved. I updated to 1.0.0-M1 which fixes the issue. (this version is also used when I create a new lagom project using activator)

## Purpose

Fix build issue with chirper sample application




