### PR TITLE
Ensure query params get added to client requests

### DIFF
--- a/api/src/main/scala/com/lightbend/lagom/internal/api/Path.scala
+++ b/api/src/main/scala/com/lightbend/lagom/internal/api/Path.scala
@@ -54,7 +54,7 @@ case class Path(parts: Seq[PathPart], queryParams: Seq[String]) {
     }
     val path = resultPathParts.mkString
     val queryParams = rawId.queryParams().asScala.collect {
-      case (name, values) if values.isEmpty =>
+      case (name, values) if !values.isEmpty =>
         name -> values.asScala.toSeq
     }.toMap
     path -> queryParams

--- a/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/MockServiceImpl.java
+++ b/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/MockServiceImpl.java
@@ -17,6 +17,7 @@ import com.lightbend.lagom.javadsl.server.HeaderServiceCall;
 import com.lightbend.lagom.javadsl.server.ServerServiceCall;
 import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -138,7 +139,12 @@ public class MockServiceImpl implements MockService {
         );
     }
 
-    /**
+    @Override
+    public ServiceCall<Optional<String>, NotUsed, String> queryParamId() {
+        return (id, request) -> CompletableFuture.completedFuture(id.orElse("none"));
+    }
+
+  /**
      * Shows example service call composition.
      */
     private <Id, Request, Response> ServerServiceCall<Id, Request, Response> withServiceName(

--- a/service-integration-tests/src/test/scala/com/lightbend/lagom/it/MockServiceSpec.scala
+++ b/service-integration-tests/src/test/scala/com/lightbend/lagom/it/MockServiceSpec.scala
@@ -3,6 +3,7 @@
  */
 package com.lightbend.lagom.it
 
+import java.util.Optional
 import java.util.concurrent.TimeUnit
 import akka.stream.scaladsl.{ Sink, Flow, Source }
 import com.lightbend.lagom.it.mocks._
@@ -123,6 +124,11 @@ class MockServiceSpec extends ServiceSupport {
     "send the service name on streams" in withMockServiceClient { implicit app => client =>
       Await.result(client.streamServiceName().invoke().toCompletableFuture.get(10, TimeUnit.SECONDS)
         .asScala.runWith(Sink.head), 10.seconds) should ===("mockservice")
+    }
+
+    "work with query params" in withMockServiceClient { implicit app => client =>
+      client.queryParamId().invoke(Optional.of("foo"), NotUsed.getInstance())
+        .toCompletableFuture.get(10, TimeUnit.SECONDS) should ===("foo")
     }
 
     "be invoked with circuit breaker" in withMockServiceClient { implicit app => client =>


### PR DESCRIPTION
Query parameters weren't being added to client requests, this ensures they are.