### PR TITLE
Use ProjectRef to assign service ports

### DIFF
--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -338,7 +338,7 @@ object LagomPlugin extends AutoPlugin {
         normalizedName
       }
     },
-    lagomServicePort := PortAssigner.assignedPortFor(name.value),
+    lagomServicePort := PortAssigner.assignedPortFor(thisProjectRef.value.project),
     Internal.Keys.stop := {
       Internal.Keys.interactionMode.value match {
         case nonBlocking: PlayNonBlockingInteractionMode => nonBlocking.stop()


### PR DESCRIPTION
## Fixes

Fixes #135 

## Purpose

The previous approach to assign ports to a Lagom service project was to use the project name key.  The name key, however, is a mutable SBT key.  This bugfix uses the ProjectRef, which per the SBT code "uniquely references a project" and shouldn't change.