### PR TITLE
WIP - Support for facilitating creating a read-side Cassandra table [don't merge]

### DIFF
--- a/persistence/src/main/resources/reference.conf
+++ b/persistence/src/main/resources/reference.conf
@@ -160,7 +160,16 @@ lagom.persistence.read-side {
     # Set the protocol version explicitly, should only be used for compatibility testing.
     # Supported values: 3, 4
     protocol-version = ""
-    
+
+    create-table {
+      # Max attempts that will be tried to successfully execute a create table statement (a 
+      # negative number means it will be tried until it succeeds). The configuration key 
+      # `retry-backoff-interval` defines the interval waited between each retry.
+      retries = -1
+
+      # Interval waited between each retry.
+      retry-backoff-interval = 2 seconds  
+    }
   }
 
   # Exponential backoff for failures in CassandraReadSideProcessor    

--- a/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideTableCreator.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideTableCreator.scala
@@ -1,0 +1,54 @@
+package com.lightbend.lagom.javadsl.persistence.cassandra
+
+import java.util.concurrent.TimeUnit
+
+import scala.compat.java8.FutureConverters.CompletionStageOps
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+import org.slf4j.LoggerFactory
+
+import com.google.inject.Inject
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.actor.Scheduler
+import akka.pattern.after
+import play.api.Configuration
+
+class CassandraReadSideTableCreator @Inject() (db: CassandraSession, system: ActorSystem, config: CassandraReadSideTableCreator.Config)(implicit ec: ExecutionContext) {
+  private val log = LoggerFactory.getLogger(classOf[CassandraReadSideTableCreator])
+
+  private implicit val scheduler = system.scheduler
+
+  def createTable(createTableStatement: String): Future[Done] = {
+    val createTable = retry(config.retries, config.retryBackoff) {
+      db.executeCreateTable(createTableStatement).toScala
+    }.map(_ => Done)
+
+    createTable.onFailure {
+      case err: Throwable => log.error(s"Failed to execute create table statement:\n$createTableStatement. Reason: ${err.getMessage}", err)
+    }
+
+    createTable
+  }
+
+  private def retry[T](retries: Int, delay: FiniteDuration)(op: => Future[T])(implicit ec: ExecutionContext, s: Scheduler): Future[T] = {
+    op.recoverWith {
+      case _ if (retries != 0) =>
+        val retriesLeft = if (retries > 0) retries - 1 else retries
+        after(delay, s)(retry(retriesLeft, delay)(op)(ec, s))
+    }
+  }
+}
+
+object CassandraReadSideTableCreator {
+  private class Config @Inject() (config: Configuration) {
+    val retries: Int = config.getInt("lagom.persistence.read-side.cassandra.create-table.retries").get
+    val retryBackoff: FiniteDuration = {
+      val backoff = config.getMilliseconds("lagom.persistence.read-side.cassandra.create-table.retry-backoff-interval").get
+      new FiniteDuration(backoff, TimeUnit.MILLISECONDS)
+    }
+  }
+}


### PR DESCRIPTION
**I've opened this PR to collect feedback on the functionality and its current implementation**

As highlighted in lagom/activator-lagom-java-chirper#24, making sure that a
read-side table is (eventually) created can be challenging. In particular, users
need to ensure that the create table statement is retried if Cassandra isn't
available.

This commit addresses the problem by encapsulating the retry logic in a new API
class: `CassandraReadSideTableCreator`. Both the number of attempts and the
interval between each attempt is configurable.

@patriknw what do you think?