### PR TITLE
Moved CassandraConfig to be part of the Java API

### DIFF
--- a/dev/cassandra-registration/src/main/scala/com/lightbend/lagom/internal/server/CassandraModule.scala
+++ b/dev/cassandra-registration/src/main/scala/com/lightbend/lagom/internal/server/CassandraModule.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Future
 
 import com.google.inject.AbstractModule
 import com.google.inject.Inject
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfig
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
 import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorHolder
 import com.lightbend.lagom.internal.registry.ServiceRegistry
 import com.lightbend.lagom.internal.registry.ServiceRegistryService

--- a/dev/cassandra-registration/src/main/scala/com/lightbend/lagom/internal/server/CassandraModule.scala
+++ b/dev/cassandra-registration/src/main/scala/com/lightbend/lagom/internal/server/CassandraModule.scala
@@ -12,6 +12,7 @@ import scala.concurrent.Future
 import com.google.inject.AbstractModule
 import com.google.inject.Inject
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraContactPoint
 import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorHolder
 import com.lightbend.lagom.internal.registry.ServiceRegistry
 import com.lightbend.lagom.internal.registry.ServiceRegistryService
@@ -37,11 +38,11 @@ object CassandraModule {
   private class RegisterCassandraContactPoints @Inject() (config: CassandraConfig, registry: ServiceRegistry, serviceLocator: ServiceLocator, system: ActorSystem)(implicit ec: ExecutionContext) {
 
     val registered = config.uris.map {
-      case (name, uri) =>
-        val r = new ServiceRegistryService(uri, Collections.emptyList[ServiceAcl])
-        registry.register().invoke(name, r).toScala.recover {
+      case contactPoint: CassandraContactPoint =>
+        val r = new ServiceRegistryService(contactPoint.uri, Collections.emptyList[ServiceAcl])
+        registry.register().invoke(contactPoint.name, r).toScala.recover {
           case t =>
-            Logger(getClass).error(s"Cassandra server name=[$name] couldn't be registered to the service locator.", t)
+            Logger(getClass).error(s"Cassandra server name=[${contactPoint.name}] couldn't be registered to the service locator.", t)
             NotUsed
         }
     }

--- a/dev/cassandra-registration/src/main/scala/com/lightbend/lagom/internal/server/CassandraModule.scala
+++ b/dev/cassandra-registration/src/main/scala/com/lightbend/lagom/internal/server/CassandraModule.scala
@@ -8,6 +8,7 @@ import java.util.Collections
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
+import scala.collection.JavaConverters._
 
 import com.google.inject.AbstractModule
 import com.google.inject.Inject
@@ -37,7 +38,7 @@ object CassandraModule {
   // make it impossible to work with Cassandra).
   private class RegisterCassandraContactPoints @Inject() (config: CassandraConfig, registry: ServiceRegistry, serviceLocator: ServiceLocator, system: ActorSystem)(implicit ec: ExecutionContext) {
 
-    val registered = config.uris.map {
+    val registered = config.uris.asScala.map {
       case contactPoint: CassandraContactPoint =>
         val r = new ServiceRegistryService(contactPoint.uri, Collections.emptyList[ServiceAcl])
         registry.register().invoke(contactPoint.name, r).toScala.recover {

--- a/dev/play-integration/src/main/scala/com/lightbend/lagom/play/LagomPlayModule.scala
+++ b/dev/play-integration/src/main/scala/com/lightbend/lagom/play/LagomPlayModule.scala
@@ -4,17 +4,14 @@
 package com.lightbend.lagom.play
 
 import java.util.Optional
-
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
-
 import com.google.inject.Provider
 import com.lightbend.lagom.internal.registry.ServiceRegistry
 import com.lightbend.lagom.internal.registry.ServiceRegistryService
 import com.lightbend.lagom.javadsl.api.ServiceAcl
 import com.lightbend.lagom.javadsl.api.ServiceInfo
 import com.lightbend.lagom.javadsl.api.transport.Method
-
 import akka.NotUsed
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/dev/play-integration/src/main/scala/com/lightbend/lagom/play/LagomPlayModule.scala
+++ b/dev/play-integration/src/main/scala/com/lightbend/lagom/play/LagomPlayModule.scala
@@ -3,7 +3,9 @@
  */
 package com.lightbend.lagom.play
 
+import java.net.URI
 import java.util.Optional
+
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import com.google.inject.Provider
@@ -12,6 +14,7 @@ import com.lightbend.lagom.internal.registry.ServiceRegistryService
 import com.lightbend.lagom.javadsl.api.ServiceAcl
 import com.lightbend.lagom.javadsl.api.ServiceInfo
 import com.lightbend.lagom.javadsl.api.transport.Method
+
 import akka.NotUsed
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -42,7 +45,7 @@ class PlayRegisterWithServiceRegistry @Inject() (config: Configuration, serviceI
 
   private val httpAddress = config.underlying.getString("play.server.http.address")
   private val httpPort = config.underlying.getString("play.server.http.port")
-  private val serviceUrl = s"http://$httpAddress:$httpPort"
+  private val serviceUrl = new URI(s"http://$httpAddress:$httpPort")
 
   private val acls = config.underlying.getConfigList("lagom.play.acls").asScala.map { aclConfig =>
     val method = if (aclConfig.hasPath("method")) {

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all/b/src-b/main/java/api/FooService.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all/b/src-b/main/java/api/FooService.java
@@ -15,6 +15,6 @@ public interface FooService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/fooservice").with(restCall(Method.GET,  "/foo",    foo()));
+    return named("/fooservice2").with(restCall(Method.GET,  "/foo",    foo()));
   }
 }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all/c/src-c/main/java/api/FooService.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all/c/src-c/main/java/api/FooService.java
@@ -15,6 +15,6 @@ public interface FooService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/fooservice").with(restCall(Method.GET,  "/foo",    foo()));
+    return named("/fooservice3").with(restCall(Method.GET,  "/foo",    foo()));
   }
 }

--- a/dev/service-locator/src/main/java/com/lightbend/lagom/discovery/impl/ServiceRegistryImpl.java
+++ b/dev/service-locator/src/main/java/com/lightbend/lagom/discovery/impl/ServiceRegistryImpl.java
@@ -3,6 +3,7 @@
  */
 package com.lightbend.lagom.discovery.impl;
 
+import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -62,13 +63,13 @@ public class ServiceRegistryImpl implements ServiceRegistry {
 	}
 
 	@Override
-	public ServiceCall<String, NotUsed, String> lookup() {
+	public ServiceCall<String, NotUsed, URI> lookup() {
 		return (name, request) -> {
 			if (LOGGER.isDebugEnabled())
 				LOGGER.debug("locate invoked, name=[" + name + "], request=[" + request + "]");
 			return PatternsCS.ask(registry, new Lookup(name), timeout).thenApply(result -> {
 				@SuppressWarnings("unchecked")
-				Optional<String> location = OptionConverters.toJava((Option<String>) result);
+				Optional<URI> location = OptionConverters.toJava((Option<URI>) result);
 				logServiceLookupResult(name, location);
 				if (location.isPresent()) {
 					return location.get();
@@ -91,7 +92,7 @@ public class ServiceRegistryImpl implements ServiceRegistry {
 		};
 	}
 
-	private void logServiceLookupResult(String name, Optional<String> location) {
+	private void logServiceLookupResult(String name, Optional<URI> location) {
 		if (LOGGER.isDebugEnabled()) {
 			if (location.isPresent())
 				LOGGER.debug("Location of service name=[" + name + "] is " + location.get());

--- a/dev/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceRegistryActor.scala
+++ b/dev/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceRegistryActor.scala
@@ -55,7 +55,7 @@ class ServiceRegistryActor @Inject() (unmanagedServices: UnmanagedServices) exte
     case GetRegisteredServices =>
       val services: List[RegisteredService] = (for {
         (name, service) <- registry
-      } yield RegisteredService.of(name, service.uri()))(collection.breakOut)
+      } yield RegisteredService.of(name, service.uri))(collection.breakOut)
       import scala.collection.JavaConverters._
       sender() ! RegisteredServices(TreePVector.from(services.asJava))
     case route: Route =>
@@ -63,7 +63,7 @@ class ServiceRegistryActor @Inject() (unmanagedServices: UnmanagedServices) exte
   }
 
   private def serviceRouter(service: ServiceRegistryService) = {
-    val addressUri = URI.create(service.uri)
+    val addressUri = service.uri
     val address = new InetSocketAddress(addressUri.getHost, addressUri.getPort)
     service.acls.asScala.map {
       case acl =>

--- a/dev/service-locator/src/main/scala/com/lightbend/lagom/discovery/UnmanagedServices.scala
+++ b/dev/service-locator/src/main/scala/com/lightbend/lagom/discovery/UnmanagedServices.scala
@@ -5,18 +5,16 @@ package com.lightbend.lagom.discovery
 
 import java.util.Collections
 import java.util.{ Map => JMap }
-
 import scala.collection.JavaConverters._
-
 import com.lightbend.lagom.internal.registry.ServiceRegistryService
-
 import javax.inject.Inject
+import java.net.URI
 
 case class UnmanagedServices @Inject() (services: Map[String, ServiceRegistryService])
 object UnmanagedServices {
   def apply(services: JMap[String, String]): UnmanagedServices = {
     val convertedServices = for ((name, url) <- services.asScala.toMap) yield {
-      name -> new ServiceRegistryService(url, Collections.emptyList())
+      name -> new ServiceRegistryService(new URI(url), Collections.emptyList())
     }
     UnmanagedServices(convertedServices)
   }

--- a/dev/service-locator/src/test/scala/com/lightbend/lagom/discovery/impl/ServiceRegistryImplSpec.scala
+++ b/dev/service-locator/src/test/scala/com/lightbend/lagom/discovery/impl/ServiceRegistryImplSpec.scala
@@ -20,6 +20,7 @@ import com.lightbend.lagom.discovery.UnmanagedServices
 import akka.NotUsed
 import java.util.concurrent.TimeUnit
 import com.lightbend.lagom.internal.registry.RegisteredService
+import java.net.URI
 
 class ServiceRegistryImplSpec extends WordSpecLike with Matchers {
 
@@ -27,7 +28,7 @@ class ServiceRegistryImplSpec extends WordSpecLike with Matchers {
 
   "A service registry" should {
     "allow to register a service" in withServiceRegistry() { registry =>
-      val expectedUrl = "http://localhost:9000"
+      val expectedUrl = new URI("http://localhost:9000")
       val serviceName = "fooservice"
       registry.register().invoke(serviceName, new ServiceRegistryService(expectedUrl, Collections.emptyList[ServiceAcl]))
       val registeredUrl = registry.lookup().invoke("fooservice", NotUsed).toCompletableFuture().get(
@@ -37,7 +38,7 @@ class ServiceRegistryImplSpec extends WordSpecLike with Matchers {
     }
 
     "allow to register a service of same service twice (idempotent)" in withServiceRegistry() { registry =>
-      val expectedUrl = "http://localhost:9000"
+      val expectedUrl = new URI("http://localhost:9000")
       val serviceName = "fooservice"
       registry.register().invoke(serviceName, new ServiceRegistryService(expectedUrl, Collections.emptyList[ServiceAcl]))
         .toCompletableFuture().get(testTimeoutInSeconds, TimeUnit.SECONDS)
@@ -57,8 +58,8 @@ class ServiceRegistryImplSpec extends WordSpecLike with Matchers {
     }
 
     "disallow registering the different endpoint for same name twice or more" in withServiceRegistry() { registry =>
-      val url1 = "http://localhost:9000"
-      val url2 = "http://localhost:9001"
+      val url1 = new URI("http://localhost:9000")
+      val url2 = new URI("http://localhost:9001")
       val serviceName = "fooservice"
       registry.register().invoke("fooservice", new ServiceRegistryService(url1, Collections.emptyList[ServiceAcl]))
         .toCompletableFuture.get(testTimeoutInSeconds, TimeUnit.SECONDS)
@@ -69,7 +70,7 @@ class ServiceRegistryImplSpec extends WordSpecLike with Matchers {
     }
 
     "allow to retrieve the full list of registered services" in {
-      val url = "http://localhost:9000"
+      val url = new URI("http://localhost:9000")
       val name = "fooservice"
       val service = new ServiceRegistryService(url, Collections.emptyList[ServiceAcl])
       val registeredService = Map(name -> service)

--- a/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/AbstractRegisteredService.java
+++ b/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/AbstractRegisteredService.java
@@ -5,6 +5,9 @@ package com.lightbend.lagom.internal.registry;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.lightbend.lagom.javadsl.immutable.ImmutableStyle;
+
+import java.net.URI;
+
 import org.immutables.value.Value;
 
 
@@ -23,6 +26,6 @@ public interface AbstractRegisteredService {
   String name();
   
   @Value.Parameter
-  String url();
+  URI url();
 
 }

--- a/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/RegisteredService.java
+++ b/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/RegisteredService.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import java.net.URI;
 import java.util.List;
 import javax.annotation.Generated;
 import javax.annotation.Nullable;
@@ -31,14 +32,14 @@ import javax.annotation.concurrent.NotThreadSafe;
 public final class RegisteredService
     implements AbstractRegisteredService {
   private final String name;
-  private final String url;
+  private final URI url;
 
-  private RegisteredService(String name, String url) {
+  private RegisteredService(String name, URI url) {
     this.name = Preconditions.checkNotNull(name, "name");
     this.url = Preconditions.checkNotNull(url, "url");
   }
 
-  private RegisteredService(RegisteredService original, String name, String url) {
+  private RegisteredService(RegisteredService original, String name, URI url) {
     this.name = name;
     this.url = url;
   }
@@ -57,7 +58,7 @@ public final class RegisteredService
    */
   @JsonProperty
   @Override
-  public String url() {
+  public URI url() {
     return url;
   }
 
@@ -79,9 +80,9 @@ public final class RegisteredService
    * @param value A new value for url
    * @return A modified copy of the {@code this} object
    */
-  public final RegisteredService withUrl(String value) {
+  public final RegisteredService withUrl(URI value) {
     if (this.url == value) return this;
-    String newValue = Preconditions.checkNotNull(value, "url");
+    URI newValue = Preconditions.checkNotNull(value, "url");
     return new RegisteredService(this, this.name, newValue);
   }
 
@@ -134,19 +135,19 @@ public final class RegisteredService
   @JsonDeserialize
   static final class Json implements AbstractRegisteredService {
     @Nullable String name;
-    @Nullable String url;
+    @Nullable URI url;
 
     public void setName(String name) {
       this.name = name;
     }
 
-    public void setUrl(String url) {
+    public void setUrl(URI url) {
       this.url = url;
     }
     @Override
     public String name() { throw new UnsupportedOperationException(); }
     @Override
-    public String url() { throw new UnsupportedOperationException(); }
+    public URI url() { throw new UnsupportedOperationException(); }
   }
 
   /**
@@ -173,7 +174,7 @@ public final class RegisteredService
    * @param url The value for the {@code url} attribute
    * @return An immutable RegisteredService instance
    */
-  public static RegisteredService of(String name, String url) {
+  public static RegisteredService of(String name, URI url) {
     return new RegisteredService(name, url);
   }
 
@@ -215,7 +216,7 @@ public final class RegisteredService
     private long initBits = 0x3;
 
     private @Nullable String name;
-    private @Nullable String url;
+    private @Nullable URI url;
 
     private Builder() {}
 
@@ -249,7 +250,7 @@ public final class RegisteredService
      * @param url The value for url 
      * @return {@code this} builder for use in a chained invocation
      */
-    public final Builder url(String url) {
+    public final Builder url(URI url) {
       this.url = Preconditions.checkNotNull(url, "url");
       initBits &= ~INIT_BIT_URL;
       return this;

--- a/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/ServiceRegistry.java
+++ b/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/ServiceRegistry.java
@@ -7,15 +7,29 @@ import static com.lightbend.lagom.javadsl.api.Service.named;
 import static com.lightbend.lagom.javadsl.api.Service.pathCall;
 import static com.lightbend.lagom.javadsl.api.Service.restCall;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
 
 import org.pcollections.PSequence;
 
 import akka.NotUsed;
+import akka.util.ByteString;
 import com.lightbend.lagom.javadsl.api.Descriptor;
 import com.lightbend.lagom.javadsl.api.Service;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.deser.DeserializationException;
+import com.lightbend.lagom.javadsl.api.deser.SerializationException;
+import com.lightbend.lagom.javadsl.api.deser.StrictMessageSerializer;
+import com.lightbend.lagom.javadsl.api.deser.MessageSerializer.NegotiatedDeserializer;
+import com.lightbend.lagom.javadsl.api.deser.MessageSerializer.NegotiatedSerializer;
+import com.lightbend.lagom.javadsl.api.transport.MessageProtocol;
 import com.lightbend.lagom.javadsl.api.transport.Method;
+import com.lightbend.lagom.javadsl.api.transport.NotAcceptable;
+import com.lightbend.lagom.javadsl.api.transport.TransportErrorCode;
+import com.lightbend.lagom.javadsl.api.transport.TransportException;
+import com.lightbend.lagom.javadsl.api.transport.UnsupportedMediaType;
 
 public interface ServiceRegistry extends Service {
 
@@ -23,7 +37,7 @@ public interface ServiceRegistry extends Service {
 
 	ServiceCall<String, ServiceRegistryService, NotUsed> register();
 	ServiceCall<String, NotUsed, NotUsed> unregister();
-	ServiceCall<String, NotUsed, String> lookup();
+	ServiceCall<String, NotUsed, URI> lookup();
 	ServiceCall<NotUsed, NotUsed, PSequence<RegisteredService>> registeredServices();
 	
 	@Override
@@ -32,9 +46,85 @@ public interface ServiceRegistry extends Service {
 		return named(SERVICE_NAME)
 	      .with(restCall(Method.PUT, "/services/:id", register()))
 		  .with(restCall(Method.DELETE, "/services/:id", unregister()))
-		  .with(restCall(Method.GET, "/services/:id", lookup()))
+		  .with(restCall(Method.GET, "/services/:id", lookup()).withResponseSerializer(CustomSerializers.URI))
 		  .with(pathCall("/services", registeredServices())
         ).withLocatableService(false);
 		// @formatter:on
 	}
+}
+
+class CustomSerializers {
+  /**
+   * A serializer for URI.
+   */
+  public static final StrictMessageSerializer<URI> URI = new StrictMessageSerializer<URI>() {
+
+      MessageProtocol defaultProtocol = new MessageProtocol(Optional.of("text/plain"), Optional.of("utf-8"), Optional.empty());
+
+      class URISerializer implements NegotiatedSerializer<URI, ByteString> {
+          private final MessageProtocol protocol;
+
+          URISerializer(MessageProtocol protocol) {
+              this.protocol = protocol;
+          }
+
+          @Override
+          public MessageProtocol protocol() {
+              return protocol;
+          }
+
+          @Override
+          public ByteString serialize(URI uri) throws SerializationException {
+              return ByteString.fromString(uri.toString(), protocol.charset().orElse("utf-8"));
+          }
+      }
+
+      class URIDeserializer implements NegotiatedDeserializer<URI, ByteString> {
+          private final String charset;
+
+          URIDeserializer(String charset) {
+              this.charset = charset;
+          }
+
+          @Override
+          public URI deserialize(ByteString wire) throws DeserializationException {
+              try {
+                return new URI(wire.decodeString(charset));
+              }
+              catch(URISyntaxException e) {
+                throw new DeserializationException(e);
+              } 
+          }
+      }
+
+      @Override
+      public NegotiatedSerializer<URI, ByteString> serializerForRequest() {
+          return new URISerializer(defaultProtocol);
+      }
+
+      @Override
+      public NegotiatedDeserializer<URI, ByteString> deserializer(MessageProtocol protocol) throws UnsupportedMediaType {
+          if (protocol.contentType().orElse("text/plain").equals("text/plain")) {
+              return new URIDeserializer(protocol.charset().orElse("utf-8"));
+          } else {
+              throw new UnsupportedMediaType(protocol, defaultProtocol);
+          }
+      }
+
+      @Override
+      public NegotiatedSerializer<URI, ByteString> serializerForResponse(List<MessageProtocol> acceptedMessageProtocols) throws NotAcceptable {
+          if (acceptedMessageProtocols.isEmpty()) {
+              return serializerForRequest();
+          } else {
+              for (MessageProtocol messageProtocol: acceptedMessageProtocols) {
+                  String contentType = messageProtocol.contentType().orElse("text/plain");
+
+                  if (contentType.equals("text/plain") || contentType.equals("text/*") || contentType.equals("*/*") || contentType.equals("*")) {
+                      return new URISerializer(messageProtocol.withContentType("text/plain"));
+                  }
+              }
+              throw new NotAcceptable(acceptedMessageProtocols, defaultProtocol);
+          }
+      }
+  };
 }

--- a/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/ServiceRegistryService.java
+++ b/dev/service-registry-client/src/main/java/com/lightbend/lagom/internal/registry/ServiceRegistryService.java
@@ -5,21 +5,22 @@ package com.lightbend.lagom.internal.registry;
 
 import com.lightbend.lagom.javadsl.api.ServiceAcl;
 
+import java.net.URI;
 import java.util.List;
 
 /**
  * A service to be registered by the service registry
  */
 public class ServiceRegistryService {
-    private final String uri;
+    private final URI uri;
     private final List<ServiceAcl> acls;
 
-    public ServiceRegistryService(String uri, List<ServiceAcl> acls) {
+    public ServiceRegistryService(URI uri, List<ServiceAcl> acls) {
         this.uri = uri;
         this.acls = acls;
     }
 
-    public String uri() {
+    public URI uri() {
         return uri;
     }
 

--- a/persistence/src/main/java/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraContactPoint.java
+++ b/persistence/src/main/java/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraContactPoint.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence.cassandra;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.concurrent.Immutable;
+ 
+@ParametersAreNonnullByDefault
+@Immutable
+public final class CassandraContactPoint {
+  private final String name;
+  private final String uri;
+
+  private CassandraContactPoint(String name, String uri) {
+    this.name = Preconditions.checkNotNull(name, "name");
+    this.uri = Preconditions.checkNotNull(uri, "uri");
+  }
+
+  /**
+   * @return The value of the {@code name} attribute
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * @return The value of the {@code uri} attribute
+   */
+  public String uri() {
+    return uri;
+  }
+
+  /**
+   * This instance is equal to all instances of {@code CassandraContactPoint} that have equal attribute values.
+   * @return {@code true} if {@code this} is equal to {@code another} instance
+   */
+  @Override
+  public boolean equals(@Nullable Object another) {
+    if (this == another) return true;
+    return another instanceof CassandraContactPoint
+        && equalTo((CassandraContactPoint) another);
+  }
+
+  private boolean equalTo(CassandraContactPoint another) {
+    return name.equals(another.name)
+        && uri.equals(another.uri);
+  }
+
+  /**
+   * Computes a hash code from attributes: {@code name}, {@code uri}.
+   * @return hashCode value
+   */
+  @Override
+  public int hashCode() {
+    int h = 31;
+    h = h * 17 + name.hashCode();
+    h = h * 17 + uri.hashCode();
+    return h;
+  }
+
+  /**
+   * Prints the immutable value {@code CassandraContactPoint...} with all non-generated
+   * and non-auxiliary attribute values.
+   * @return A string representation of the value
+   */
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper("CassandraContactPoint")
+        .add("name", name)
+        .add("uri", uri)
+        .toString();
+  }
+
+  /**
+   * Construct a new immutable {@code CassandraContactPoint} instance.
+   * @param name The value for the {@code name} attribute
+   * @param uri The value for the {@code uri} attribute
+   * @return An immutable CassandraContactPoint instance
+   */
+  public static CassandraContactPoint of(String name, String uri) {
+    return new CassandraContactPoint(name, uri);
+  }
+}

--- a/persistence/src/main/java/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraContactPoint.java
+++ b/persistence/src/main/java/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraContactPoint.java
@@ -5,6 +5,7 @@ package com.lightbend.lagom.javadsl.persistence.cassandra;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import java.net.URI;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.annotation.concurrent.Immutable;
@@ -13,9 +14,9 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class CassandraContactPoint {
   private final String name;
-  private final String uri;
+  private final URI uri;
 
-  private CassandraContactPoint(String name, String uri) {
+  private CassandraContactPoint(String name, URI uri) {
     this.name = Preconditions.checkNotNull(name, "name");
     this.uri = Preconditions.checkNotNull(uri, "uri");
   }
@@ -30,7 +31,7 @@ public final class CassandraContactPoint {
   /**
    * @return The value of the {@code uri} attribute
    */
-  public String uri() {
+  public URI uri() {
     return uri;
   }
 
@@ -81,7 +82,7 @@ public final class CassandraContactPoint {
    * @param uri The value for the {@code uri} attribute
    * @return An immutable CassandraContactPoint instance
    */
-  public static CassandraContactPoint of(String name, String uri) {
+  public static CassandraContactPoint of(String name, URI uri) {
     return new CassandraContactPoint(name, uri);
   }
 }

--- a/persistence/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConfig.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConfig.scala
@@ -3,41 +3,37 @@
  */
 package com.lightbend.lagom.internal.persistence.cassandra
 
+import java.net.URI
+
 import scala.language.implicitConversions
+
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
 
 import akka.actor.ActorSystem
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
 
-trait CassandraConfig {
-  def uris: Set[(String, String)]
+// Injecting ActorSystem and not Configuration because Configuration isn't always bound when running tests
+@Singleton
+class CassandraConfigProvider @Inject() (system: ActorSystem) extends Provider[CassandraConfig] {
+  private val config = system.settings.config
+
+  override lazy val get: CassandraConfig = CassandraConfigProvider.CassandraConfigImpl(cassandraUrisFromConfig)
+
+  private def cassandraUrisFromConfig: Set[(String, String)] = {
+    List("cassandra-journal", "cassandra-snapshot-store", "lagom.persistence.read-side.cassandra").flatMap { path =>
+      val c = config.getConfig(path)
+      if (c.getString("session-provider") == classOf[ServiceLocatorSessionProvider].getName) {
+        val name = c.getString("cluster-id")
+        val port = c.getInt("port")
+        val uri = s"tcp://127.0.0.1:$port/$name"
+        Some(name -> uri)
+      } else None
+    }.toSet
+  }
 }
 
-object CassandraConfig {
-  // Injecting ActorSystem and not Configuration because Configuration isn't always bound when running tests
-  @Singleton
-  class CassandraConfigProvider @Inject() (system: ActorSystem) extends Provider[CassandraConfig] {
-    private val config = system.settings.config
-
-    override lazy val get: CassandraConfig = CassandraConfigImpl(cassandraUrisFromConfig)
-
-    private def cassandraUrisFromConfig: Set[(String, String)] = {
-      List("cassandra-journal", "cassandra-snapshot-store", "lagom.persistence.read-side.cassandra").flatMap { path =>
-        val c = config.getConfig(path)
-        if (c.getString("session-provider") == classOf[ServiceLocatorSessionProvider].getName) {
-          val name = c.getString("cluster-id")
-          val port = c.getInt("port")
-          val uri = s"tcp://127.0.0.1:$port/$name"
-          Some(name -> uri)
-        } else None
-      }.toSet
-    }
-
-    import scala.language.implicitConversions
-    private implicit def asFiniteDuration(d: java.time.Duration) =
-      scala.concurrent.duration.Duration.fromNanos(d.toNanos)
-  }
-
-  private[this] case class CassandraConfigImpl(uris: Set[(String, String)]) extends CassandraConfig
+private object CassandraConfigProvider {
+  case class CassandraConfigImpl(uris: Set[(String, String)]) extends CassandraConfig
 }

--- a/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistenceModule.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistenceModule.scala
@@ -11,8 +11,8 @@ import com.google.inject.spi.InjectionListener
 import com.google.inject.spi.TypeEncounter
 import com.google.inject.spi.TypeListener
 import com.lightbend.lagom.internal.persistence.PersistentEntityRegistryImpl
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfig.CassandraConfigProvider
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfigProvider
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideImpl
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraSessionImpl
 import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorHolder
@@ -31,7 +31,7 @@ class PersistenceModule extends AbstractModule {
     binder.bind(classOf[PersistentEntityRegistry]).to(classOf[PersistentEntityRegistryImpl])
     binder.bind(classOf[CassandraSession]).to(classOf[CassandraSessionImpl])
     binder.bind(classOf[CassandraReadSide]).to(classOf[CassandraReadSideImpl])
-    binder.bind(classOf[CassandraConfig]).toProvider(classOf[CassandraConfig.CassandraConfigProvider])
+    binder.bind(classOf[CassandraConfig]).toProvider(classOf[CassandraConfigProvider])
     binder.bind(classOf[PersistenceModule.InitServiceLocatorHolder]).asEagerSingleton()
     initServiceLocatorHolder()
   }

--- a/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraConfig.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraConfig.scala
@@ -3,10 +3,11 @@
  */
 package com.lightbend.lagom.javadsl.persistence.cassandra
 
+import java.net.URI
+
 trait CassandraConfig {
-  /**
-   * Returns the Cassandra contact-points as a collection of pairs.
-   * Each contact-point (i.e., each pair) is composed of a cluster ID and it's full URL.
-   */
-  def uris: Set[(String, String)]
+
+  /** Returns the Cassandra contact-points. */
+  def uris: Set[CassandraContactPoint]
+
 }

--- a/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraConfig.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraConfig.scala
@@ -4,10 +4,11 @@
 package com.lightbend.lagom.javadsl.persistence.cassandra
 
 import java.net.URI
+import org.pcollections.PSet
 
 trait CassandraConfig {
 
   /** Returns the Cassandra contact-points. */
-  def uris: Set[CassandraContactPoint]
+  def uris: PSet[CassandraContactPoint]
 
 }

--- a/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraConfig.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraConfig.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence.cassandra
+
+trait CassandraConfig {
+  /**
+   * Returns the Cassandra contact-points as a collection of pairs.
+   * Each contact-point (i.e., each pair) is composed of a cluster ID and it's full URL.
+   */
+  def uris: Set[(String, String)]
+}

--- a/server/src/main/scala/com/lightbend/lagom/internal/server/ServerModule.scala
+++ b/server/src/main/scala/com/lightbend/lagom/internal/server/ServerModule.scala
@@ -4,10 +4,10 @@
 package com.lightbend.lagom.internal.server
 
 import javax.inject.Inject
-
 import com.google.inject.Provider
 import play.api.{ Configuration, Environment }
 import play.api.inject.{ Binding, Module }
+import java.net.URI
 
 class ServerModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
@@ -20,10 +20,10 @@ class ServiceConfigProvider @Inject() (config: Configuration) extends Provider[S
     // FIXME: I'm unsure about how to support both http and https services in dev mode.
     val httpAddress = config.underlying.getString("play.server.http.address")
     val httpPort = config.getString("play.server.http.port").get
-    val url = s"http://$httpAddress:$httpPort"
+    val url = new URI(s"http://$httpAddress:$httpPort")
 
     ServiceConfig(url)
   }
 }
 
-case class ServiceConfig(url: String)
+case class ServiceConfig(url: URI)

--- a/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
@@ -3,21 +3,27 @@
  */
 package com.lightbend.lagom.internal.testkit
 
-import javax.inject.Singleton
 import java.net.URI
 import java.util.Optional
-import java.util.concurrent.CompletionStage
-import com.lightbend.lagom.javadsl.api.ServiceLocator
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import akka.persistence.cassandra.testkit.CassandraLauncher
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import com.lightbend.lagom.javadsl.api.ServiceLocator
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
+
 import javax.inject.Inject
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfig
+import javax.inject.Singleton
 
 @Singleton
-private[lagom] class TestServiceLocator @Inject() (port: TestServiceLocatorPort, config: CassandraConfig) extends ServiceLocator {
+private[lagom] class TestServiceLocator @Inject() (
+  port:            TestServiceLocatorPort,
+  config:          CassandraConfig,
+  implicit val ec: ExecutionContext
+) extends ServiceLocator {
 
   private val futureUri = port.port.map(p => URI.create("http://localhost:" + p))
 

--- a/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -28,9 +29,8 @@ private[lagom] class TestServiceLocator @Inject() (
 
   private val futureUri = port.port.map(p => URI.create("http://localhost:" + p))
 
-  private val cassandraUris = config.uris.map {
-    case contactPoint: CassandraContactPoint => contactPoint.name -> new URI(contactPoint.uri)
-  }.toMap
+  private val cassandraUris: Map[String, URI] =
+    (config.uris.asScala.map(contactPoint => contactPoint.name -> contactPoint.uri))(collection.breakOut)
 
   override def doWithService[R](name: String, block: java.util.function.Function[URI, CompletionStage[R]]): CompletionStage[Optional[R]] = {
     val result = cassandraUris.get(name) match {

--- a/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
@@ -14,6 +14,7 @@ import scala.concurrent.Future
 
 import com.lightbend.lagom.javadsl.api.ServiceLocator
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraContactPoint
 
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,7 +29,7 @@ private[lagom] class TestServiceLocator @Inject() (
   private val futureUri = port.port.map(p => URI.create("http://localhost:" + p))
 
   private val cassandraUris = config.uris.map {
-    case (name, uri) => name -> new URI(uri)
+    case contactPoint: CassandraContactPoint => contactPoint.name -> new URI(contactPoint.uri)
   }.toMap
 
   override def doWithService[R](name: String, block: java.util.function.Function[URI, CompletionStage[R]]): CompletionStage[Optional[R]] = {

--- a/testkit/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -16,13 +16,13 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 import com.lightbend.lagom.internal.cluster.JoinClusterModule
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfig.CassandraConfigProvider
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfigProvider
 import com.lightbend.lagom.internal.testkit.TestServiceLocator
 import com.lightbend.lagom.internal.testkit.TestServiceLocatorPort
 import com.lightbend.lagom.javadsl.api.Service
 import com.lightbend.lagom.javadsl.api.ServiceLocator
 import com.lightbend.lagom.javadsl.persistence.PersistenceModule
+import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
 import com.lightbend.lagom.javadsl.persistence.testkit.TestUtil
 import com.lightbend.lagom.javadsl.pubsub.PubSubModule
 
@@ -190,7 +190,7 @@ object ServiceTest {
 
     val b1 = new GuiceApplicationBuilder()
       .bindings(sBind[TestServiceLocatorPort].to(testServiceLocatorPort))
-      .bindings(sBind[CassandraConfig].toProvider(classOf[CassandraConfig.CassandraConfigProvider]))
+      .bindings(sBind[CassandraConfig].toProvider(classOf[CassandraConfigProvider]))
       .bindings(sBind[ServiceLocator].to(classOf[TestServiceLocator]))
       .configure("play.akka.actor-system", testName)
 


### PR DESCRIPTION
This PR is based on the feedback provided by @patriknw on https://github.com/lagom/lagom/pull/53.

In a nutshell, it makes `CassandraConfig` part of the Java API. Because of that, a couple more refactoring were needed:

* Java API classes should not leak Scala types such as `Pair` and `Set`, and
* `URI` should be used instead of plain `String`.

Refer to the commit messages for more details.