### PR TITLE
Avoid redefining sbt update task for dev runtime configs. Fix #74

### DIFF
--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/run/RunSupport.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/run/RunSupport.scala
@@ -106,13 +106,13 @@ private[sbt] object RunSupport {
   }
 
   private def devModeDependencies = Def.task {
-    cassandraDependencyClasspath.value ++ (externalDependencyClasspath in Internal.Configs.DevRuntime).value
+    cassandraDependencyClasspath.value ++ (managedClasspath in Internal.Configs.DevRuntime).value
   }
 
   private def cassandraDependencyClasspath = Def.task {
     val projectDependencies = (allDependencies in Runtime).value
     if (projectDependencies.exists(_ == LagomImport.lagomJavadslPersistence))
-      (dependencyClasspath in Internal.Configs.CassandraRuntime).value
+      (managedClasspath in Internal.Configs.CassandraRuntime).value
     else
       Seq.empty
   }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
@@ -65,7 +65,7 @@ def checkDevClasspathTask(config: Configuration): Def.Initialize[InputTask[Unit]
 }
 
 def checkClasspath(projName: String, name: String, config: Configuration): Def.Initialize[Task[Unit]] = Def.task {
-  val cp = classpathOf(projName, config).value.flatten
+  val cp = classpathOf(projName, config).value
   val names = cp.files.map(_.getName)
   val matches = names.filter(_ contains name)
   if (matches.isEmpty)
@@ -75,6 +75,5 @@ def checkClasspath(projName: String, name: String, config: Configuration): Def.I
 def classpathOf(projName: String, config: Configuration) = Def.taskDyn {
   val structure = buildStructure.value
   val projRef = ProjectRef(structure.root, projName)
-  val filter = ScopeFilter(inDependencies(projRef), inConfigurations(config))
-  fullClasspath.all(filter)
+  managedClasspath in projRef in config
 }


### PR DESCRIPTION
As explained in the related ticket, adding the `Defaults.baseClasspaths`
settings to the `DevRuntime` ivy configuration, was preventing the update cache
to properly work, and effectively cause full dependency resolution to be
triggered every time the `runAll` task was evaluated.

The fix implemented in this commit is to simply scope dependencies needed only
during development to the `DevRuntime` configuration, instead of adding tasks to
the configuration.