### PR TITLE
Added full details to exceptions when in dev mode

### DIFF
--- a/api/src/main/java/com/lightbend/lagom/javadsl/api/deser/ExceptionSerializer.java
+++ b/api/src/main/java/com/lightbend/lagom/javadsl/api/deser/ExceptionSerializer.java
@@ -8,10 +8,35 @@ import com.lightbend.lagom.javadsl.api.transport.MessageProtocol;
 
 import java.util.Collection;
 
+/**
+ * Handles the serialization and deserialization of exceptions.
+ */
 public interface ExceptionSerializer {
 
+    /**
+     * Serialize the given exception to an exception message.
+     *
+     * The raw exception message consists of an error code, a message protocol, and a message entity to send across the
+     * wire.
+     *
+     * The exception serializer may attempt to match one of the protocols passed into the accept parameter.
+     *
+     * @param exception The exception to serialize.
+     * @param accept The accepted protocols.
+     * @return The raw exception message.
+     */
     RawExceptionMessage serialize(Throwable exception, Collection<MessageProtocol> accept);
 
+    /**
+     * Deserialize an exception message into an exception.
+     *
+     * The exception serializer should make a best effort attempt at deserializing the message, but should not expect
+     * the message to be in any particular format.  If it cannot deserialize the message, it should return a generic
+     * exception, it should not itself throw an exception.
+     *
+     * @param message The message to deserialize.
+     * @return The deserialized exception.
+     */
     Throwable deserialize(RawExceptionMessage message);
 
     /**

--- a/api/src/main/java/com/lightbend/lagom/javadsl/api/deser/RawExceptionMessage.java
+++ b/api/src/main/java/com/lightbend/lagom/javadsl/api/deser/RawExceptionMessage.java
@@ -11,6 +11,15 @@ import java.util.Base64;
 
 /**
  * A serialized exception message.
+ *
+ * A serialized exception message consists of a transport error code, a protocol, and a message body. All, some or none
+ * of these details may be sent over the wire when the error is sent, depending on what the underlying protocol
+ * supports.
+ *
+ * Some protocols have a maximum limit on the amount of data that can be sent with an error message, eg for WebSockets,
+ * the WebSocket close frame can have a maximum payload of 125 bytes.  While it's up to the transport implementation
+ * itself to enforce this limit and gracefully handle when the message exceeds this, exception serializers should be
+ * aware of this when producing exception messages.
  */
 public class RawExceptionMessage {
 
@@ -24,14 +33,31 @@ public class RawExceptionMessage {
         this.message = message;
     }
 
+    /**
+     * The error code.
+     *
+     * This will be sent as an HTTP status code, or WebSocket close code.
+     *
+     * @return The error code.
+     */
     public TransportErrorCode errorCode() {
         return errorCode;
     }
 
+    /**
+     * The protocol.
+     *
+     * @return The protocol.
+     */
     public MessageProtocol protocol() {
         return protocol;
     }
 
+    /**
+     * The message.
+     *
+     * @return The message.
+     */
     public ByteString message() {
         return message;
     }
@@ -49,5 +75,35 @@ public class RawExceptionMessage {
         } else {
             return Base64.getEncoder().encodeToString(message.toArray());
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RawExceptionMessage that = (RawExceptionMessage) o;
+
+        if (!errorCode.equals(that.errorCode)) return false;
+        if (!protocol.equals(that.protocol)) return false;
+        return message.equals(that.message);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = errorCode.hashCode();
+        result = 31 * result + protocol.hashCode();
+        result = 31 * result + message.hashCode();
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RawExceptionMessage{" +
+                "errorCode=" + errorCode +
+                ", protocol=" + protocol +
+                ", message=" + message +
+                '}';
     }
 }

--- a/docs/manual/guide/services/ServiceErrorHandling.md
+++ b/docs/manual/guide/services/ServiceErrorHandling.md
@@ -1,0 +1,18 @@
+# Service error handling
+
+Lagom provides a number of different mechanisms for controlling and customising the way errors are handled and reported between services.
+
+There are a number of principles behind the design of Lagom's built in error handling:
+
+* In production, a Lagom service should never give out details of the errors it encounters to another service, unless it knows it is safe to do so.  This is for security reasons, uncensored error messages can be used by attackers to gain detailed information about how a service is implemented.  In practice, this means there are a number of built in exceptions that Lagom considers safe that it will returns the details of, and the rest it returns nothing for.
+* In development, it's useful to have full error messages sent over the wire.  Lagom will attempt to send useful information about exceptions when the service is running in development.
+* If possible, Lagom will try to reconstruct errors on the client side when thrown on the service side.  So, if the server side throws an exception saying it couldn't serialize something, the client code should receive that same exception.
+* If possible, exceptions should be mapped to idiomatic protocol response codes, such as HTTP 4xx and 5xx status codes and WebSocket error close codes.
+
+## Exception serializers
+
+Lagom provides an [`ExceptionSerializer`](api/java/index.html?com/lightbend/lagom/javadsl/api/deser/ExceptionSerializer.html) interface that allows exceptions to be serialized into some form, such as JSON, and an error code to be selected.  It also allows an exception to be recreated from an error code and their serialized form.
+
+Exception serializers convert exceptions to [`RawExceptionMessage`](api/java/index.html?com/lightbend/lagom/javadsl/api/deser/RawExceptionMessage.html).  The raw exception message contains a status code, which will correspond to an HTTP status code or WebSocket close code, a message body, and a protocol descriptor to say what content type the message is - in HTTP, this will translate to a `Content-Type` header in the response.
+
+The default exception serializer provided by Lagom uses Jackson to serialize exceptions to JSON.  This exception serializer implements the guidelines stated above - it will only return details of the exception if it's a child class of [`TransportException`](api/java/index.html?com/lightbend/lagom/javadsl/api/transport/TransportException.html), unless in development.  There are a few useful built in subclasses of `TransportException` that you may use, these include [`NotFound`](api/java/index.html?com/lightbend/lagom/javadsl/api/transport/NotFound.html) and [`PolicyViolation`](api/java/index.html?com/lightbend/lagom/javadsl/api/transport/PolicyViolation.html).  Lagom will generally be able to throw these exceptions through to the client.  You may also instantiate `TransportException` directly and use that, or you may define a sub class of `TransportException`, however note that Lagom won't throw the subclass in a client since it will not know about it.

--- a/docs/manual/guide/services/index.toc
+++ b/docs/manual/guide/services/index.toc
@@ -3,3 +3,4 @@ ServiceImplementation:Implementing services
 ServiceClients:Consuming services
 Test:Testing Services
 MessageSerializers:Message serializers
+ServiceErrorHandling:Error handling

--- a/integration-client/src/main/java/com/lightbend/lagom/javadsl/client/integration/LagomClientFactory.java
+++ b/integration-client/src/main/java/com/lightbend/lagom/javadsl/client/integration/LagomClientFactory.java
@@ -204,7 +204,7 @@ public class LagomClientFactory implements Closeable {
         ServiceInfo serviceInfo = new ServiceInfo(serviceName);
 
         JacksonSerializerFactory serializerFactory = new JacksonSerializerFactory(actorSystem);
-        JacksonExceptionSerializer exceptionSerializer = new JacksonExceptionSerializer();
+        JacksonExceptionSerializer exceptionSerializer = new JacksonExceptionSerializer(new play.Environment(environment));
 
         Function<ServiceLocator, ServiceClientLoader> serviceClientLoaderCreator = serviceLocator -> {
             ServiceClientImplementor implementor = new ServiceClientImplementor(wsClient, webSocketClient, serviceInfo,


### PR DESCRIPTION
Fixes #107

Also:

* Added tests for this
* Fixed a bug when exceptions serialized to WebSocket close frames exceed the maximum control frame payload length
* Documented error handling and exception serializers