### PR TITLE
Change docs source URL to edit

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -48,7 +48,7 @@ lazy val docs = project
     markdownTheme := Some("lagom.LagomMarkdownTheme"),
     markdownGenerateTheme := Some("bare"),
     markdownGenerateIndex := true,
-    markdownSourceUrl := Some(url(s"https://github.com/lagom/lagom/tree/$branch/docs/manual/")),
+    markdownSourceUrl := Some(url(s"https://github.com/lagom/lagom/edit/$branch/docs/manual/")),
 
     markdownS3CredentialsHost := "downloads.typesafe.com.s3.amazonaws.com",
     markdownS3Bucket := Some("downloads.typesafe.com"),


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?

Not applicable I assume
* [ ] Have you added tests for any changed functionality?

Don't know if there are any, happy to add (or change) them if there are.

## Fixes

N/A

## Purpose

This way it skips a step, making it 1 click to edit rather than 2.

## Background Context

I mentioned to @SethTisue that the ENSIME website (https://ensime.github.io/) has an [EDIT] button on each page, and he mentioned that the Lagom docs does as well, except it's a 2 click process.

## References

* #15 introduced docs source URL to Lagom
* typesafehub/lightbend-markdown@9d49952d6c9eea0a97e5ec5abf9e0d74aa6ebef0 introduced docs source URLs to the plugin