### PR TITLE
use ClassTag in PersistentEntityRegistry.refFor, #1

### DIFF
--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -19,7 +19,7 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
 
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 
-  override def register(entityFactory: => PersistentEntity[_, _, _]): Unit = {
+  override def register(entityFactory: => PersistentEntity): Unit = {
     ensureTablesCreated
     super.register(entityFactory)
   }

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
@@ -92,7 +92,11 @@ object PersistentEntity {
  * @tparam Event the super type of all events
  * @tparam State the type of the state
  */
-abstract class PersistentEntity[Command, Event, State] {
+abstract class PersistentEntity {
+
+  type Command
+  type Event
+  type State
 
   type Behavior = State => Actions
   type EventHandler = PartialFunction[(Event, State), State]

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
@@ -29,14 +29,14 @@ trait PersistentEntityRegistry {
    * That will happen in another thread, so the `entityFactory` must be thread-safe, e.g.
    * not close over shared mutable state that is not thread-safe.
    */
-  def register(entityFactory: => PersistentEntity[_, _, _]): Unit
+  def register(entityFactory: => PersistentEntity): Unit
 
   /**
    * Retrieve a [[com.lightbend.lagom.scaladsl.persistence.PersistentEntityRef]] for a
    * given [[com.lightbend.lagom.scaladsl.persistence.PersistentEntity]] class
    * and identifier. Commands are sent to a `PersistentEntity` using a `PersistentEntityRef`.
    */
-  def refFor[C](entityClass: Class[_ <: PersistentEntity[C, _, _]], entityId: String): PersistentEntityRef[C]
+  def refFor[P <: PersistentEntity: ClassTag](entityId: String): PersistentEntityRef[P#Command]
 
   /**
    * A stream of the persistent events that have the given `aggregateTag`, e.g.

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
@@ -132,8 +132,12 @@ class TestEntitySerializerRegistry extends SerializerRegistry {
 }
 
 class TestEntity(system: ActorSystem)
-  extends PersistentEntity[TestEntity.Cmd, TestEntity.Evt, TestEntity.State] {
+  extends PersistentEntity {
   import TestEntity._
+
+  override type Command = Cmd
+  override type Event = Evt
+  override type State = TestEntity.State
 
   def this(system: ActorSystem, probe: Option[ActorRef]) = {
     this(system)

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -117,7 +117,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
 
     "send commands to target entity" in within(20.seconds) {
 
-      val ref1 = registry.refFor(classOf[TestEntity], "1").withAskTimeout(remaining)
+      val ref1 = registry.refFor[TestEntity]("1").withAskTimeout(remaining)
 
       // note that this is done on both node1 and node2
       val r1 = ref1.ask(TestEntity.Add("a"))
@@ -125,7 +125,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       expectMsg(TestEntity.Appended("A"))
       enterBarrier("appended-A")
 
-      val ref2 = registry.refFor(classOf[TestEntity], "2")
+      val ref2 = registry.refFor[TestEntity]("2")
       val r2 = ref2.ask(TestEntity.Add("b"))
       r2.pipeTo(testActor)
       expectMsg(TestEntity.Appended("B"))
@@ -156,7 +156,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       // and lagom.persistence.run-entities-on-role = backend
       // i.e. no entities on node3
 
-      val entities = for (n <- 10 to 29) yield registry.refFor(classOf[TestEntity], n.toString)
+      val entities = for (n <- 10 to 29) yield registry.refFor[TestEntity](n.toString)
       val addresses = entities.map { ent =>
         val r = ent.ask(TestEntity.GetAddress)
         val h: Future[String] = r.map(_.hostPort) // compile check that the reply type is inferred correctly
@@ -176,12 +176,12 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
 
       runOn(node1) {
         within(15.seconds) {
-          val ref1 = registry.refFor(classOf[TestEntity], "1").withAskTimeout(remaining)
+          val ref1 = registry.refFor[TestEntity]("1").withAskTimeout(remaining)
           val r1: Future[TestEntity.Evt] = ref1.ask(TestEntity.Add("a"))
           r1.pipeTo(testActor)
           expectMsg(TestEntity.Appended("A"))
 
-          val ref2 = registry.refFor(classOf[TestEntity], "2")
+          val ref2 = registry.refFor[TestEntity]("2")
           val r2: Future[TestEntity.Evt] = ref2.ask(TestEntity.Add("b"))
           r2.pipeTo(testActor)
           expectMsg(TestEntity.Appended("B"))

--- a/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
+++ b/persistence/scaladsl/src/test/scala/docs/home/scaladsl/persistence/Post.scala
@@ -60,8 +60,12 @@ object Post {
 
 }
 
-final class Post extends PersistentEntity[Post.BlogCommand, Post.BlogEvent, Post.BlogState] {
+final class Post extends PersistentEntity {
   import Post._
+
+  override type Command = BlogCommand
+  override type Event = BlogEvent
+  override type State = BlogState
 
   override def initialState: BlogState = BlogState.empty
 

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/PersistentEntityTestDriver.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/PersistentEntityTestDriver.scala
@@ -68,7 +68,11 @@ object PersistentEntityTestDriver {
  * It also verifies that all commands, events, replies and state are
  * serializable, and reports any such problems in the `issues` of the `Outcome`.
  */
-class PersistentEntityTestDriver[C, E, S](system: ActorSystem, entity: PersistentEntity[C, E, S], entityId: String) {
+class PersistentEntityTestDriver[C, E, S](
+  val system:   ActorSystem,
+  val entity:   PersistentEntity { type Command = C; type Event = E; type State = S },
+  val entityId: String
+) {
   import PersistentEntityTestDriver._
 
   private val serialization = SerializationExtension(system)
@@ -132,6 +136,8 @@ class PersistentEntityTestDriver[C, E, S](system: ActorSystem, entity: Persisten
       issues :+= UnhandledCommand(cmd)
       entity.persistNone
   }
+
+  def runOne[CC <: entity.Command](command: C): Outcome[E, S] = ???
 
   /**
    * The entity will process the commands and the emitted events and side effects


### PR DESCRIPTION
This PR is based on https://github.com/lagom/lagom/pull/233, so ignore the first commit here.

It's possible to use ClassTag for the PersistentEntityRegistry by using abstract type members in PersistentEntity. One drawback to be aware of is that there is no clear compilation error if one forgets to override the type members.

``` scala
  override type Command = Post.BlogCommand
  override type Event = Post.BlogEvent
  override type State = Post.BlogState
```
