### PR TITLE
Use project name to build the port map

### DIFF
--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -320,9 +320,12 @@ object LagomPlugin extends AutoPlugin {
     // build the map at most once
     val projects = extracted.currentUnit.defined
     val lagomProjects = (for {
-      (name, proj) <- projects
+      (id, proj) <- projects
       if proj.autoPlugins.toSet.contains(LagomPlugin)
-    } yield ProjectName(name))(collection.breakOut)
+      projName <- (name in ProjectRef(extracted.currentUnit.unit.uri, id)).get(extracted.structure.data).toSeq
+    } yield {
+      ProjectName(projName)
+    })(collection.breakOut)
     val portMap = oldPortMap ++ PortAssigner.computeProjectsPort(portRange, lagomProjects)
     state.put(projectPortMap, portMap)
   }


### PR DESCRIPTION
Fixes #183.

Note I haven't added a test for this, since scripted tests are expensive, and I don't imagine this is going to regress anytime soon. I did reproduce locally, and then test that my fix fixed the problem.