### PR TITLE
infer right reply type in entityRef.ask, #1

### DIFF
--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRef.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRef.scala
@@ -35,7 +35,7 @@ final class PersistentEntityRef[Command](
    * or a `akka.pattern.AskTimeoutException` if there is no reply within a timeout.
    * The timeout can defined in configuration or overridden using [[#withAskTimeout]].
    */
-  def ask[Reply, Cmd <: Command with PersistentEntity.ReplyType[Reply]](command: Cmd): Future[Reply] = {
+  def ask[Cmd <: Command with PersistentEntity.ReplyType[_]](command: Cmd): Future[command.ReplyType] = {
     import scala.compat.java8.FutureConverters._
     import system.dispatcher
     (region ? CommandEnvelope(entityId, command)).flatMap {
@@ -43,7 +43,7 @@ final class PersistentEntityRef[Command](
         // not using akka.actor.Status.Failure because it is using Java serialization
         Future.failed(exc)
       case result => Future.successful(result)
-    }.asInstanceOf[Future[Reply]]
+    }.asInstanceOf[Future[command.ReplyType]]
   }
 
   /**

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -120,7 +120,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       val ref1 = registry.refFor(classOf[TestEntity], "1").withAskTimeout(remaining)
 
       // note that this is done on both node1 and node2
-      val r1: Future[TestEntity.Evt] = ref1.ask(TestEntity.Add("a"))
+      val r1 = ref1.ask(TestEntity.Add("a"))
       r1.pipeTo(testActor)
       expectMsg(TestEntity.Appended("A"))
       enterBarrier("appended-A")
@@ -158,7 +158,8 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
 
       val entities = for (n <- 10 to 29) yield registry.refFor(classOf[TestEntity], n.toString)
       val addresses = entities.map { ent =>
-        val r: Future[Address] = ent.ask(TestEntity.GetAddress)
+        val r = ent.ask(TestEntity.GetAddress)
+        val h: Future[String] = r.map(_.hostPort) // compile check that the reply type is inferred correctly
         r.pipeTo(testActor)
         expectMsgType[Address]
       }.toSet

--- a/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
+++ b/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
@@ -74,15 +74,15 @@ final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post
     Actions()
       // Command handlers are invoked for incoming messages (commands).
       // A command handler must "return" the events to be persisted (if any).
-      .onCommand {
-        case (cmd @ AddPost(content), ctx, state) =>
+      .onCommand[AddPost, AddPostDone] {
+        case (AddPost(content), ctx, state) =>
           if (content.title == null || content.title.equals("")) {
             ctx.invalidCommand("Title must be defined")
             ctx.done
           } else {
             ctx.thenPersist(PostAdded(entityId, content), evt =>
               // After persist is done additional side effects can be performed
-              ctx.reply(cmd, AddPostDone(entityId)))
+              ctx.reply(AddPostDone(entityId)))
           }
       }
       // Event handlers are used both when persisting new events and when replaying
@@ -95,9 +95,9 @@ final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post
 
   private val postAdded: Actions = {
     Actions()
-      .onCommand {
-        case (cmd @ ChangeBody(body), ctx, state) =>
-          ctx.thenPersist(BodyChanged(entityId, body), _ => ctx.reply(cmd, Done))
+      .onCommand[ChangeBody, Done] {
+        case (ChangeBody(body), ctx, state) =>
+          ctx.thenPersist(BodyChanged(entityId, body), _ => ctx.reply(Done))
       }
   }
 


### PR DESCRIPTION
- The return type from PersistentEntityRef.ask was inferred to
  Future[Nothing]
- Add type member in ReplyType and use that in ask
- To make the CommandContext.reply method use the right type
  I changed the definition of the command handlers to be per
  command class, which also has several other benefits:
  - no need to pass the command as parameter to reply
  - defining handler per class is more natural than chaining
    one single partial function
  - easier to read (understand) the command handler definitions
    when the types are enforced
