### PR TITLE
1.0.x documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Lagom focuses on ensuring that your application realises the full potention of t
 ### Learn More
 
 * [Website](https://www.lightbend.com/lagom)
-* [Documentation](http://www.lagomframework.com/documentation/1.0.x/Home.html)
-* [Installation](http://www.lagomframework.com/documentation/1.0.x/Installation.html)
+* [Documentation](http://www.lagomframework.com/documentation/1.0.x/java/Home.html)
+* [Installation](http://www.lagomframework.com/documentation/1.0.x/java/Installation.html)
 * [Community Chat](https://gitter.im/lagom/lagom)
 * [Mailing list](https://groups.google.com/forum/#!forum/lagom-framework)
 * [Get help](https://stackoverflow.com/questions/ask?tags=lagom)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Lagom Framework - The Reactive Microservices Framework
 
-Lagom is a Swedish word meaning just right, sufficient. Microservices are about creating services that are just the right size, that is, they have just the right level of functionality and isolation to be able to adequately implement a scalable and resilient system.
+Lagom is a Swedish word meaning *just right, sufficient*. Microservices are about creating services that are just the right size, that is, they have just the right level of functionality and isolation to be able to adequately implement a scalable and resilient system.
 
-Lagom focuses on ensuring that your application realises the full potention of the [Reactive Manifesto](http://reactivemanifesto.org), while delivering a high productivity development environment, and seamless production deployment experience.
+Lagom focuses on ensuring that your application realises the full potential of the [Reactive Manifesto](http://reactivemanifesto.org), while delivering a high productivity development environment, and seamless production deployment experience.
 
 ### Learn More
 

--- a/docs/manual/gettingstarted/Installation.md
+++ b/docs/manual/gettingstarted/Installation.md
@@ -23,7 +23,7 @@ $ which activator
 /opt/activator-1.3.10-minimal/bin/activator
 ```
 
-The important bit is that the <version> appended after `activator-<version>` must be at least 1.13.10 for Lagom to properly work. 
+The important bit is that the <version> appended after `activator-<version>` must be at least 1.3.10 for Lagom to properly work. 
 
 Follow [this link](https://www.lightbend.com/activator/download) to download the latest activator bundle.
 

--- a/docs/manual/guide/production/ConductR.md
+++ b/docs/manual/guide/production/ConductR.md
@@ -34,7 +34,7 @@ usage: conduct [-h]
 Now, add the [sbt-conductr plugin](https://github.com/typesafehub/sbt-conductr) to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.7")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.14")
 ```
 
 sbt-conductr adds several commands to the activator console:

--- a/docs/manual/guide/production/ConductR.md
+++ b/docs/manual/guide/production/ConductR.md
@@ -10,8 +10,9 @@ ConductR is free for development usage and comes with a "sandbox" so that you ca
 This guide will explain how to:
 
 * Install ConductR sandbox
-* Package Lagom services
 * Start local ConductR cluster
+* Conveniently package, load and run your entire Lagom system
+* Package Lagom services individually
 * Load and run services during and outside of development
 * Run Cassandra on ConductR
  
@@ -33,26 +34,52 @@ usage: conduct [-h]
 Now, add the [sbt-conductr plugin](https://github.com/typesafehub/sbt-conductr) to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.4")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.7")
 ```
 
 sbt-conductr adds several commands to the activator console:
- 
-* `bundle:dist` to produce ConductR packages for your services
-* `configuration:dist` to produce a custom ConductR configuration for your services
+
+* `install` to introspect your projects and then load and run them within the sandbox
+* `generateInstallationScript` to produce an installation script to deploy your Lagom system that you can then tailor
+* `bundle:dist` to produce individual ConductR packages for your services
+* `configuration:dist` to produce individual custom ConductR configuration for your services
 * Commands from the `conductr-cli`
 
 We will use most of these commands in the next sections. 
 
-## Packaging your services
+## Run it all
 
-Packaging your Lagom services so that you can deliver them to ConductR is straightforward. Start the activator console from the terminal:
+The simplest thing that you can do in order to deploy your entire Lagom system is to run a local ConductR cluster and then run the `install` command.
+
+To start a ConductR cluster locally you should use the ConductR sandbox which is a docker image based on Ubuntu that includes ConductR. With this docker image you can easily spin up multiple ConductR nodes on your local machine. The `sandbox run` command will pick up and run this ConductR docker image. In order to use this command we need to specify the ConductR version. Note that this version is the version of ConductR itself and not the version of the `sbt-conductr` plugin. Please visit again the [ConductR Developer page](https://www.lightbend.com/product/conductr/developer) to pick up the latest ConductR version from the section **Quick Configuration**.
+
+First, start the activator console from the terminal:
 
 ```console
 $ activator
 ```
 
-You can then package your services from within the activator console with the `bundle:dist` command:
+Now start the local ConductR cluster with the `sandbox run` command: 
+
+```console
+> sandbox run <CONDUCTR_VERSION>
+```
+
+You can then install your entire Lagom system in one go:
+
+```console
+> install
+```
+
+The install command will introspect your project and its sub-projects and then package, load and run everything in ConductR at once - including Cassandra. The local sandbox is expected to be running and it will first be restarted to ensure that it is in a clean state.
+
+We expect that you will use the `install` command early on, but graduate to ConductR's lower-level commands as you evolve your services through their development lifecyle.
+
+The remainder of this document describes the lower level ConductR commands.
+
+## Packaging your services
+
+Packaging your Lagom services so that you can deliver them to ConductR is straightforward. To do this then use the `bundle:dist` command from within the activator console:
 
 ```console
 > bundle:dist
@@ -65,15 +92,7 @@ The above creates what is known as a "bundle". A bundle is the unit of deploymen
 
 ## Loading and running your services during development
 
-To start a ConductR cluster locally you should use the ConductR sandbox which is a docker image based on Ubuntu that includes ConductR. With this docker image you can easily spin up multiple ConductR nodes on your local machine. The `sandbox run` command will pick up and run this ConductR docker image. In order to use this command we need to specify the ConductR version. Note that this version is the version of ConductR itself and not the version of the `sbt-conductr` plugin. Please visit again the [ConductR Developer page](https://www.lightbend.com/product/conductr/developer) to pick up the latest ConductR version from the section **Quick Configuration**.
-
-Now, go to the activator console to start the local ConductR cluster with the `sandbox run` command: 
-
-```console
-> sandbox run <CONDUCTR_VERSION>
-```
-
-With the ConductR sandbox running you can now load the bundle that you previously generated:
+With the ConductR sandbox running you can load the bundle that you previously generated:
 
 ```console
 > project my-service-impl

--- a/docs/manual/guide/production/ConductR.md
+++ b/docs/manual/guide/production/ConductR.md
@@ -19,7 +19,7 @@ If you'd like to know more about our commercial license then [please contact us]
 
 ## Installing ConductR sandbox
 
-The ConductR sandbox is a docker image to easily create a ConductR cluster locally. To run ConductR on your development machine follow the instructions on the [ConductR developer page](https://www.lightbend.com/product/conductr/developer) up to the section **Configure Docker Machine**. We will run the sandbox later on in this guide. Note that in order to access this page you need to login with your Lightbend account. If you don't have an account yet, head out to the [Sign Up page](https://www.lightbend.com/account/register) and create a free account.
+The ConductR sandbox is a docker image to easily create a ConductR cluster locally. To run ConductR on your development machine follow the instructions on the [ConductR developer page](https://www.lightbend.com/product/conductr/developer) up to the section **Configure Docker VM**. We will run the sandbox later on in this guide. Note that in order to access this page you need to login with your Lightbend account. If you don't have an account yet, head out to the [Sign Up page](https://www.lightbend.com/account/register) and create a free account.
  
 Verify the successful installation of the `conductr-cli` by running the `conduct` command within the terminal:
 
@@ -33,7 +33,7 @@ usage: conduct [-h]
 Now, add the [sbt-conductr plugin](https://github.com/typesafehub/sbt-conductr) to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.0.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.4")
 ```
 
 sbt-conductr adds several commands to the activator console:


### PR DESCRIPTION
Pulled these documentation updates from long-ago `master`.

I believe they're all relevant to Lagom 1.0.0, but they don't appear in the 1.0.x docs on the site.

Note that the merge target is a new 1.0.x branch.