### PR TITLE
Improve PersistentEntity, #1

### DIFF
--- a/persistence/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/TestEntity.java
+++ b/persistence/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/TestEntity.java
@@ -530,9 +530,6 @@ public class TestEntity extends PersistentEntity<TestEntity.Cmd, TestEntity.Evt,
       else
         return ctx.thenPersistAll(fill(a, cmd.getTimes()), () -> ctx.reply(a));
     });
-
-    b.setCommandHandler(Add.class,
-        (cmd, ctx) -> ctx.thenPersist(new Prepended(entityId(), cmd.element.toLowerCase()), evt -> ctx.reply(evt)));
     return b.build();
   }
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
@@ -17,6 +17,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.actor.ReceiveTimeout
 import akka.cluster.sharding.ShardRegion
 import com.lightbend.lagom.scaladsl.persistence.{ AggregateEvent, AggregateEventShards, AggregateEventTag, PersistentEntity }
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
 
 import akka.persistence.journal.Tagged
 import play.api.Logger
@@ -60,21 +61,9 @@ private[lagom] class PersistentEntityActor[C, E, S](
   entity.internalSetEntityId(entityId)
 
   private var eventCount = 0L
+  private var behavior: entity.Behavior = null
 
   context.setReceiveTimeout(passivateAfterIdleTimeout)
-
-  // create a new instance every time, to capture sender()
-  private def newCtx(): entity.CommandContext[Any] = new entity.CommandContext[Any] {
-    private val replyTo: ActorRef = sender()
-
-    override def reply(msg: Any): Unit =
-      replyTo ! msg
-
-    override def commandFailed(cause: Throwable): Unit =
-      // not using akka.actor.Status.Failure because it is using Java serialization
-      reply(cause)
-
-  }
 
   override def receiveRecover: Receive = {
 
@@ -82,23 +71,20 @@ private[lagom] class PersistentEntityActor[C, E, S](
 
     def initEmpty(): Unit =
       if (!initialized) {
-        val inital = entity.initialBehavior(None)
-        entity.internalSetCurrentBehavior(inital)
+        behavior = entity.initialBehavior(None)
         initialized = true
       }
 
     {
       case SnapshotOffer(_, snapshot) =>
         if (!initialized) {
-          val inital = entity.initialBehavior(Some(snapshot.asInstanceOf[S]))
-          entity.internalSetCurrentBehavior(inital)
+          behavior = entity.initialBehavior(Some(snapshot.asInstanceOf[S]))
           initialized = true
         }
 
       case RecoveryCompleted =>
         initEmpty()
-        val newBehavior = entity.recoveryCompleted()
-        entity.internalSetCurrentBehavior(newBehavior)
+        behavior = entity.recoveryCompleted(behavior)
 
       case evt =>
         initEmpty()
@@ -108,84 +94,93 @@ private[lagom] class PersistentEntityActor[C, E, S](
     }
   }
 
+  private val unhandledEvent: PartialFunction[(E, entity.Behavior), entity.Behavior] = {
+    case event =>
+      log.warn(s"Unhandled event [${event.getClass.getName}] in [${entity.getClass.getName}] with id [${entityId}]")
+      behavior
+  }
+
   private def applyEvent(event: Any): Unit = {
-    entity.behavior.eventHandler(event.asInstanceOf[E]) match {
-      case Some(newBehavior) =>
-        entity.internalSetCurrentBehavior(newBehavior)
-      case None =>
-        log.warn(s"Unhandled event [${event.getClass.getName}] in [${entity.getClass.getName}] with id [${entityId}]")
-    }
+    behavior = behavior.eventHandler.applyOrElse((event.asInstanceOf[E], behavior), unhandledEvent)
+  }
+
+  private def unhandledCommand: PartialFunction[(C, entity.CommandContext, S), entity.Persist[_]] = {
+    case cmd =>
+      // not using akka.actor.Status.Failure because it is using Java serialization
+      sender() ! PersistentEntity.UnhandledCommandException(
+        s"Unhandled command [${cmd.getClass.getName}] in [${entity.getClass.getName}] with id [${entityId}]"
+      )
+      unhandled(cmd)
+      entity.persistNone
   }
 
   def receiveCommand: Receive = {
     case cmd: PersistentEntity.ReplyType[_] =>
-      val ctx = entity.newCtx(sender())
+      val replyTo = sender()
+      val ctx = new entity.CommandContext {
+        def reply[R](currentCommand: C with ReplyType[R], msg: R): Unit = {
+          if (currentCommand ne cmd) throw new IllegalArgumentException(
+            "Reply must be sent in response to the command that is currently processed, " +
+              s"Received command is [$cmd], but reply was to [$currentCommand]"
+          )
+          replyTo.tell(msg, ActorRef.noSender)
+        }
 
-      val maybePersist: Option[entity.Persist[_ <: E]] = try entity.behavior.commandHandler(cmd.asInstanceOf[C], ctx)
-      catch {
+        override def commandFailed(cause: Throwable): Unit =
+          // not using akka.actor.Status.Failure because it is using Java serialization
+          replyTo.tell(cause, ActorRef.noSender)
+      }
+
+      try {
+        val result = behavior.commandHandler.applyOrElse((cmd.asInstanceOf[C], ctx, behavior.state), unhandledCommand)
+
+        result match {
+          case _: entity.PersistNone[_] => // done
+          case entity.PersistOne(event, afterPersist) =>
+            // apply the event before persist so that validation exception is handled before persisting
+            // the invalid event, in case such validation is implemented in the event handler.
+            applyEvent(event)
+            persist(tag(event)) { evt =>
+              try {
+                eventCount += 1
+                if (afterPersist != null)
+                  afterPersist(event)
+                if (snapshotAfter > 0 && eventCount % snapshotAfter == 0)
+                  saveSnapshot(behavior.state)
+              } catch {
+                case NonFatal(e) =>
+                  ctx.commandFailed(e) // reply with failure
+                  throw e
+              }
+            }
+          case entity.PersistAll(events, afterPersist) =>
+            // if we trigger snapshot it makes sense to do it after handling all events
+            var count = events.size
+            var snap = false
+            // apply the event before persist so that validation exception is handled before persisting
+            // the invalid event, in case such validation is implemented in the event handler.
+            events.foreach(applyEvent)
+            persistAll(events.map(tag)) { evt =>
+              try {
+                eventCount += 1
+                count -= 1
+                if (afterPersist != null && count == 0)
+                  afterPersist.apply()
+                if (snapshotAfter > 0 && eventCount % snapshotAfter == 0)
+                  snap = true
+                if (count == 0 && snap)
+                  saveSnapshot(behavior.state)
+              } catch {
+                case NonFatal(e) =>
+                  ctx.commandFailed(e) // reply with failure
+                  throw e
+              }
+            }
+        }
+      } catch { // exception thrown from handler.apply
         case NonFatal(e) =>
           ctx.commandFailed(e) // reply with failure
           throw e
-      }
-
-      maybePersist match {
-        case None => {
-          // not using akka.actor.Status.Failure because it is using Java serialization
-          sender() ! PersistentEntity.UnhandledCommandException(
-            s"Unhandled command [${cmd.getClass.getName}] in [${entity.getClass.getName}] with id [${entityId}]"
-          )
-          unhandled(cmd)
-        }
-
-        case Some(p) => {
-          p match {
-            //        case Some(handler) =>
-            // create a new instance every time and capture sender()
-            //          try handler.apply(cmd.asInstanceOf[C], ctx) match {
-            case entity.PersistOne(event, afterPersist) =>
-              // apply the event before persist so that validation exception is handled before persisting
-              // the invalid event, in case such validation is implemented in the event handler.
-              applyEvent(event)
-              persist(event) { evt =>
-                try {
-                  eventCount += 1
-                  if (afterPersist != null)
-                    afterPersist(evt)
-                  if (snapshotAfter > 0 && eventCount % snapshotAfter == 0)
-                    saveSnapshot(entity.behavior.state)
-                } catch {
-                  case NonFatal(e) =>
-                    ctx.commandFailed(e) // reply with failure
-                    throw e
-                }
-              }
-            case entity.PersistAll(events, afterPersist) =>
-              // if we trigger snapshot it makes sense to do it after handling all events
-              var count = events.size
-              var snap = false
-              // apply the event before persist so that validation exception is handled before persisting
-              // the invalid event, in case such validation is implemented in the event handler.
-              events.foreach(applyEvent)
-              persistAll(events) { evt =>
-                try {
-                  eventCount += 1
-                  count -= 1
-                  if (afterPersist != null && count == 0)
-                    afterPersist.apply()
-                  if (snapshotAfter > 0 && eventCount % snapshotAfter == 0)
-                    snap = true
-                  if (count == 0 && snap)
-                    saveSnapshot(entity.behavior.state)
-                } catch {
-                  case NonFatal(e) =>
-                    ctx.commandFailed(e) // reply with failure
-                    throw e
-                }
-              }
-            case _: entity.PersistNone[_] => println("no persistence") // done
-
-          }
-        }
       }
 
     case ReceiveTimeout =>

--- a/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
+++ b/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package docs.home.scaladsl.persistence
+
+import akka.Done
+import com.lightbend.lagom.scaladsl.persistence.AggregateEvent
+import com.lightbend.lagom.scaladsl.persistence.AggregateEventShards
+import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
+
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
+
+// FIXME move to docs project when API has settled
+
+object Post {
+
+  // FIXME Jsonable
+  sealed trait BlogCommand
+
+  final case class AddPost(content: PostContent) extends BlogCommand with ReplyType[AddPostDone]
+  final case class AddPostDone(postId: String)
+  case object GetPost extends BlogCommand with ReplyType[PostContent]
+  final case class ChangeBody(body: String) extends BlogCommand with ReplyType[Done]
+  case object Publish extends BlogCommand with ReplyType[Done]
+
+  object BlogEvent {
+    val NumShards = 20
+    // second param is optional, defaults to the class name
+    val aggregateEventShards = AggregateEventTag.sharded(classOf[BlogEvent], NumShards)
+  }
+
+  sealed trait BlogEvent extends AggregateEvent[BlogEvent] {
+    override def aggregateTag: AggregateEventShards[BlogEvent] = BlogEvent.aggregateEventShards
+  }
+
+  final case class PostAdded(postId: String, content: PostContent) extends BlogEvent
+  final case class BodyChanged(postId: String, body: String) extends BlogEvent
+  final case class PostPublished(postId: String) extends BlogEvent
+
+  final case class PostContent(title: String, body: String)
+
+  object BlogState {
+    val empty = BlogState(None, published = false)
+
+  }
+
+  final case class BlogState(content: Option[PostContent], published: Boolean) {
+    def withBody(body: String): BlogState = {
+      content match {
+        case Some(c) =>
+          copy(content = Some(c.copy(body = body)))
+        case None =>
+          throw new IllegalStateException("Can't set body without content")
+      }
+    }
+
+    def isEmpty: Boolean = content.isEmpty
+  }
+
+}
+
+final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post.BlogState] {
+  import Post._
+
+  override def initialBehavior(snapshot: Option[BlogState]): Behavior = {
+    snapshot match {
+      case Some(snap) if !snap.isEmpty =>
+        // behavior after snapshot must be restored by initialBehavior
+        becomePostAdded(snap)
+      case _ =>
+        // Behavior consist of a State and defined event handlers and command handlers.
+        Behavior(BlogState.empty)
+          // Command handlers are invoked for incoming messages (commands).
+          // A command handler must "return" the events to be persisted (if any).
+          .addCommandHandler {
+            case (cmd @ AddPost(content), ctx, state) =>
+              if (content.title == null || content.title.equals("")) {
+                ctx.invalidCommand("Title must be defined")
+                ctx.done
+              } else {
+                ctx.thenPersist(PostAdded(entityId, content), evt =>
+                  // After persist is done additional side effects can be performed
+                  ctx.reply(cmd, AddPostDone(entityId)))
+              }
+          }
+          // Event handlers are used both when persisting new events and when replaying
+          // events.
+          .addEventHandler {
+            case (PostAdded(postId, content), behavior) =>
+              becomePostAdded(BlogState(Some(content), published = false))
+          }
+    }
+
+  }
+
+  private def becomePostAdded(state: BlogState): Behavior = {
+    Behavior(state)
+      .addCommandHandler {
+        case (cmd @ ChangeBody(body), ctx, state) =>
+          ctx.thenPersist(BodyChanged(entityId, body), _ => ctx.reply(cmd, Done))
+      }
+  }
+
+}

--- a/testkit/src/test/scala/com/lightbend/lagom/javadsl/testkit/PersistentEntityTestDriverCompatSpec.scala
+++ b/testkit/src/test/scala/com/lightbend/lagom/javadsl/testkit/PersistentEntityTestDriverCompatSpec.scala
@@ -42,7 +42,8 @@ class PersistentEntityTestDriverCompatSpec extends CassandraPersistenceSpec {
       }
       val replies = receiveN(replySideEffects.size)
       replySideEffects should be(replies)
-      outcome.events.asScala should be(replies.collect { case evt: TestEntity.Evt => evt })
+      // Add 2 generates 2 events, but only one reply so drop last event when comparing
+      outcome.events.asScala.dropRight(1) should be(replies.collect { case evt: TestEntity.Evt => evt })
 
       outcome.state should be(replies.last)
 


### PR DESCRIPTION
* State/Behavior is passed as parameter to the functions
  instead of having an accessor in the PersistentEntity.
* The reply type was lost in previous implementation.
  It's difficult becuase the CommandContext can't be
  passed in because the ReplyType is not known until after
  pattern matching. Therefore I added the currentCommand
  parameter to the reply method.
* Rewrote the TestEntity, it shows several advanced things,
  such as "become" (change command handlers)
* Converted the BlogPost sample from the docs
* Removed BehaviorBuilder, Behavior is enough. Composing
  behaviors is possible.