### PR TITLE
Fork the kafka-broker tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -526,6 +526,7 @@ lazy val `kafka-broker` = (project in file("kafka-broker"))
   .enablePlugins(RuntimeLibPlugins)
   .settings(name := "lagom-javadsl-kafka-broker")
   .settings(runtimeLibCommon: _*)
+  .settings(forkedTests: _*)
   .settings(
     libraryDependencies ++= Seq(
       scalaTest % Test


### PR DESCRIPTION
This mitigates a memory leak in the metrics library used by Kafka.