### PR TITLE
Remove duplicated "when" in documentation sample

### DIFF
--- a/docs/manual/guide/cluster/code/docs/home/persistence/Post2.java
+++ b/docs/manual/guide/cluster/code/docs/home/persistence/Post2.java
@@ -41,7 +41,7 @@ public class Post2 extends PersistentEntity<BlogCommand, BlogEvent, BlogState> {
     });
 
     //#event-handler
-    // Event handlers are used both when when persisting new events
+    // Event handlers are used both when persisting new events
     // and when replaying events.
     b.setEventHandler(PostAdded.class, evt ->
       state().withContent(Optional.of(evt.getContent())));


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Not related to an issue

## Purpose

It removes duplicated "when" in a documentation sample code

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?

"when" was written twice