### PR TITLE
Improve maven incompatible version handling

### DIFF
--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/pom.xml
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/pom.xml
@@ -38,6 +38,27 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce-maven-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <!-- Lagom requires at least Maven version 3.2.1 -->
+                                <requireMavenVersion>
+                                    <version>[3.2.1,)</version>
+                                </requireMavenVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/dev/maven-plugin/src/main/java/com/lightbend/lagom/maven/LagomAbstractMojo.java
+++ b/dev/maven-plugin/src/main/java/com/lightbend/lagom/maven/LagomAbstractMojo.java
@@ -1,0 +1,51 @@
+package com.lightbend.lagom.maven;
+
+import org.apache.maven.Maven;
+import org.apache.maven.plugin.AbstractMojo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public abstract class LagomAbstractMojo extends AbstractMojo {
+
+    private static final Logger log = LoggerFactory.getLogger(LagomAbstractMojo.class);
+    private static final String MAVEN_CORE_POM_PROPERTIES = "META-INF/maven/org.apache.maven/maven-core/pom.properties";
+    private static final Pattern VERSION_PARSER = Pattern.compile("(\\d+)\\.(\\d+).*");
+
+    static {
+        InputStream is = Maven.class.getClassLoader().getResourceAsStream(MAVEN_CORE_POM_PROPERTIES);
+        if (is != null) {
+            try {
+                Properties props = new Properties();
+                props.load(is);
+                String version = props.getProperty("version");
+                if (version != null) {
+                    Matcher matcher = VERSION_PARSER.matcher(version);
+                    if (matcher.matches()) {
+                        int major = Integer.parseInt(matcher.group(1));
+                        int minor = Integer.parseInt(matcher.group(2));
+                        if (major < 3 || (major == 3 && minor < 2)) {
+                            String message = "Lagom requires at least Maven 3.2, you are using Maven " + version + ". Please upgrade to a more recent version of Maven.";
+                            log.error(message);
+                            throw new RuntimeException(message);
+                        }
+                    } else {
+                        log.warn("Could not parse version " + version + " in " + MAVEN_CORE_POM_PROPERTIES + " to check and enforce maven version");
+                    }
+                } else {
+                    log.warn("Could not find version property in " + MAVEN_CORE_POM_PROPERTIES + " to check and enforce maven version");
+                }
+            } catch (IOException e) {
+                log.warn("Could not load " + MAVEN_CORE_POM_PROPERTIES + " to check and enforce maven version", e);
+            }
+        } else {
+            log.warn("Could not find " + MAVEN_CORE_POM_PROPERTIES + " to check and enforce maven version");
+        }
+    }
+
+}

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ConfigureMojo.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ConfigureMojo.scala
@@ -3,7 +3,6 @@ package com.lightbend.lagom.maven
 import javax.inject.Inject
 
 import org.apache.maven.execution.MavenSession
-import org.apache.maven.plugin.AbstractMojo
 
 import scala.beans.BeanProperty
 
@@ -11,7 +10,7 @@ import scala.beans.BeanProperty
  * Internal goal, invoked by other Lagom mojos that work with multiple projects at once, to read plugin configuration
  * for a project and set up the projects context values.
  */
-class ConfigureMojo @Inject() (session: MavenSession) extends AbstractMojo {
+class ConfigureMojo @Inject() (session: MavenSession) extends LagomAbstractMojo {
 
   @BeanProperty
   var lagomService: Boolean = _

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/RenameConductRBundleMojo.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/RenameConductRBundleMojo.scala
@@ -5,7 +5,6 @@ import java.util.Locale
 import java.util.zip.ZipFile
 import javax.inject.Inject
 
-import org.apache.maven.plugin.AbstractMojo
 import better.files.{ File => ScalaFile, _ }
 
 import scala.beans.BeanProperty
@@ -14,7 +13,7 @@ import scala.collection.JavaConverters._
 /**
  * Converts a zip artifact to one named according to ConductR's conventions.
  */
-class RenameConductRBundleMojo @Inject() (logger: MavenLoggerProxy) extends AbstractMojo {
+class RenameConductRBundleMojo @Inject() (logger: MavenLoggerProxy) extends LagomAbstractMojo {
 
   @BeanProperty
   var sourceConductRBundle: File = _

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
@@ -4,7 +4,6 @@ import javax.inject.Inject
 
 import com.lightbend.lagom.core.LagomVersion
 import com.lightbend.lagom.dev.{ Servers, StaticServiceLocations }
-import org.apache.maven.plugin.AbstractMojo
 import org.eclipse.aether.artifact.DefaultArtifact
 import java.util.{ Collections, List => JList, Map => JMap }
 
@@ -16,7 +15,7 @@ import scala.beans.BeanProperty
 import org.apache.maven.execution.MavenSession
 import org.eclipse.aether.graph.Dependency
 
-class StartCassandraMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, mavenLoggerManager: LoggerManager) extends AbstractMojo {
+class StartCassandraMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, mavenLoggerManager: LoggerManager) extends LagomAbstractMojo {
 
   @BeanProperty
   var cassandraMaxBootWaitingSeconds: Int = _
@@ -44,7 +43,7 @@ class StartCassandraMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProx
   }
 }
 
-class StopCassandraMojo @Inject() (logger: MavenLoggerProxy) extends AbstractMojo {
+class StopCassandraMojo @Inject() (logger: MavenLoggerProxy) extends LagomAbstractMojo {
   @BeanProperty
   var cassandraEnabled: Boolean = _
 
@@ -55,7 +54,7 @@ class StopCassandraMojo @Inject() (logger: MavenLoggerProxy) extends AbstractMoj
   }
 }
 
-class StartKafkaMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, mavenLoggerManager: LoggerManager, session: MavenSession) extends AbstractMojo {
+class StartKafkaMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, mavenLoggerManager: LoggerManager, session: MavenSession) extends LagomAbstractMojo {
 
   @BeanProperty
   var kafkaPort: Int = _
@@ -113,7 +112,7 @@ class StartKafkaMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, m
   }
 }
 
-class StopKafkaMojo @Inject() (logger: MavenLoggerProxy) extends AbstractMojo {
+class StopKafkaMojo @Inject() (logger: MavenLoggerProxy) extends LagomAbstractMojo {
   @BeanProperty
   var kafkaEnabled: Boolean = _
 
@@ -125,7 +124,7 @@ class StopKafkaMojo @Inject() (logger: MavenLoggerProxy) extends AbstractMojo {
 }
 
 class StartServiceLocatorMojo @Inject() (logger: MavenLoggerProxy, facade: MavenFacade,
-    scalaClassLoaderManager: ScalaClassLoaderManager) extends AbstractMojo {
+    scalaClassLoaderManager: ScalaClassLoaderManager) extends LagomAbstractMojo {
 
   @BeanProperty
   var serviceLocatorEnabled: Boolean = _
@@ -162,7 +161,7 @@ class StartServiceLocatorMojo @Inject() (logger: MavenLoggerProxy, facade: Maven
   }
 }
 
-class StopServiceLocatorMojo @Inject() (logger: MavenLoggerProxy) extends AbstractMojo {
+class StopServiceLocatorMojo @Inject() (logger: MavenLoggerProxy) extends LagomAbstractMojo {
 
   @BeanProperty
   var serviceLocatorEnabled: Boolean = _

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceMojos.scala
@@ -7,7 +7,6 @@ import com.lightbend.lagom.dev.{ Colors, ConsoleHelper, LagomConfig }
 import com.lightbend.lagom.dev.PortAssigner.ProjectName
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.Dependency
-import org.apache.maven.plugin.AbstractMojo
 import play.dev.filewatch.LoggerProxy
 
 import scala.beans.BeanProperty
@@ -20,7 +19,7 @@ import scala.collection.JavaConverters._
 /**
  * Run a service, blocking until the user hits enter before stopping it again.
  */
-class RunMojo @Inject() (mavenFacade: MavenFacade, logger: LoggerProxy, session: MavenSession) extends AbstractMojo {
+class RunMojo @Inject() (mavenFacade: MavenFacade, logger: LoggerProxy, session: MavenSession) extends LagomAbstractMojo {
 
   private val consoleHelper = new ConsoleHelper(new Colors("lagom.noformat"))
 
@@ -43,7 +42,7 @@ class RunMojo @Inject() (mavenFacade: MavenFacade, logger: LoggerProxy, session:
 /**
  * Start a service.
  */
-class StartMojo @Inject() (serviceManager: ServiceManager, session: MavenSession) extends AbstractMojo {
+class StartMojo @Inject() (serviceManager: ServiceManager, session: MavenSession) extends LagomAbstractMojo {
 
   @BeanProperty
   var lagomService: Boolean = _
@@ -134,7 +133,7 @@ class StartMojo @Inject() (serviceManager: ServiceManager, session: MavenSession
 /**
  * Stop a service.
  */
-class StopMojo @Inject() (serviceManager: ServiceManager, session: MavenSession) extends AbstractMojo {
+class StopMojo @Inject() (serviceManager: ServiceManager, session: MavenSession) extends LagomAbstractMojo {
 
   @BeanProperty
   var lagomService: Boolean = _
@@ -153,7 +152,7 @@ class StopMojo @Inject() (serviceManager: ServiceManager, session: MavenSession)
   }
 }
 
-class StartExternalProjects @Inject() (serviceManager: ServiceManager, session: MavenSession) extends AbstractMojo {
+class StartExternalProjects @Inject() (serviceManager: ServiceManager, session: MavenSession) extends LagomAbstractMojo {
 
   @BeanProperty
   var externalProjects: JList[ExternalProject] = Collections.emptyList()
@@ -229,7 +228,7 @@ class StartExternalProjects @Inject() (serviceManager: ServiceManager, session: 
 
 }
 
-class StopExternalProjects @Inject() (serviceManager: ServiceManager, session: MavenSession) extends AbstractMojo {
+class StopExternalProjects @Inject() (serviceManager: ServiceManager, session: MavenSession) extends LagomAbstractMojo {
 
   @BeanProperty
   var externalProjects: JList[ExternalProject] = Collections.emptyList()
@@ -259,7 +258,7 @@ class ExternalProject {
 /**
  * Starts all services.
  */
-class StartAllMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, session: MavenSession) extends AbstractMojo {
+class StartAllMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, session: MavenSession) extends LagomAbstractMojo {
 
   private val consoleHelper = new ConsoleHelper(new Colors("lagom.noformat"))
 
@@ -285,7 +284,7 @@ class StartAllMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, ses
 /**
  * Stops all services.
  */
-class StopAllMojo @Inject() (facade: MavenFacade, session: MavenSession) extends AbstractMojo {
+class StopAllMojo @Inject() (facade: MavenFacade, session: MavenSession) extends LagomAbstractMojo {
 
   @BeanProperty
   var externalProjects: JList[Dependency] = Collections.emptyList()
@@ -311,7 +310,7 @@ class StopAllMojo @Inject() (facade: MavenFacade, session: MavenSession) extends
 /**
  * Run a service, blocking until the user hits enter before stopping it again.
  */
-class RunAllMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, session: MavenSession) extends AbstractMojo {
+class RunAllMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, session: MavenSession) extends LagomAbstractMojo {
 
   val consoleHelper = new ConsoleHelper(new Colors("lagom.noformat"))
 

--- a/docs/manual/common/gettingstarted/Installation.md
+++ b/docs/manual/common/gettingstarted/Installation.md
@@ -31,7 +31,7 @@ If you don't have java and javac, you can get it from the [Oracle Java downloads
 
 To install Maven, see the official [Maven installation page](https://maven.apache.org/install.html).
 
-There are many other ways to install Maven, Lagom should work with Maven no matter how it was installed, as long as it is a recent Maven version (we recommend at least Maven 3.3).
+Lagom requires at least Maven 3.2.1, earlier versions of Maven will not work with Lagom. We recommend that you use at least Maven 3.3. When checking your Maven version, make sure also that your IDE is configured to use a recent Maven version, many IDEs use an older version by default.
 
 ## Installing sbt
 


### PR DESCRIPTION
* Added maven enforcer plugin to archetype to enforce at least Maven version 3.2.1.
* Added static check to mojos that, when the class is loaded, checks that the version of Maven is at least 3.2.1. This check only fails with Maven 3.1.x, prior versions don't initialise the class when loading it and fail before the check can be done.
* Improved documentation to make it clear minimum Maven version must be 3.2.1.