### PR TITLE
define comand and event handlers by state, #1

### DIFF
--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
@@ -59,49 +59,40 @@ private[lagom] class PersistentEntityActor[C, E, S](
   override val persistenceId: String = persistenceIdPrefix + entityId
 
   entity.internalSetEntityId(entityId)
+  private var state: S = entity.initialState
+  private val behavior: entity.Behavior = entity.behavior
 
   private var eventCount = 0L
-  private var behavior: entity.Behavior = null
 
   context.setReceiveTimeout(passivateAfterIdleTimeout)
 
   override def receiveRecover: Receive = {
+    case SnapshotOffer(_, snapshot) =>
+      state = snapshot.asInstanceOf[S]
 
-    var initialized = false
+    case RecoveryCompleted =>
+      state = entity.recoveryCompleted(state)
 
-    def initEmpty(): Unit =
-      if (!initialized) {
-        behavior = entity.initialBehavior(None)
-        initialized = true
-      }
-
-    {
-      case SnapshotOffer(_, snapshot) =>
-        if (!initialized) {
-          behavior = entity.initialBehavior(Some(snapshot.asInstanceOf[S]))
-          initialized = true
-        }
-
-      case RecoveryCompleted =>
-        initEmpty()
-        behavior = entity.recoveryCompleted(behavior)
-
-      case evt =>
-        initEmpty()
-        applyEvent(evt)
-        eventCount += 1
-
-    }
+    case evt =>
+      applyEvent(evt.asInstanceOf[E])
+      eventCount += 1
   }
 
-  private val unhandledEvent: PartialFunction[(E, entity.Behavior), entity.Behavior] = {
+  private val unhandledEvent: PartialFunction[(E, S), S] = {
     case event =>
       log.warn(s"Unhandled event [${event.getClass.getName}] in [${entity.getClass.getName}] with id [${entityId}]")
-      behavior
+      state
   }
 
-  private def applyEvent(event: Any): Unit = {
-    behavior = behavior.eventHandler.applyOrElse((event.asInstanceOf[E], behavior), unhandledEvent)
+  private val unhandledState: PartialFunction[S, entity.Actions] = {
+    case s =>
+      log.warn(s"Undefined state [${state.getClass.getName}] in [${entity.getClass.getName}] with id [${entityId}]")
+      entity.Actions()
+  }
+
+  private def applyEvent(event: E): Unit = {
+    val actions = behavior.applyOrElse(state, unhandledState)
+    actions.eventHandler.applyOrElse((event, state), unhandledEvent)
   }
 
   private def unhandledCommand: PartialFunction[(C, entity.CommandContext, S), entity.Persist[_]] = {
@@ -132,21 +123,22 @@ private[lagom] class PersistentEntityActor[C, E, S](
       }
 
       try {
-        val result = behavior.commandHandler.applyOrElse((cmd.asInstanceOf[C], ctx, behavior.state), unhandledCommand)
+        val actions = behavior.applyOrElse(state, unhandledState)
+        val result = actions.commandHandler.applyOrElse((cmd.asInstanceOf[C], ctx, state), unhandledCommand)
 
         result match {
           case _: entity.PersistNone[_] => // done
           case entity.PersistOne(event, afterPersist) =>
             // apply the event before persist so that validation exception is handled before persisting
             // the invalid event, in case such validation is implemented in the event handler.
-            applyEvent(event)
+            applyEvent(event.asInstanceOf[E])
             persist(tag(event)) { evt =>
               try {
                 eventCount += 1
                 if (afterPersist != null)
                   afterPersist(event)
                 if (snapshotAfter > 0 && eventCount % snapshotAfter == 0)
-                  saveSnapshot(behavior.state)
+                  saveSnapshot(state)
               } catch {
                 case NonFatal(e) =>
                   ctx.commandFailed(e) // reply with failure
@@ -159,7 +151,7 @@ private[lagom] class PersistentEntityActor[C, E, S](
             var snap = false
             // apply the event before persist so that validation exception is handled before persisting
             // the invalid event, in case such validation is implemented in the event handler.
-            events.foreach(applyEvent)
+            events.foreach(e => applyEvent(e.asInstanceOf[E]))
             persistAll(events.map(tag)) { evt =>
               try {
                 eventCount += 1
@@ -169,7 +161,7 @@ private[lagom] class PersistentEntityActor[C, E, S](
                 if (snapshotAfter > 0 && eventCount % snapshotAfter == 0)
                   snap = true
                 if (count == 0 && snap)
-                  saveSnapshot(behavior.state)
+                  saveSnapshot(state)
               } catch {
                 case NonFatal(e) =>
                   ctx.commandFailed(e) // reply with failure

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
@@ -42,18 +42,18 @@ object PersistentEntity {
  * it can be accessed from anywhere in the cluster. It is run by an actor
  * and the state is persistent using event sourcing.
  *
- * `initialBehavior` is an abstract method that your concrete subclass must implement.
- * It returns the `Behavior` of the entity. The behavior consists of current state
- * and functions to process incoming commands and persisted events.
+ * `initialState` and `behavior` are abstract methods that your concrete subclass must implement.
+ * The behavior is defined as a set of actions given a state. The actions are functions to process
+ * incoming commands and persisted events.
  *
  * The `PersistentEntity` receives commands of type `Command` that can be validated before
  * persisting state changes as events of type `Event`. The functions that process incoming
- * commands are registered in the `Behavior` using `setCommandHandler` of the
- * `BehaviorBuilder`.
+ * commands are registered in the `Actions` using `addCommandHandler` of the
+ * `Actions`.
  *
  * A command may also be read-only and only perform some side-effect, such as replying
- * to the request. Such command handlers are registered using `setReadOnlyCommandHandler`
- * of the `BehaviorBuilder`. Replies are sent with the `reply` method of the context that
+ * to the request. Such command handlers are registered using `addReadOnlyCommandHandler`
+ * of the `Actions`. Replies are sent with the `reply` method of the context that
  * is passed to the command handler function.
  *
  * A command handler returns a `Persist` directive that defines what event or events,
@@ -62,11 +62,11 @@ object PersistentEntity {
  *
  * When an event has been persisted successfully the state of type `State` is updated by
  * applying the event to the current state. The functions for updating the state are
- * registered with the `setEventHandler` method of the `BehaviorBuilder`.
+ * registered with the `addEventHandler` method of the `Actions`.
  * The event handler returns the new state. The state must be immutable, so you return
- * a new instance of the state. Current state can be accessed from the event handler with
- * the `state` method of the `PersistentEntity`. The same event handlers are also used when
- * the entity is started up to recover its state from the stored events.
+ * a new instance of the state. Current state is passed as parameter to the event handler.
+ * The same event handlers are also used when the entity is started up to recover its
+ * state from the stored events.
  *
  * After persisting an event, external side effects can be performed in the `afterPersist`
  * function that can be defined when creating the `Persist` directive.
@@ -76,23 +76,13 @@ object PersistentEntity {
  *
  * The event handlers are typically only updating the state, but they may also change
  * the behavior of the entity in the sense that new functions for processing commands
- * and events may be defined. This is useful when implementing finite state machine (FSM)
- * like entities. Event handlers that change the behavior are registered with the
- * `setEventHandlerChangingBehavior` of the `BehaviorBuilder`. Such an event handler
- * returns the new `Behavior` instead of just returning the new state. You can
- * access current behavior with the `behavior` method of the `PersistentEntity`
- * and using the `builder` method of the `Behavior`.
+ * and events may be defined for a given state. This is useful when implementing
+ * finite state machine (FSM) like entities.
  *
  * When the entity is started the state is recovered by replaying stored events.
  * To reduce this recovery time the entity may start the recovery from a snapshot
  * of the state and then only replaying the events that were stored after the snapshot.
  * Such snapshots are automatically saved after a configured number of persisted events.
- * The snapshot if any is passed as a parameter to the `initialBehavior` method and
- * you should use that state as the state of the returned `Behavior`.
- * One thing to keep in mind is that if you are using event handlers that change the
- * behavior (`setEventHandlerChangingBehavior`) you must also restore corresponding
- * `Behavior` from the snapshot state that is passed as a parameter to the `initialBehavior`
- * method.
  *
  * @tparam Command the super type of all commands, must implement [[PersistentEntity.ReplyType]]
  *   to define the reply type of each command type
@@ -101,6 +91,11 @@ object PersistentEntity {
  */
 abstract class PersistentEntity[Command, Event, State] {
   import PersistentEntity.ReplyType
+
+  type Behavior = PartialFunction[State, Actions]
+  type EventHandler = PartialFunction[(Event, State), State]
+  type CommandHandler = PartialFunction[(Command, CommandContext, State), Persist[Event]]
+  type ReadOnlyCommandHandler = PartialFunction[(Command, ReadOnlyCommandContext, State), Unit]
 
   private var _entityId: String = _
 
@@ -122,42 +117,37 @@ abstract class PersistentEntity[Command, Event, State] {
    */
   def entityTypeName: String = Logging.simpleName(getClass)
 
+  def initialState: State
+
   /**
    * Abstract method that must be implemented by concrete subclass to define
    * the behavior of the entity. Use [[#newBehaviorBuilder]] to create a mutable builder
    * for defining the behavior.
    */
-  def initialBehavior(snapshotState: Option[State]): Behavior
+  def behavior: Behavior
 
   /**
    * This method is called to notify the entity that the recovery process
    * is finished.
    */
-  def recoveryCompleted(currentBehavior: Behavior): Behavior = currentBehavior
+  def recoveryCompleted(state: State): State = state
 
-  type EventHandler = PartialFunction[(Event, Behavior), Behavior]
-  type CommandHandler = PartialFunction[(Command, CommandContext, State), Persist[Event]]
-  type ReadOnlyCommandHandler = PartialFunction[(Command, ReadOnlyCommandContext, State), Unit]
-
-  object Behavior {
-    def apply(state: State): Behavior =
-      new Behavior(state, PartialFunction.empty, PartialFunction.empty)
+  object Actions {
+    private val empty = new Actions(PartialFunction.empty, PartialFunction.empty)
+    def apply(): Actions = empty
   }
 
   /**
-   * Behavior consists of current state and functions to process incoming commands
-   * and persisted events. `Behavior` is an immutable class.
+   * Actions consists of functions to process incoming commands
+   * and persisted events. `Actions` is an immutable class.
    */
-  class Behavior(
-    val state:          State,
+  class Actions(
     val eventHandler:   EventHandler,
     val commandHandler: CommandHandler
   ) {
 
-    def addCommandHandler(handler: CommandHandler) = {
-      new Behavior(state, eventHandler,
-        commandHandler.orElse(handler))
-    }
+    def addCommandHandler(handler: CommandHandler) =
+      new Actions(eventHandler, commandHandler.orElse(handler))
 
     def addReadOnlyCommandHandler(handler: ReadOnlyCommandHandler) = {
       val delegate: CommandHandler = {
@@ -166,31 +156,19 @@ abstract class PersistentEntity[Command, Event, State] {
           ctx.done
       }
 
-      new Behavior(state, eventHandler, commandHandler.orElse(delegate))
+      new Actions(eventHandler, commandHandler.orElse(delegate))
     }
 
     def addEventHandler(handler: EventHandler) = {
-      new Behavior(state, eventHandler.orElse(handler), commandHandler)
+      new Actions(eventHandler.orElse(handler), commandHandler)
     }
-
-    /**
-     * @return new instance with the given state
-     */
-    def withState(newState: State): Behavior =
-      new Behavior(state = newState, eventHandler, commandHandler)
-
-    /**
-     * Transform the state
-     */
-    def mapState(f: State => State): Behavior =
-      new Behavior(state = f(state), eventHandler, commandHandler)
 
     /**
      * Append `eventHandler` and `commandHandler` from `b` to the handlers
      * of this `Behavior`.
      */
-    def orElse(b: Behavior): Behavior =
-      new Behavior(state, eventHandler.orElse(b.eventHandler), commandHandler.orElse(b.commandHandler))
+    def orElse(b: Actions): Actions =
+      new Actions(eventHandler.orElse(b.eventHandler), commandHandler.orElse(b.commandHandler))
 
   }
 

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractPersistentEntityActorSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractPersistentEntityActorSpec.scala
@@ -116,13 +116,10 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
       // awaitAssert because it is not guaranteed that we will see the snapshot immediately
       within(10.seconds) {
         awaitAssert {
-
           val probe2 = TestProbe()
           val p2 = system.actorOf(PersistentEntityActor.props("test", Some("4"),
             () => new TestEntity(system, Some(probe2.ref)), Some(3), 10.seconds))
-          probe2.expectMsgType[TestEntity.Snapshot]
-          p2 ! TestEntity.Get
-          val state2 = expectMsgType[TestEntity.State]
+          val state2 = probe2.expectMsgType[TestEntity.AfterRecovery].state
           state2.elements should ===((1 to 10).toList.map(_.toString))
         }
       }

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
@@ -90,20 +90,20 @@ class TestEntity @Inject() (system: ActorSystem, probe: Option[ActorRef] = None)
 
   val baseActions: Actions = {
     Actions()
-      .addReadOnlyCommandHandler {
+      .onReadOnlyCommand {
         case (Get, ctx, state)        => ctx.reply(Get, state)
         case (GetAddress, ctx, state) => ctx.reply(GetAddress, Cluster.get(system).selfAddress)
       }
-      .addCommandHandler(changeMode)
+      .onCommand(changeMode)
   }
 
   private val appending: Actions =
     baseActions
-      .addEventHandler {
+      .onEvent {
         case (Appended(elem), state) => state.add(elem)
         case (InPrependMode, state)  => state.copy(mode = Mode.Prepend)
       }
-      .addCommandHandler {
+      .onCommand {
         case (a @ Add(elem, times), ctx, state) =>
           // note that null should trigger NPE, for testing exception
           if (elem == null)
@@ -121,11 +121,11 @@ class TestEntity @Inject() (system: ActorSystem, probe: Option[ActorRef] = None)
 
   private val prepending: Actions =
     baseActions
-      .addEventHandler {
+      .onEvent {
         case (Prepended(elem), state) => state.add(elem)
         case (InAppendMode, state)    => state.copy(mode = Mode.Append)
       }
-      .addCommandHandler {
+      .onCommand {
         case (a @ Add(elem, times), ctx, state) =>
           if (elem == null || elem.length == 0) {
             ctx.invalidCommand("element must not be empty");

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
@@ -64,13 +64,19 @@ object TestEntity {
   }
 
   // TestProbe message
-  final case class Snapshot(state: State)
   final case class AfterRecovery(state: State)
 }
 
 class TestEntity @Inject() (system: ActorSystem, probe: Option[ActorRef] = None)
   extends PersistentEntity[TestEntity.Cmd, TestEntity.Evt, TestEntity.State] {
   import TestEntity._
+
+  override def initialState: State = State.empty
+
+  override def behavior: Behavior = {
+    case State(Mode.Append, _)  => appending
+    case State(Mode.Prepend, _) => prepending
+  }
 
   private val changeMode: CommandHandler = {
     case (c @ ChangeMode(mode), ctx, state) => {
@@ -82,14 +88,8 @@ class TestEntity @Inject() (system: ActorSystem, probe: Option[ActorRef] = None)
     }
   }
 
-  val baseBehavior: Behavior = {
-    Behavior(State.empty)
-      .addEventHandler {
-        case (Appended(elem), b)  => b.mapState(_.add(elem))
-        case (Prepended(elem), b) => b.mapState(_.add(elem))
-        case (InAppendMode, b)    => becomeAppending(b.state)
-        case (InPrependMode, b)   => becomePrepending(b.state)
-      }
+  val baseActions: Actions = {
+    Actions()
       .addReadOnlyCommandHandler {
         case (Get, ctx, state)        => ctx.reply(Get, state)
         case (GetAddress, ctx, state) => ctx.reply(GetAddress, Cluster.get(system).selfAddress)
@@ -97,23 +97,12 @@ class TestEntity @Inject() (system: ActorSystem, probe: Option[ActorRef] = None)
       .addCommandHandler(changeMode)
   }
 
-  override def initialBehavior(snapshotState: Option[State]): Behavior = {
-    val state = snapshotState match {
-      case Some(snap) =>
-        probe.foreach(_ ! Snapshot(snap))
-        snap
-      case None => State.empty
-    }
-
-    state.mode match {
-      case Mode.Append  => becomeAppending(state)
-      case Mode.Prepend => becomeAppending(state)
-    }
-  }
-
-  private def becomeAppending(s: State): Behavior = {
-    baseBehavior
-      .withState(s.copy(mode = Mode.Append))
+  private val appending: Actions =
+    baseActions
+      .addEventHandler {
+        case (Appended(elem), state) => state.add(elem)
+        case (InPrependMode, state)  => state.copy(mode = Mode.Prepend)
+      }
       .addCommandHandler {
         case (a @ Add(elem, times), ctx, state) =>
           // note that null should trigger NPE, for testing exception
@@ -129,11 +118,13 @@ class TestEntity @Inject() (system: ActorSystem, probe: Option[ActorRef] = None)
           else
             ctx.thenPersistAll(List.fill(times)(appended), () => ctx.reply(a, appended))
       }
-  }
 
-  private def becomePrepending(s: State): Behavior = {
-    baseBehavior
-      .withState(s.copy(mode = Mode.Prepend))
+  private val prepending: Actions =
+    baseActions
+      .addEventHandler {
+        case (Prepended(elem), state) => state.add(elem)
+        case (InAppendMode, state)    => state.copy(mode = Mode.Append)
+      }
       .addCommandHandler {
         case (a @ Add(elem, times), ctx, state) =>
           if (elem == null || elem.length == 0) {
@@ -146,11 +137,10 @@ class TestEntity @Inject() (system: ActorSystem, probe: Option[ActorRef] = None)
           else
             ctx.thenPersistAll(List.fill(times)(prepended), () => ctx.reply(a, prepended))
       }
-  }
 
-  override def recoveryCompleted(currentBehavior: Behavior): Behavior = {
-    probe.foreach(_ ! AfterRecovery(currentBehavior.state))
-    currentBehavior
+  override def recoveryCompleted(state: State): State = {
+    probe.foreach(_ ! AfterRecovery(state))
+    state
   }
 
 }

--- a/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
+++ b/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
@@ -63,39 +63,38 @@ object Post {
 final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post.BlogState] {
   import Post._
 
-  override def initialBehavior(snapshot: Option[BlogState]): Behavior = {
-    snapshot match {
-      case Some(snap) if !snap.isEmpty =>
-        // behavior after snapshot must be restored by initialBehavior
-        becomePostAdded(snap)
-      case _ =>
-        // Behavior consist of a State and defined event handlers and command handlers.
-        Behavior(BlogState.empty)
-          // Command handlers are invoked for incoming messages (commands).
-          // A command handler must "return" the events to be persisted (if any).
-          .addCommandHandler {
-            case (cmd @ AddPost(content), ctx, state) =>
-              if (content.title == null || content.title.equals("")) {
-                ctx.invalidCommand("Title must be defined")
-                ctx.done
-              } else {
-                ctx.thenPersist(PostAdded(entityId, content), evt =>
-                  // After persist is done additional side effects can be performed
-                  ctx.reply(cmd, AddPostDone(entityId)))
-              }
-          }
-          // Event handlers are used both when persisting new events and when replaying
-          // events.
-          .addEventHandler {
-            case (PostAdded(postId, content), behavior) =>
-              becomePostAdded(BlogState(Some(content), published = false))
-          }
-    }
+  override def initialState: BlogState = BlogState.empty
 
+  override def behavior: Behavior = {
+    case state if state.isEmpty  => initial
+    case state if !state.isEmpty => postAdded
   }
 
-  private def becomePostAdded(state: BlogState): Behavior = {
-    Behavior(state)
+  private val initial: Actions = {
+    Actions()
+      // Command handlers are invoked for incoming messages (commands).
+      // A command handler must "return" the events to be persisted (if any).
+      .addCommandHandler {
+        case (cmd @ AddPost(content), ctx, state) =>
+          if (content.title == null || content.title.equals("")) {
+            ctx.invalidCommand("Title must be defined")
+            ctx.done
+          } else {
+            ctx.thenPersist(PostAdded(entityId, content), evt =>
+              // After persist is done additional side effects can be performed
+              ctx.reply(cmd, AddPostDone(entityId)))
+          }
+      }
+      // Event handlers are used both when persisting new events and when replaying
+      // events.
+      .addEventHandler {
+        case (PostAdded(postId, content), state) =>
+          BlogState(Some(content), published = false)
+      }
+  }
+
+  private val postAdded: Actions = {
+    Actions()
       .addCommandHandler {
         case (cmd @ ChangeBody(body), ctx, state) =>
           ctx.thenPersist(BodyChanged(entityId, body), _ => ctx.reply(cmd, Done))

--- a/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
+++ b/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
@@ -74,7 +74,7 @@ final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post
     Actions()
       // Command handlers are invoked for incoming messages (commands).
       // A command handler must "return" the events to be persisted (if any).
-      .addCommandHandler {
+      .onCommand {
         case (cmd @ AddPost(content), ctx, state) =>
           if (content.title == null || content.title.equals("")) {
             ctx.invalidCommand("Title must be defined")
@@ -87,7 +87,7 @@ final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post
       }
       // Event handlers are used both when persisting new events and when replaying
       // events.
-      .addEventHandler {
+      .onEvent {
         case (PostAdded(postId, content), state) =>
           BlogState(Some(content), published = false)
       }
@@ -95,7 +95,7 @@ final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post
 
   private val postAdded: Actions = {
     Actions()
-      .addCommandHandler {
+      .onCommand {
         case (cmd @ ChangeBody(body), ctx, state) =>
           ctx.thenPersist(BodyChanged(entityId, body), _ => ctx.reply(cmd, Done))
       }


### PR DESCRIPTION
* Use a partial function from State => Actions as
  the selection of command and event handlers for a
  given state.
* This is similar to what Fun.CQRS does
* Makes it easier to understand (read) the different
  states that the entity has. Better for FSM like entities.
* Another advantage is that no special treatment is needed
  during recovery to restore the behavior from the snapshot
  state.