### PR TITLE
ClassTag instead of Class parameter, #1

### DIFF
--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
@@ -57,7 +57,7 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
   def receive = {
     case EnsureActive(tagName) =>
 
-      val tag = AggregateEventTag(clazz, tagName)
+      val tag = new AggregateEventTag(clazz, tagName)
 
       implicit val timeout = Timeout(globalPrepareTimeout)
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AggregateEventTag.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AggregateEventTag.scala
@@ -3,6 +3,8 @@
  */
 package com.lightbend.lagom.scaladsl.persistence
 
+import scala.reflect.ClassTag
+
 object AggregateEventTag {
   /**
    * Convenience factory method of [[AggregateEventTag]] that uses the
@@ -10,14 +12,16 @@ object AggregateEventTag {
    * retain the original tag when the class name is changed because
    * the tag is part of the store event data.
    */
-  def apply[Event <: AggregateEvent[Event]](eventType: Class[Event]): AggregateEventTag[Event] =
+  def apply[Event <: AggregateEvent[Event]: ClassTag](): AggregateEventTag[Event] = {
+    val eventType = implicitly[ClassTag[Event]].runtimeClass.asInstanceOf[Class[Event]]
     new AggregateEventTag(eventType, eventType.getName)
+  }
 
   /**
    * Factory method of [[AggregateEventTag]].
    */
-  def apply[Event <: AggregateEvent[Event]](eventType: Class[Event], tag: String): AggregateEventTag[Event] =
-    new AggregateEventTag(eventType, tag)
+  def apply[Event <: AggregateEvent[Event]: ClassTag](tag: String): AggregateEventTag[Event] =
+    new AggregateEventTag(implicitly[ClassTag[Event]].runtimeClass.asInstanceOf[Class[Event]], tag)
 
   /**
    * Create an aggregate event shards tagger.
@@ -32,12 +36,13 @@ object AggregateEventTag {
    * same entity will be produced by different event streams and handled by different shards in the read side
    * processor, leading to out of order event handling.
    *
-   * @param eventType The type of the event.
    * @param numShards The number of shards.
    * @return The aggregate event shards tagger.
    */
-  def sharded[Event <: AggregateEvent[Event]](eventType: Class[Event], numShards: Int): AggregateEventShards[Event] =
-    sharded(eventType, eventType.getName, numShards)
+  def sharded[Event <: AggregateEvent[Event]: ClassTag](numShards: Int): AggregateEventShards[Event] = {
+    val eventType = implicitly[ClassTag[Event]].runtimeClass.asInstanceOf[Class[Event]]
+    sharded[Event](eventType.getName, numShards)
+  }
 
   /**
    * Create a sharded aggregate event tag.
@@ -49,13 +54,15 @@ object AggregateEventTag {
    * same entity will be produced by different event streams and handled by different shards in the read side
    * processor, leading to out of order event handling.
    *
-   * @param eventType The type of the event.
    * @param baseTagName The base name for the tag, this will be combined with the shard number to form the tag name.
    * @param numShards The number of shards.
    * @return The aggregate event shards tagger.
    */
-  def sharded[Event <: AggregateEvent[Event]](eventType: Class[Event], baseTagName: String, numShards: Int): AggregateEventShards[Event] = {
-    new AggregateEventShards[Event](eventType, baseTagName, numShards)
+  def sharded[Event <: AggregateEvent[Event]: ClassTag](
+    baseTagName: String, numShards: Int): AggregateEventShards[Event] = {
+    new AggregateEventShards[Event](
+      implicitly[ClassTag[Event]].runtimeClass.asInstanceOf[Class[Event]],
+      baseTagName, numShards)
   }
 
   /**
@@ -102,8 +109,7 @@ sealed trait AggregateEventTagger[Event <: AggregateEvent[Event]] {
  */
 final class AggregateEventTag[Event <: AggregateEvent[Event]](
   val eventType: Class[Event],
-  val tag:       String
-) extends AggregateEventTagger[Event] {
+  val tag: String) extends AggregateEventTagger[Event] {
 
   override def toString: String = s"AggregateEventTag($eventType, $tag)"
 
@@ -129,9 +135,8 @@ final class AggregateEventTag[Event <: AggregateEvent[Event]](
  */
 final class AggregateEventShards[Event <: AggregateEvent[Event]](
   val eventType: Class[Event],
-  val tag:       String,
-  val numShards: Int
-) extends AggregateEventTagger[Event] {
+  val tag: String,
+  val numShards: Int) extends AggregateEventTagger[Event] {
 
   /**
    * Get the tag for the given entity ID.
@@ -139,10 +144,9 @@ final class AggregateEventShards[Event <: AggregateEvent[Event]](
    * @param entityId The entity ID to get the tag for.
    * @return The tag.
    */
-  def forEntityId(entityId: String): AggregateEventTag[Event] = AggregateEventTag(
+  def forEntityId(entityId: String): AggregateEventTag[Event] = new AggregateEventTag(
     eventType,
-    AggregateEventTag.shardTag(tag, AggregateEventTag.selectShard(numShards, entityId))
-  )
+    AggregateEventTag.shardTag(tag, AggregateEventTag.selectShard(numShards, entityId)))
 
   /**
    * Get all the tags for this shard.
@@ -150,10 +154,9 @@ final class AggregateEventShards[Event <: AggregateEvent[Event]](
    * @return All the tags.
    */
   val allTags: Set[AggregateEventTag[Event]] = {
-    (for (shardNo <- 0 until numShards) yield AggregateEventTag(
+    (for (shardNo <- 0 until numShards) yield new AggregateEventTag(
       eventType,
-      AggregateEventTag.shardTag(tag, shardNo)
-    )).toSet
+      AggregateEventTag.shardTag(tag, shardNo))).toSet
   }
 
   override def toString: String = s"AggregateEventShards($eventType, $tag)"

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
@@ -76,7 +76,7 @@ object TestEntity {
   object Evt {
     val NumShards = 4
     // second param is optional, defaults to the class name
-    val aggregateEventShards = AggregateEventTag.sharded(classOf[Evt], NumShards)
+    val aggregateEventShards = AggregateEventTag.sharded[Evt](NumShards)
 
     import play.api.libs.json._
     import Serializers.emptySingletonFormat

--- a/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
+++ b/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
@@ -27,7 +27,7 @@ object Post {
   object BlogEvent {
     val NumShards = 20
     // second param is optional, defaults to the class name
-    val aggregateEventShards = AggregateEventTag.sharded(classOf[BlogEvent], NumShards)
+    val aggregateEventShards = AggregateEventTag.sharded[BlogEvent](NumShards)
   }
 
   sealed trait BlogEvent extends AggregateEvent[BlogEvent] {


### PR DESCRIPTION
@jroper It's possible to use ClassTag for the PersistentEntityRegistry by using abstract type members in `PersistentEntity`. One drawback to be aware of is that there is no clear compilation error if one forgets to override the type members. See 0127520

```scala
  override type Command = Post.BlogCommand
  override type Event = Post.BlogEvent
  override type State = Post.BlogState
```

There is one more challenge, which I have not solved yet. `ReadSide.register`. There we have the additional relationship `Event <: AggregateEvent[Event]`
