### PR TITLE
Added support for declaring services using a Scala trait

### DIFF
--- a/api/src/main/java/com/lightbend/lagom/javadsl/api/Service.java
+++ b/api/src/main/java/com/lightbend/lagom/javadsl/api/Service.java
@@ -10,9 +10,6 @@ import com.lightbend.lagom.internal.api.UnresolvedTypeIdSerializer;
 import akka.NotUsed;
 import com.lightbend.lagom.javadsl.api.transport.Method;
 import java.lang.reflect.Type;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 /**
  * A self describing service.

--- a/api/src/main/scala/com/lightbend/lagom/internal/api/ScalaSig.scala
+++ b/api/src/main/scala/com/lightbend/lagom/internal/api/ScalaSig.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.api
+
+import scala.util.matching.Regex
+
+// https://github.com/retronym/scalac-survival-guide/blob/master/src/main/scala/guide/_19_ScalaSig.scala
+// Jason warned me it may not be robust, but it seems to work fine for the specific purpose we have (i.e., 
+// checking if a top-level Class was created with Scala). 
+object ScalaSig {
+  private val ModuleClassName: Regex = """(.*)\$""".r
+  private val ImplClassName: Regex = """(.*)\$class""".r
+
+  def isScala(cls: Class[_]) = {
+    import scala.reflect.{ ScalaSignature, ScalaLongSignature }
+    def hasAnn(cls: Class[_]): Boolean = {
+      val anns = List(classOf[ScalaSignature], classOf[ScalaLongSignature])
+      anns.exists(ann => cls.getDeclaredAnnotation(ann) != null)
+    }
+    def classForName(name: String, init: Boolean, loader: ClassLoader): Option[Class[_]] = try {
+      Some(Class.forName(name, init, loader))
+    } catch {
+      case _: ClassNotFoundException =>
+        None
+    }
+
+    def topLevelClass(cls: Class[_]): Class[_] = {
+      if (cls.getEnclosingClass != null) topLevelClass(cls.getEnclosingClass)
+      else {
+        cls.getName match {
+          case ModuleClassName(companionClassName) =>
+            classForName(companionClassName, init = false, cls.getClassLoader).getOrElse(cls)
+          case ImplClassName(interfaceName) =>
+            classForName(interfaceName, init = false, cls.getClassLoader).getOrElse(cls)
+          case _ => cls
+        }
+      }
+    }
+    hasAnn(topLevelClass(cls))
+  }
+}

--- a/api/src/test/scala/com/lightbend/lagom/api/mock/ScalaMockService.scala
+++ b/api/src/test/scala/com/lightbend/lagom/api/mock/ScalaMockService.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.api.mock
+
+import com.lightbend.lagom.javadsl.api.Descriptor
+import com.lightbend.lagom.javadsl.api.Service
+import com.lightbend.lagom.javadsl.api.Service._
+import com.lightbend.lagom.javadsl.api.ServiceCall
+import com.lightbend.lagom.javadsl.api.transport.Method
+import akka.NotUsed
+
+trait ScalaMockService extends Service {
+
+  def hello(): ServiceCall[String, NotUsed, String]
+
+  override def descriptor(): Descriptor =
+    named("/mock").`with`(restCall(Method.GET, "/hello/:name", hello()))
+}
+
+abstract class ScalaMockServiceWrong extends ScalaMockService


### PR DESCRIPTION
Lagom can now consume Service declaration in the form of a Scala trait, which
was not possible before this commit.

This commit only intends to improve usability of Scala with the Lagom Java API.