### PR TITLE
Improved service locator/gateway error reporting

### DIFF
--- a/dev/service-locator/src/main/java/com/lightbend/lagom/discovery/impl/ServiceRegistryModule.java
+++ b/dev/service-locator/src/main/java/com/lightbend/lagom/discovery/impl/ServiceRegistryModule.java
@@ -34,7 +34,6 @@ public class ServiceRegistryModule extends AbstractModule implements ServiceGuic
 		bindServices(serviceBinding(ServiceRegistry.class, ServiceRegistryImpl.class));
 		bindActor(ServiceRegistryActor.class, SERVICE_REGISTRY_ACTOR);
 		bind(ServiceGatewayConfig.class).toInstance(serviceGatewayConfig);
-		bind(ServiceGateway.class).asEagerSingleton();
 		bind(UnmanagedServices.class).toInstance(UnmanagedServices.apply(unmanagedServices));
 		bind(ServiceLocator.class).to(NoServiceLocator.class);
 	}

--- a/dev/service-locator/src/main/scala/com/lightbend/lagom/gateway/ServiceGateway.scala
+++ b/dev/service-locator/src/main/scala/com/lightbend/lagom/gateway/ServiceGateway.scala
@@ -11,7 +11,6 @@ import javax.inject.{ Inject, Named, Singleton }
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
-import com.lightbend.lagom.discovery.ServiceRegistryActor
 import com.lightbend.lagom.internal.NettyFutureConverters
 import NettyFutureConverters._
 import com.lightbend.lagom.discovery.ServiceRegistryActor.{ Found, NotFound, Route, RouteResult }
@@ -46,8 +45,14 @@ case class ServiceGatewayConfig(
 )
 
 @Singleton
-class ServiceGateway @Inject() (lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig,
-                                @Named("serviceRegistryActor") registry: ActorRef) {
+class ServiceGatewayFactory @Inject() (lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig,
+  @Named("serviceRegistryActor") registry: ActorRef) {
+  def start(): ServiceGateway = {
+    new ServiceGateway(lifecycle, config, registry)
+  }
+}
+
+class ServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig, registry: ActorRef) {
 
   private implicit val timeout = Timeout(5.seconds)
   private val log = LoggerFactory.getLogger(classOf[ServiceGateway])


### PR DESCRIPTION
* Ensured the exception states which of the service locator and gateway didn't start, and what port it was running on.
* Ensure that when the service gateway fails to bind to the port, the exception is not wrapped in a guice creation exception, which adds a lot of noise.