### PR TITLE
Testkit changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -357,10 +357,11 @@ lazy val testkit = (project in file("testkit"))
       "com.typesafe.play" %% "play-netty-server" % PlayVersion,
       "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion exclude("io.netty", "netty-all"),
       "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
       scalaTest % Test
     )
   )
-  .dependsOn(server, pubsub, `persistence-cassandra` % "compile;test->test")
+  .dependsOn(server, pubsub, broker, persistence % "compile;test->test", `persistence-cassandra` % "test->test")
 
 lazy val `service-integration-tests` = (project in file("service-integration-tests"))
   .settings(name := "lagom-service-integration-tests")

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceTest.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceTest.java
@@ -18,7 +18,7 @@ public class ${service1ClassName}ServiceTest {
 
   @Test
   public void shouldStorePersonalizedGreeting() throws Exception {
-    withServer(defaultSetup(), server -> {
+    withServer(defaultSetup().withCassandra(true), server -> {
       ${service1ClassName}Service service = server.client(${service1ClassName}Service.class);
 
       String msg1 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);

--- a/dev/maven-plugin/src/maven-test/start-all/helloworld-impl/src/test/java/sample/helloworld/impl/HelloServiceTest.java
+++ b/dev/maven-plugin/src/maven-test/start-all/helloworld-impl/src/test/java/sample/helloworld/impl/HelloServiceTest.java
@@ -18,7 +18,7 @@ public class HelloServiceTest {
 
   @Test
   public void shouldStorePersonalizedGreeting() throws Exception {
-    withServer(defaultSetup(), server -> {
+    withServer(defaultSetup().withCassandra(true), server -> {
       HelloService service = server.client(HelloService.class);
 
       String msg1 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);

--- a/docs/src/test/java/docs/home/persistence/CqrsIntegrationTest.java
+++ b/docs/src/test/java/docs/home/persistence/CqrsIntegrationTest.java
@@ -57,7 +57,7 @@ public class CqrsIntegrationTest {
   @BeforeClass
   public static void setup() throws Exception {
 
-    Config config = TestUtil.persistenceConfig("CqrsIntegrationTest", CassandraLauncher.randomPort(), false);
+    Config config = TestUtil.persistenceConfig("CqrsIntegrationTest", CassandraLauncher.randomPort());
 
     File cassandraDirectory = new File("target/CqrsIntegrationTest");
     CassandraLauncher.start(cassandraDirectory, CassandraLauncher.DefaultTestConfigResource(), true, 0);

--- a/persistence-cassandra/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/testkit/TestUtil.scala
+++ b/persistence-cassandra/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/testkit/TestUtil.scala
@@ -8,8 +8,9 @@ import com.typesafe.config.Config
 
 object TestUtil extends AbstractTestUtil {
 
-  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean): Config = {
-    com.lightbend.lagom.javadsl.persistence.testkit.TestUtil.persistenceConfig(testName, cassandraPort, useServiceLocator)
+  def persistenceConfig(testName: String, cassandraPort: Int): Config = {
+    com.lightbend.lagom.javadsl.persistence.testkit.TestUtil.persistenceConfig(testName, cassandraPort,
+      useServiceLocator = false)
   }
 
 }

--- a/persistence-cassandra/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
+++ b/persistence-cassandra/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
@@ -11,13 +11,8 @@ import com.lightbend.lagom.javadsl.persistence.multinode.{AbstractClusteredPersi
 import com.typesafe.config.{Config, ConfigFactory}
 
 object CassandraClusteredPersistentEntityConfig extends AbstractClusteredPersistentEntityConfig {
-  override def additionalCommonConfig(databasePort: Int): Config = ConfigFactory.parseString(
-    """
-      cassandra-journal.session-provider = akka.persistence.cassandra.ConfigSessionProvider
-      cassandra-snapshot-store.session-provider = akka.persistence.cassandra.ConfigSessionProvider
-      lagom.persistence.read-side.cassandra.session-provider = akka.persistence.cassandra.ConfigSessionProvider
-    """
-  ).withFallback(TestUtil.persistenceConfig("ClusteredPersistentEntitySpec", databasePort, useServiceLocator = false))
+  override def additionalCommonConfig(databasePort: Int): Config =
+    TestUtil.persistenceConfig("ClusteredPersistentEntitySpec", databasePort)
 }
 
 class CassandraClusteredPersistentEntitySpecMultiJvmNode1 extends CassandraClusteredPersistentEntitySpec

--- a/persistence-cassandra/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
+++ b/persistence-cassandra/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
@@ -48,7 +48,7 @@ public class PersistentEntityRefTest {
         "akka.remote.netty.tcp.port = 0 \n" +
         "akka.remote.netty.tcp.hostname = 127.0.0.1 \n" +
         "akka.loglevel = INFO \n")
-        .withFallback(TestUtil.persistenceConfig("PersistentEntityRefTest", CassandraLauncher.randomPort(), false));
+        .withFallback(TestUtil.persistenceConfig("PersistentEntityRefTest", CassandraLauncher.randomPort()));
 
     application = new GuiceApplicationBuilder()
             .configure(new Configuration(config))

--- a/persistence-cassandra/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -17,7 +17,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
   def this(testName: String, config: Config) =
     this(ActorSystem(testName, config.withFallback(TestUtil.persistenceConfig(
       testName,
-      CassandraLauncher.randomPort, useServiceLocator = false
+      CassandraLauncher.randomPort
     ))))
 
   def this(config: Config) = this(PersistenceSpec.getCallerName(getClass), config)

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/testkit/TestUtil.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/testkit/TestUtil.scala
@@ -16,13 +16,11 @@ import java.util.concurrent.TimeUnit
 @deprecated("Use com.lightbend.lagom.javadsl.persistence.cassandra.testkit.TestUtil instead", "1.2.0")
 object TestUtil extends AbstractTestUtil {
 
-  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean): Config = {
-    (if (useServiceLocator) ConfigFactory.empty
-    else ConfigFactory.parseString(s"""
-      cassandra-journal.session-provider = akka.persistence.cassandra.ConfigSessionProvider
-      cassandra-snapshot-store.session-provider = akka.persistence.cassandra.ConfigSessionProvider
-      lagom.persistence.read-side.cassandra.session-provider = akka.persistence.cassandra.ConfigSessionProvider
-    """)).withFallback(ConfigFactory.parseString(s"""
+  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean) = ConfigFactory.parseString(s"""
+    cassandra-journal.session-provider = akka.persistence.cassandra.ConfigSessionProvider
+    cassandra-snapshot-store.session-provider = akka.persistence.cassandra.ConfigSessionProvider
+    lagom.persistence.read-side.cassandra.session-provider = akka.persistence.cassandra.ConfigSessionProvider
+
     akka.persistence.journal.plugin = "cassandra-journal"
     akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
 
@@ -42,8 +40,7 @@ object TestUtil extends AbstractTestUtil {
     }
 
     akka.test.single-expect-default = 5s
-    """)).withFallback(clusterConfig())
-  }
+    """).withFallback(clusterConfig())
 
   class AwaitPersistenceInit extends PersistentActor {
     def persistenceId: String = self.path.name

--- a/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/PersistenceServiceTest.java
+++ b/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/PersistenceServiceTest.java
@@ -21,7 +21,10 @@ public class PersistenceServiceTest {
   
   @BeforeClass
   public static void setUp() {
-    server = startServer(defaultSetup().withConfigureBuilder(b -> b.bindings(new PersistenceServiceModule())));
+    server = startServer(defaultSetup()
+                    .withCassandra(true)
+                    .withConfigureBuilder(b -> b.bindings(new PersistenceServiceModule()))
+    );
     client = server.client(PersistenceService.class);
   }
   

--- a/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestServiceLocator.scala
@@ -5,40 +5,29 @@ package com.lightbend.lagom.internal.testkit
 
 import java.net.URI
 import java.util.Optional
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionStage
 
 import scala.compat.java8.FutureConverters._
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import com.lightbend.lagom.javadsl.api.{ Descriptor, ServiceLocator }
+import com.lightbend.lagom.javadsl.api.Descriptor
 import javax.inject.Inject
 import javax.inject.Singleton
 
 import com.lightbend.lagom.internal.client.CircuitBreakers
 import com.lightbend.lagom.javadsl.client.CircuitBreakingServiceLocator
-import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraConfig
 
 @Singleton
 private[lagom] class TestServiceLocator @Inject() (
   circuitBreakers: CircuitBreakers,
   port:            TestServiceLocatorPort,
-  config:          CassandraConfig,
   implicit val ec: ExecutionContext
 ) extends CircuitBreakingServiceLocator(circuitBreakers) {
 
   private val futureUri = port.port.map(p => URI.create("http://localhost:" + p))
 
-  private val cassandraUris: Map[String, URI] =
-    config.uris.asScala.map(contactPoint => contactPoint.name -> contactPoint.uri)(collection.breakOut)
-
   override def locate(name: String, call: Descriptor.Call[_, _]): CompletionStage[Optional[URI]] =
-    cassandraUris.get(name) match {
-      case None      => futureUri.map(uri => Optional.of(uri)).toJava
-      case Some(uri) => CompletableFuture.completedFuture(Optional.of(uri))
-    }
-
+    futureUri.map(uri => Optional.of(uri)).toJava
 }
 
 private[lagom] final case class TestServiceLocatorPort(port: Future[Int])

--- a/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestTopicFactory.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/internal/testkit/TestTopicFactory.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.testkit
+
+import java.util.concurrent.CompletionStage
+import javax.inject.Inject
+
+import akka.Done
+import akka.stream.Materializer
+import akka.stream.javadsl.{ Flow, Sink, Source }
+import com.lightbend.lagom.internal.api.MethodTopicHolder
+import com.lightbend.lagom.internal.api.broker.TopicFactory
+import com.lightbend.lagom.internal.broker.TaggedOffsetTopicProducer
+import com.lightbend.lagom.internal.server.ResolvedServices
+import com.lightbend.lagom.javadsl.api.Descriptor.TopicCall
+import com.lightbend.lagom.javadsl.api.broker.Topic.TopicId
+import com.lightbend.lagom.javadsl.api.broker.{ Subscriber, Topic }
+import com.lightbend.lagom.javadsl.persistence.{ AggregateEvent, Offset }
+
+import scala.collection.JavaConverters._
+
+/**
+ * Topic factory that connects consumers directly to the implementing producers.
+ */
+class TestTopicFactory @Inject() (resolvedServices: ResolvedServices, materializer: Materializer) extends TopicFactory {
+
+  private val topics: Map[TopicId, Any] = resolvedServices.services.flatMap { service =>
+    service.descriptor.topicCalls().asScala.map { topicCall =>
+      topicCall.topicId -> service.service
+    }
+  }.toMap
+
+  override def create[Message](topicCall: TopicCall[Message]): Topic[Message] = {
+    topics.get(topicCall.topicId()) match {
+      case Some(service) =>
+        topicCall.topicHolder() match {
+          case method: MethodTopicHolder =>
+            method.create(service) match {
+              case topicProducer: TaggedOffsetTopicProducer[Message, _] =>
+                new TestTopic(topicCall, topicProducer)
+              case other =>
+                throw new IllegalArgumentException(s"Testkit does not know how to handle topic $other")
+            }
+        }
+      case None => throw new IllegalArgumentException(s"$topicCall hasn't been resolved.")
+    }
+  }
+
+  private class TestTopic[Message, Event <: AggregateEvent[Event]](
+    topicCall:     TopicCall[Message],
+    topicProducer: TaggedOffsetTopicProducer[Message, Event]
+  ) extends Topic[Message] {
+
+    override def topicId = topicCall.topicId
+
+    override def subscribe(): Subscriber[Message] = new Subscriber[Message] {
+
+      override def withGroupId(groupId: String): Subscriber[Message] = this
+
+      override def atMostOnceSource(): Source[Message, _] = {
+
+        val serializer = topicCall.messageSerializer().serializerForRequest()
+        val deserializer = topicCall.messageSerializer().deserializer(serializer.protocol())
+
+        // Create a source for all the tags, and merge them all together.
+        // Then, send the flow through a serializer and deserializer, to simulate sending it over the wire.
+        Source.from(topicProducer.tags).asScala.flatMapMerge(topicProducer.tags.size(), { tag =>
+          topicProducer.readSideStream.apply(tag, Offset.NONE).asScala.map(_.first)
+        }).map { message =>
+          serializer.serialize(message)
+        }.map { bytes =>
+          deserializer.deserialize(bytes)
+        }.asJava
+      }
+
+      override def atLeastOnce(flow: Flow[Message, Done, _]): CompletionStage[Done] = {
+        atMostOnceSource().via(flow).runWith(Sink.ignore(), materializer)
+      }
+    }
+  }
+}

--- a/testkit/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -3,7 +3,6 @@
  */
 package com.lightbend.lagom.javadsl.testkit
 
-import java.io.File
 import java.nio.file.Files
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -16,23 +15,20 @@ import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
 import com.lightbend.lagom.internal.cluster.JoinClusterModule
-import com.lightbend.lagom.internal.testkit.TestServiceLocator
-import com.lightbend.lagom.internal.testkit.TestServiceLocatorPort
+import com.lightbend.lagom.internal.testkit.{ TestServiceLocator, TestServiceLocatorPort, TestTopicFactory }
 import com.lightbend.lagom.javadsl.api.Service
 import com.lightbend.lagom.javadsl.api.ServiceLocator
 import com.lightbend.lagom.javadsl.persistence.PersistenceModule
-import com.lightbend.lagom.javadsl.persistence.cassandra.testkit.TestUtil
+import com.lightbend.lagom.javadsl.persistence.testkit.TestUtil
 import com.lightbend.lagom.javadsl.pubsub.PubSubModule
 import akka.actor.ActorSystem
 import akka.japi.function.Effect
 import akka.japi.function.Procedure
 import akka.persistence.cassandra.testkit.CassandraLauncher
 import akka.stream.Materializer
-import javax.inject.Singleton
 
 import com.lightbend.lagom.internal.javadsl.persistence.{ InMemoryOffsetStore, OffsetStore }
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraConfigProvider
-import com.lightbend.lagom.javadsl.persistence.cassandra.{ CassandraConfig, CassandraPersistenceModule }
+import com.lightbend.lagom.internal.api.broker.TopicFactory
 import org.apache.cassandra.io.util.FileUtils
 import play.Application
 import play.Configuration
@@ -68,45 +64,105 @@ import play.inject.guice.GuiceApplicationBuilder
  */
 object ServiceTest {
 
-  case class Setup(persistence: Boolean, cluster: Boolean,
-                   configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]) {
+  // These are all specified as strings so that we can say they are disabled without having a dependency on them.
+  private val JdbcPersistenceModule = "com.lightbend.lagom.javadsl.persistence.jdbc.JdbcPersistenceModule"
+  private val CassandraPersistenceModule = "com.lightbend.lagom.javadsl.persistence.cassandra.CassandraPersistenceModule"
+  private val KafkaBrokerModule = "com.lightbend.lagom.internal.broker.kafka.KafkaBrokerModule"
+  private val KafkaClientModule = "com.lightbend.lagom.javadsl.broker.kafka.KafkaClientModule"
+
+  sealed trait Setup {
+    @deprecated(message = "Use withCassandra instead", since = "1.2.0")
+    def withPersistence(enabled: Boolean): Setup = withCassandra(enabled)
+
+    /**
+     * Enable or disable Cassandra.
+     *
+     * If enabled, this will start an embedded Cassandra server before the tests start, and shut it down afterwards.
+     * It will also configure Lagom to use the embedded Cassandra server.
+     *
+     * @param enabled True if Cassandra should be enabled, or false if disabled.
+     * @return A copy of this setup.
+     */
+    def withCassandra(enabled: Boolean): Setup
+
+    @deprecated(message = "Use configureBuilder instead", since = "1.2.0")
+    def withConfigureBuilder(configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]) =
+      this.configureBuilder(configureBuilder)
+
+    /**
+     * Configure the builder.
+     *
+     * Allows a function to be supplied to configure the Play Guice application builder. This allows components to be
+     * mocked, modules to be enabled/disabled, and custom configuration to be supplied.
+     *
+     * @param configureBuilder The builder configuration function.
+     * @return A copy of this setup.
+     */
+    def configureBuilder(configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]): Setup
+
+    /**
+     * Enable clustering.
+     *
+     * Disabling this will automatically disable any persistence plugins, since persistence requires clustering.
+     *
+     * @param enabled True if clustering should be enabled, or false if disabled.
+     * @return A copy of this setup.
+     */
+    def withCluster(enabled: Boolean): Setup
+
+    /**
+     * Whether Cassandra is enabled.
+     */
+    def cassandra: Boolean
+
+    /**
+     * Whether clustering is enabled.
+     */
+    def cluster: Boolean
+
+    /**
+     * The builder configuration function
+     */
+    def configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]
+
+  }
+
+  private case class SetupImpl(cassandra: Boolean, cluster: Boolean,
+                               configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]) extends Setup {
 
     def this() = this(
-      persistence = true,
-      cluster = true,
+      cassandra = false,
+      cluster = false,
       configureBuilder = new JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder] {
       override def apply(b: GuiceApplicationBuilder): GuiceApplicationBuilder = b
     }
     )
 
-    /**
-     * Disable or enable persistence, including Cassandra startup.
-     */
-    def withPersistence(enabled: Boolean): Setup =
-      copy(persistence = enabled)
-
-    /**
-     * Disable or enable cluster and pubsub.
-     * If cluster is disabled the persistence is also disabled,
-     * since cluster is a prerequisite for persistence.
-     */
-    def withCluster(enabled: Boolean): Setup = {
-      if (enabled) copy(cluster = true)
-      else copy(cluster = false, persistence = false)
+    override def withCassandra(enabled: Boolean): Setup = {
+      if (enabled) {
+        copy(cassandra = true, cluster = true)
+      } else {
+        copy(cassandra = false)
+      }
     }
 
-    /**
-     * Transformation of the Guice builder. Can for example be used to override bindings
-     * to stub out dependencies to other services.
-     */
-    def withConfigureBuilder(transformation: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]): Setup =
-      copy(configureBuilder = transformation)
+    override def configureBuilder(configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]): Setup = {
+      copy(configureBuilder = configureBuilder)
+    }
+
+    override def withCluster(enabled: Boolean): Setup = {
+      if (enabled) {
+        copy(cluster = true)
+      } else {
+        copy(cluster = false, cassandra = false)
+      }
+    }
   }
 
   /**
    * The default `Setup` configuration, which has persistence enabled.
    */
-  val defaultSetup: Setup = new Setup()
+  val defaultSetup: Setup = new SetupImpl()
 
   /**
    * When the server is started you can get the service client and other
@@ -192,33 +248,37 @@ object ServiceTest {
 
     val b1 = new GuiceApplicationBuilder()
       .bindings(sBind[TestServiceLocatorPort].to(testServiceLocatorPort))
-      .bindings(sBind[CassandraConfig].toProvider(classOf[CassandraConfigProvider]))
       .bindings(sBind[ServiceLocator].to(classOf[TestServiceLocator]))
+      .bindings(sBind[TopicFactory].to(classOf[TestTopicFactory]))
       .configure("play.akka.actor-system", testName)
 
     val log = Logger(getClass)
 
-    val b2 =
-      if (setup.persistence) {
+    val b3 =
+      if (setup.cassandra) {
         val cassandraPort = CassandraLauncher.randomPort
         val cassandraDirectory = Files.createTempDirectory(testName).toFile
         FileUtils.deleteRecursiveOnExit(cassandraDirectory)
         val t0 = System.nanoTime()
         CassandraLauncher.start(cassandraDirectory, CassandraLauncher.DefaultTestConfigResource, clean = false, port = 0)
         log.debug(s"Cassandra started in ${TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0)} ms")
-        b1.configure(new Configuration(TestUtil.persistenceConfig(testName, cassandraPort, useServiceLocator = true)))
+        val b2 = b1.configure(new Configuration(TestUtil.persistenceConfig(testName, cassandraPort, useServiceLocator = false)))
           .configure("lagom.cluster.join-self", "on")
-      } else if (setup.cluster)
-        b1.configure(new Configuration(TestUtil.clusterConfig))
+        disableModules(b2, KafkaClientModule, KafkaBrokerModule)
+      } else if (setup.cluster) {
+        val b2 = b1.configure(new Configuration(TestUtil.clusterConfig))
           .configure("lagom.cluster.join-self", "on")
-          .disable(classOf[PersistenceModule], classOf[CassandraPersistenceModule])
+          .disable(classOf[PersistenceModule])
           .bindings(play.api.inject.bind[OffsetStore].to[InMemoryOffsetStore])
-      else
-        b1.configure("akka.actor.provider", "akka.actor.LocalActorRefProvider")
-          .disable(classOf[PersistenceModule], classOf[CassandraPersistenceModule], classOf[PubSubModule], classOf[JoinClusterModule])
+        disableModules(b2, CassandraPersistenceModule, KafkaClientModule, KafkaBrokerModule)
+      } else {
+        val b2 = b1.configure("akka.actor.provider", "akka.actor.LocalActorRefProvider")
+          .disable(classOf[PersistenceModule], classOf[PubSubModule], classOf[JoinClusterModule])
           .bindings(play.api.inject.bind[OffsetStore].to[InMemoryOffsetStore])
+        disableModules(b2, CassandraPersistenceModule, JdbcPersistenceModule, KafkaClientModule, KafkaBrokerModule)
+      }
 
-    val application = setup.configureBuilder(b2).build()
+    val application = setup.configureBuilder(b3).build()
 
     Play.start(application.getWrappedApplication)
     val serverConfig = ServerConfig(port = Some(0), mode = Mode.Test)
@@ -226,12 +286,28 @@ object ServiceTest {
     val assignedPort = srv.httpPort.orElse(srv.httpsPort).get
     port.success(assignedPort)
 
-    if (setup.persistence) {
+    if (setup.cassandra) {
       val system = application.injector().instanceOf(classOf[ActorSystem])
       TestUtil.awaitPersistenceInit(system)
     }
 
     new TestServer(assignedPort, application, srv)
+  }
+
+  private def disableModules(builder: GuiceApplicationBuilder, classes: String*): GuiceApplicationBuilder = {
+    val loadedClasses = classes.flatMap { className =>
+      try {
+        Seq(getClass.getClassLoader.loadClass(className))
+      } catch {
+        case cfne: ClassNotFoundException =>
+          Seq.empty[Class[_]]
+      }
+    }
+    if (loadedClasses.nonEmpty) {
+      builder.disable(loadedClasses: _*)
+    } else {
+      builder
+    }
   }
 
   /**

--- a/testkit/src/test/java/com/lightbend/lagom/javadsl/testkit/TestServerTest.java
+++ b/testkit/src/test/java/com/lightbend/lagom/javadsl/testkit/TestServerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.testkit;
+
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import com.google.inject.AbstractModule;
+import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestServerTest {
+
+    @Test
+    public void testTestingTopics() {
+        ServiceTest.withServer(ServiceTest.defaultSetup()
+                        .configureBuilder(builder ->
+                                builder.bindings(new TestTopicServiceModule())), server -> {
+
+            Source<String, ?> source = server.client(TestTopicService.class).testTopic().subscribe().atMostOnceSource();
+
+            List<String> messages = source.runWith(Sink.seq(), server.materializer()).toCompletableFuture().get();
+
+            assertEquals(Arrays.asList("message1", "message2"), messages);
+        });
+    }
+
+    public static class TestTopicServiceModule extends AbstractModule implements ServiceGuiceSupport {
+        @Override
+        protected void configure() {
+            bindServices(serviceBinding(TestTopicService.class, TestTopicService.Impl.class));
+        }
+    }
+}

--- a/testkit/src/test/java/com/lightbend/lagom/javadsl/testkit/TestTopicService.java
+++ b/testkit/src/test/java/com/lightbend/lagom/javadsl/testkit/TestTopicService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.testkit;
+
+import akka.japi.Pair;
+import akka.stream.javadsl.Source;
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.broker.Topic;
+import com.lightbend.lagom.javadsl.broker.TopicProducer;
+import com.lightbend.lagom.javadsl.persistence.Offset;
+
+import java.util.Arrays;
+
+import static com.lightbend.lagom.javadsl.api.Service.*;
+
+public interface TestTopicService extends Service {
+    Topic<String> testTopic();
+
+    @Override
+    default Descriptor descriptor() {
+        return named("testtopicservice")
+                .publishing(topic("testtopic", this::testTopic));
+    }
+
+    class Impl implements TestTopicService {
+        @Override
+        public Topic<String> testTopic() {
+            return TopicProducer.singleStreamWithOffset(offset ->
+                    Source.from(Arrays.asList(
+                            Pair.create("message1", new Offset.Sequence(1)),
+                            Pair.create("message2", new Offset.Sequence(2))
+                    ))
+            );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #171

* Added support to the testkit for testing topics (doesn't use Kafka, we could add something that uses Kafka in future if we find it's needed, but for now it just plumbs the sinks/sources directly together through the message serializer).
* Removed dependence on persistence-cassandra from testkit. The testkit still allows to setup Cassandra, and will run it and shut it down for you, but because there's no longer a direct dependency in persistence-cassandra, you can also use the testkit with JDBC. There's no specific support for JDBC, but this can be added in future if for example we decide we want to support running H2 automatically for you.