### PR TITLE
Inject Configuration into CircuitBreakerConfig

### DIFF
--- a/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/client/CircuitBreakers.scala
+++ b/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/client/CircuitBreakers.scala
@@ -12,6 +12,7 @@ import akka.actor.ActorSystem
 import akka.pattern.{ CircuitBreakerOpenException, CircuitBreaker => AkkaCircuitBreaker }
 import com.lightbend.lagom.internal.spi.{ CircuitBreakerMetrics, CircuitBreakerMetricsProvider }
 import com.typesafe.config.Config
+import play.api.Configuration
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration._
@@ -71,7 +72,7 @@ class CircuitBreakers @Inject() (system: ActorSystem, circuitBreakerConfig: Circ
 }
 
 @Singleton
-class CircuitBreakerConfig @Inject() (system: ActorSystem) {
-  val config: Config = system.settings.config.getConfig("lagom.circuit-breaker")
+class CircuitBreakerConfig @Inject() (configuration: Configuration) {
+  val config: Config = configuration.underlying.getConfig("lagom.circuit-breaker")
   val default: Config = config.getConfig("default")
 }

--- a/service/javadsl/integration-client/src/main/java/com/lightbend/lagom/javadsl/client/integration/LagomClientFactory.java
+++ b/service/javadsl/integration-client/src/main/java/com/lightbend/lagom/javadsl/client/integration/LagomClientFactory.java
@@ -211,7 +211,7 @@ public class LagomClientFactory implements Closeable {
         TopicFactoryProvider topicFactoryProvider = () -> Some.apply(kafkaTopicFactory);
 
         // ServiceClientLoader
-        CircuitBreakers circuitBreakers = new CircuitBreakers(actorSystem, new CircuitBreakerConfig(actorSystem),
+        CircuitBreakers circuitBreakers = new CircuitBreakers(actorSystem, new CircuitBreakerConfig(configuration),
                 new CircuitBreakerMetricsProviderImpl(actorSystem));
 
         JacksonSerializerFactory serializerFactory = new JacksonSerializerFactory(actorSystem);


### PR DESCRIPTION
## Purpose

This breaks its dependency on the `ActorSystem` configuration.

## Background Context

`LagomClientFactory` does not pass the full `Configuration` to the `ActorSystem` it creates (only the "akka" config) so previously, "lagom.circuit-breaker" config settings were not being picked up correctly.