### PR TITLE
Remove Jackson object provider hack

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val PlayVersion = "2.5.4"
 val AkkaVersion = "2.4.10"
 val AkkaPersistenceCassandraVersion = "0.17"
 val ScalaTestVersion = "2.2.4"
-val JacksonVersion = "2.7.2"
+val JacksonVersion = "2.7.8"
 val CassandraAllVersion = "3.0.2"
 val GuavaVersion = "19.0"
 val MavenVersion = "3.3.9"
@@ -272,7 +272,7 @@ lazy val immutables = (project in file("immutables"))
   .settings(runtimeLibCommon: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
-    libraryDependencies += "org.immutables" % "value" % "2.1.3"
+    libraryDependencies += "org.immutables" % "value" % "2.3.2"
   )
 
 lazy val spi = (project in file("spi"))

--- a/jackson/src/main/java/com/lightbend/lagom/javadsl/jackson/JacksonSerializerFactory.java
+++ b/jackson/src/main/java/com/lightbend/lagom/javadsl/jackson/JacksonSerializerFactory.java
@@ -33,18 +33,18 @@ import akka.util.ByteStringBuilder;
 @Singleton
 public class JacksonSerializerFactory implements SerializerFactory {
 
-    private final JacksonObjectMapperProvider objectMapperProvider;
+    private final ObjectMapper objectMapper;
 
     @Inject
     public JacksonSerializerFactory(ActorSystem system) {
-      objectMapperProvider = JacksonObjectMapperProvider.get(system);
+        this(JacksonObjectMapperProvider.get(system).objectMapper());
     }
 
     /**
      * For testing purposes
      */
-    public JacksonSerializerFactory(JacksonObjectMapperProvider provider) {
-      objectMapperProvider = provider;
+    public JacksonSerializerFactory(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
     }
 
 
@@ -62,7 +62,6 @@ public class JacksonSerializerFactory implements SerializerFactory {
         private final NegotiatedDeserializer<MessageEntity, ByteString> deserializer;
 
         public JacksonMessageSerializer(Type type) {
-            ObjectMapper objectMapper = objectMapperProvider.objectMapper(type);
             JavaType javaType = objectMapper.constructType(type);
             serializer = new JacksonSerializer(objectMapper.writerFor(javaType));
             deserializer = new JacksonDeserializer(objectMapper.readerFor(javaType));

--- a/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/MockService.java
+++ b/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/MockService.java
@@ -13,8 +13,10 @@ import com.lightbend.lagom.javadsl.api.Descriptor;
 import com.lightbend.lagom.javadsl.api.Service;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
 import com.lightbend.lagom.javadsl.api.transport.Method;
+
 import static com.lightbend.lagom.javadsl.api.Service.*;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MockService extends Service {
@@ -47,6 +49,8 @@ public interface MockService extends Service {
 
     ServiceCall<NotUsed, String> queryParamId(Optional<String> query);
 
+    ServiceCall<MockRequestEntity, List<MockResponseEntity>> listResults();
+
     default Descriptor descriptor() {
         return named("mockservice").withCalls(
                 restCall(Method.POST, "/mock/:id", this::mockCall),
@@ -62,7 +66,8 @@ public interface MockService extends Service {
                 call(this::streamCustomHeaders),
                 call(this::serviceName),
                 call(this::streamServiceName),
-                pathCall("/queryparam?qp", this::queryParamId)
+                pathCall("/queryparam?qp", this::queryParamId),
+                call(this::listResults)
         );
     }
 }

--- a/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/MockServiceImpl.java
+++ b/service-integration-tests/src/test/java/com/lightbend/lagom/it/mocks/MockServiceImpl.java
@@ -15,13 +15,17 @@ import com.lightbend.lagom.javadsl.api.transport.NotFound;
 import com.lightbend.lagom.javadsl.api.transport.ResponseHeader;
 import com.lightbend.lagom.javadsl.server.HeaderServiceCall;
 import com.lightbend.lagom.javadsl.server.ServerServiceCall;
+
 import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class MockServiceImpl implements MockService {
 
@@ -144,7 +148,16 @@ public class MockServiceImpl implements MockService {
         return request -> CompletableFuture.completedFuture(query.orElse("none"));
     }
 
-  /**
+    @Override
+    public ServiceCall<MockRequestEntity, List<MockResponseEntity>> listResults() {
+        return request -> CompletableFuture.completedFuture(
+                IntStream.range(0, request.field2())
+                        .mapToObj(i -> new MockResponseEntity(i, request))
+                        .collect(Collectors.toList())
+        );
+    }
+
+    /**
      * Shows example service call composition.
      */
     private <Request, Response> ServerServiceCall<Request, Response> withServiceName(

--- a/service-integration-tests/src/test/scala/com/lightbend/lagom/it/ErrorHandlingSpec.scala
+++ b/service-integration-tests/src/test/scala/com/lightbend/lagom/it/ErrorHandlingSpec.scala
@@ -216,7 +216,7 @@ class ErrorHandlingSpec extends ServiceSupport {
     val environment = Environment.simple(mode = mode)
     val jacksonSerializerFactory = new JacksonSerializerFactory(new JacksonObjectMapperProvider(
       ConfigFactory.load(), new ReflectiveDynamicAccess(environment.classLoader), None
-    ))
+    ).objectMapper)
     val jacksonExceptionSerializer = new JacksonExceptionSerializer(new play.Environment(environment))
     val descriptor = ServiceReader.readServiceDescriptor(environment.classLoader, classOf[MockService])
     val resolved = ServiceReader.resolveServiceDescriptor(descriptor, environment.classLoader,

--- a/service-integration-tests/src/test/scala/com/lightbend/lagom/it/MockServiceSpec.scala
+++ b/service-integration-tests/src/test/scala/com/lightbend/lagom/it/MockServiceSpec.scala
@@ -131,6 +131,13 @@ class MockServiceSpec extends ServiceSupport {
         .toCompletableFuture.get(10, TimeUnit.SECONDS) should ===("foo")
     }
 
+    "work with collections of entities" in withMockServiceClient { implicit app => client =>
+      val request = new MockRequestEntity("results", 10)
+      val response = client.listResults().invoke(request).toCompletableFuture.get(10, TimeUnit.SECONDS)
+
+      response.size() should ===(request.field2)
+    }
+
     "be invoked with circuit breaker" in withMockServiceClient { implicit app => client =>
       MockServiceImpl.invoked.set(false)
       (1 to 20).foreach { _ =>


### PR DESCRIPTION
Jackson is updated to 2.7.8 and Immutables is updated to 2.3.2.

These versions use an explicit mode on the `@JsonCreator` annotation.

This lets us consolidate on a single object mapper instance and remove all of the code that was previously used to select the correct one.

Fixes #172