### PR TITLE
Make default persistent entity offset Long

### DIFF
--- a/persistence/src/main/java/com/lightbend/lagom/javadsl/persistence/Offset.java
+++ b/persistence/src/main/java/com/lightbend/lagom/javadsl/persistence/Offset.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence;
+
+import java.util.UUID;
+
+/**
+ * An offset.
+ *
+ * Offsets are used for ordering of events, typically in event journals, so that consumers can keep track of what events
+ * they have and haven't consumed.
+ *
+ * Akka persistence, which underlies Lagom's persistence APIs, uses different offset types for different persistence
+ * datastores. This class provides an abstraction over them. The two types currently supported are a <code>long</code>
+ * sequence number and a time based <code>UUID</code>.
+ */
+public abstract class Offset {
+
+    private Offset() {}
+
+    /**
+     * Create a sequence offset.
+     *
+     * @param value The sequence number to create it from.
+     * @return The sequence offset.
+     */
+    public static Offset sequence(long value) {
+        return new Sequence(value);
+    }
+
+    /**
+     * Create a time based UUID offset.
+     *
+     * @param uuid The timebased UUID to create it from.
+     * @return The time based UUID.
+     */
+    public static Offset timeBasedUUID(UUID uuid) {
+        return new TimeBasedUUID(uuid);
+    }
+
+    /**
+     * No offset.
+     */
+    public static final Offset NONE = new NoOffset();
+
+    /**
+     * A sequence number offset, backed by a long.
+     */
+    public static final class Sequence extends Offset implements Comparable<Sequence> {
+        private final long value;
+
+        public Sequence(long value) {
+            this.value = value;
+        }
+
+        public long value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Sequence sequence1 = (Sequence) o;
+
+            return value == sequence1.value;
+
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(value);
+        }
+
+        @Override
+        public String toString() {
+            return Long.toString(value);
+        }
+
+        @Override
+        public int compareTo(Sequence o) {
+            return Long.compare(value, o.value);
+        }
+    }
+
+    /**
+     * A time-based UUID offset, backed by a UUID.
+     */
+    public static final class TimeBasedUUID extends Offset implements Comparable<TimeBasedUUID> {
+        private final UUID value;
+
+        public TimeBasedUUID(UUID value) {
+            if (value == null || value.version() != 1) {
+                throw new IllegalArgumentException("UUID " + value + " is not a time-based UUID");
+            }
+            this.value = value;
+        }
+
+        public UUID value() {
+            return value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            TimeBasedUUID that = (TimeBasedUUID) o;
+
+            return value.equals(that.value);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return value.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
+        }
+
+        @Override
+        public int compareTo(TimeBasedUUID o) {
+            return value.compareTo(o.value);
+        }
+    }
+
+    public static final class NoOffset extends Offset {
+        private NoOffset() {}
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof NoOffset;
+        }
+
+        @Override
+        public String toString() {
+            return "NoOffset";
+        }
+    }
+}

--- a/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistenceModule.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistenceModule.scala
@@ -3,24 +3,19 @@
  */
 package com.lightbend.lagom.javadsl.persistence
 
-import com.google.inject.AbstractModule
-import com.google.inject.Inject
-import com.google.inject.TypeLiteral
+import com.google.inject.{ AbstractModule, Inject, Key, TypeLiteral }
 import com.google.inject.matcher.AbstractMatcher
 import com.google.inject.spi.InjectionListener
 import com.google.inject.spi.TypeEncounter
 import com.google.inject.spi.TypeListener
-import com.lightbend.lagom.internal.persistence.PersistentEntityRegistryImpl
-import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraPersistentEntityRegistry
+import com.lightbend.lagom.javadsl.persistence.cassandra.{ CassandraConfig, CassandraReadSide, CassandraSession }
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfigProvider
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideImpl
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraSessionImpl
 import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorHolder
 import com.lightbend.lagom.javadsl.api.ServiceLocator
 import com.lightbend.lagom.javadsl.persistence.PersistenceModule.InitServiceLocatorHolder
-import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraReadSide
-import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraSession
-
 import akka.actor.ActorSystem
 
 /**
@@ -28,7 +23,7 @@ import akka.actor.ActorSystem
  */
 class PersistenceModule extends AbstractModule {
   override def configure(): Unit = {
-    binder.bind(classOf[PersistentEntityRegistry]).to(classOf[PersistentEntityRegistryImpl])
+    binder.bind(classOf[PersistentEntityRegistry]).to(classOf[CassandraPersistentEntityRegistry])
     binder.bind(classOf[CassandraSession]).to(classOf[CassandraSessionImpl])
     binder.bind(classOf[CassandraReadSide]).to(classOf[CassandraReadSideImpl])
     binder.bind(classOf[CassandraConfig]).toProvider(classOf[CassandraConfigProvider])

--- a/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
@@ -5,12 +5,15 @@ package com.lightbend.lagom.javadsl.persistence
 
 import java.util.Optional
 import java.util.UUID
+
 import scala.concurrent.duration._
 import akka.japi.Pair
 import akka.stream.javadsl
 import akka.NotUsed
 import java.util.concurrent.CompletionStage
+
 import akka.Done
+import com.lightbend.lagom.javadsl.persistence.Offset.{ Sequence, TimeBasedUUID }
 
 /**
  * At system startup all [[PersistentEntity]] classes must be registered here
@@ -36,11 +39,47 @@ trait PersistentEntityRegistry {
   /**
    * A stream of the persistent events that have the given `aggregateTag`, e.g.
    * all persistent events of all `Order` entities.
+   *
+   * The type of the offset is journal dependent, some journals use time-based
+   * UUID offsets, while others use sequence numbers. The passed in `fromOffset`
+   * must either be [[Offset#NONE]], or an offset that has previously been produced
+   * by this journal.
+   *
+   * @throws IllegalArgumentException If the `fromOffset` type is not supported
+   *   by this journal.
    */
   def eventStream[Event <: AggregateEvent[Event]](
     aggregateTag: AggregateEventTag[Event],
+    fromOffset:   Offset
+  ): javadsl.Source[Pair[Event, Offset], NotUsed]
+
+  /**
+   * A stream of the persistent events that have the given `aggregateTag`, e.g.
+   * all persistent events of all `Order` entities.
+   *
+   * This method will only work with journals that support UUID offsets. Journals that
+   * produce sequence offsets will fail during stream handling.
+   */
+  @deprecated("Use eventStream(AggregateEventTag, Offset) instead", "1.2.0")
+  def eventStream[Event <: AggregateEvent[Event]](
+    aggregateTag: AggregateEventTag[Event],
     fromOffset:   Optional[UUID]
-  ): javadsl.Source[Pair[Event, UUID], NotUsed]
+  ): javadsl.Source[Pair[Event, UUID], NotUsed] = {
+    val offset = if (fromOffset.isPresent) {
+      Offset.timeBasedUUID(fromOffset.get())
+    } else Offset.NONE
+    eventStream(aggregateTag, offset).asScala.map { pair =>
+      val uuid = pair.second match {
+        case timeBased: TimeBasedUUID => timeBased.value()
+        case sequence: Sequence =>
+          // While we *could* translate the sequence number to a time-based UUID, this would be very bad, since the UUID
+          // would either be non unique (violating the fundamental aim of UUIDs), or it would change every time the
+          // event was loaded. Also, a sequence number is not a timestamp.
+          throw new IllegalStateException("Sequence based offset is not supported in a UUID event stream")
+      }
+      Pair(pair.first, uuid)
+    }.asJava
+  }
 
   /**
    * Gracefully stop the persistent entities and leave the cluster.


### PR DESCRIPTION
The current PersistentEntityRegistry API is specific to Cassandra, since it uses UUID for offsets, where Akka persistence only requires the use of Long.

This change moves the UUID version of the method to a new CassandraPeristentEntityRegistry trait, deprecates the existing method, and creates a new version of the method that uses Long offsets.

In order to keep the change binary compatible, the new method switches the order of parameters around. That's not entirely ideal, since it probably makes more sence to have the `startFrom` parameter second. However, I couldn't think of a better way, I think `eventStream` is the best name. I'm open to suggestions if someone can think of a better name or strategy to maintain binary compatibility.