### PR TITLE
Make lagom-spi be a java only artefact

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -277,6 +277,12 @@ lazy val spi = (project in file("spi"))
   .settings(name := "lagom-spi")
   .settings(runtimeLibCommon: _*)
   .enablePlugins(RuntimeLibPlugins)
+  .settings(
+    unmanagedSourceDirectories in Compile := (javaSource in Compile).value :: Nil,
+    autoScalaLibrary := false,
+    crossPaths := false,
+    crossVersion := CrossVersion.Disabled
+  )
 
 lazy val jackson = (project in file("jackson"))
   .settings(name := "lagom-javadsl-jackson")


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes no ticket

## Purpose

The Lagom SPI is pure Java, and a pure Java implementation of it should not have to worry about different Scala versions.
