### PR TITLE
Add Log4j2 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -268,7 +268,8 @@ val coreProjects = Seq[ProjectReference](
   `persistence-core`,
   `persistence-cassandra-core`,
   `persistence-jdbc-core`,
-  logback
+  logback,
+  log4j2
 )
 
 val otherProjects = Seq[ProjectReference](
@@ -757,6 +758,21 @@ lazy val logback = (project in file("logback"))
       // needed only because we use play.utils.Colors
       "com.typesafe.play" %% "play" % PlayVersion
     ) ++ Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.3")
+  )
+
+lazy val log4j2 = (project in file("log4j2"))
+  .enablePlugins(RuntimeLibPlugins)
+  .settings(runtimeLibCommon: _*)
+  .settings(
+    name := "lagom-log4j2",
+    libraryDependencies ++= Seq(
+      "log4j-api",
+      "log4j-core",
+      "log4j-slf4j-impl"
+    ).map("org.apache.logging.log4j" % _ % "2.7") ++ Seq(
+      "com.lmax" % "disruptor" % "3.3.6",
+      "com.typesafe.play" %% "play" % PlayVersion
+    )
   )
 
 lazy val `dev-environment` = (project in file("dev"))

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala
@@ -31,6 +31,7 @@ object LagomImport {
   val lagomJavadslServer = component("lagom-javadsl-server")
   val lagomJavadslTestKit = component("lagom-javadsl-testkit") % Test
   val lagomLogback = component(lagomLogbackModuleName)
+  val lagomLog4j2 = component("lagom-log4j2")
 
   val lagomScaladslApi = component("lagom-scaladsl-api")
   val lagomScaladslClient = component("lagom-scaladsl-client")

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -563,6 +563,14 @@ object LagomLogback extends AutoPlugin {
   )
 }
 
+object LagomLog4j2 extends AutoPlugin {
+  override def requires = Lagom
+
+  override def projectSettings = Seq(
+    libraryDependencies += LagomImport.lagomLog4j2
+  )
+}
+
 private[sbt] object SbtConsoleHelper {
   private val consoleHelper = new ConsoleHelper(new Colors("sbt.log.noformat"))
   def printStartScreen(log: Logger, services: (String, DevServer)*): Unit =

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -24,7 +24,8 @@ lazy val docs = project
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.scalatest" %% "scalatest" % "2.2.4" % Test,
       "com.typesafe.play" %% "play-netty-server" % PlayVersion % Test,
-      "com.typesafe.play" %% "play-logback" % PlayVersion % Test
+      "com.typesafe.play" %% "play-logback" % PlayVersion % Test,
+      "org.apache.logging.log4j" % "log4j-api" % "2.7" % "test"
     ),
     javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation"),
     testOptions in Test += Tests.Argument("-oDF"),

--- a/docs/manual/java/guide/logging/Logging.md
+++ b/docs/manual/java/guide/logging/Logging.md
@@ -25,3 +25,31 @@ If you'd like to use the Lagom logger module on a project that doesn't have the 
 @[lagom-logback-libdep](code/build-log.sbt)
 
 The Lagom logger module includes a default logback configuration. Read [[Configuring Logging|SettingsLogger]] for details.
+
+## Log4j 2
+
+Lagom can be configured to use [Log4j 2](https://logging.apache.org/log4j/2.x/) as its default logging engine. Using Log4j 2 can use either the SLF4J API for logging as shown above or the Log4j 2 API. For example, using the Log4j 2 API:
+
+@[](code/docs/logging/Log4j2Example.java)
+
+If you're using maven, you'll need to add the Lagom log4j2 dependency to your classpath to get Log4j 2 support:
+
+```xml
+<dependency>
+    <groupId>com.lightbend.lagom</groupId>
+    <artifactId>lagom-log4j2_2.11</artifactId>
+    <version>${lagom.version}</version>
+</dependency>
+```
+
+Note that this dependency replaces logback here, so remove any logback dependencies from your pom.xml as well.
+
+If you're using sbt, you'll have to disable the `LagomLogback` plugin and enable the `LagomLog4j2` plugin instead. So for example, if you're using the `LagomJava` plugin:
+
+@[lagom-log4j2-plugin-lagomjava](code/build-log.sbt)
+
+When you're not using the `LagomJava` plugin, add the Lagom Log4j2 module as a dependency:
+
+@[lagom-log4j2-libdep](code/build-log.sbt)
+
+The Lagom Log4j2 module also includes default logging configurations. Read [[Configuring Logging|SettingsLogger]] for details.

--- a/docs/manual/java/guide/logging/SettingsLogger.md
+++ b/docs/manual/java/guide/logging/SettingsLogger.md
@@ -87,6 +87,27 @@ Play system logging can be done by changing the `play` logger to DEBUG.
 <logger name="play" level="DEBUG" />
 ```
 
+## Default Log4j2 configuration
+
+Similarly to the default logback configuration, when using the Log4j2 Lagom module, a default configuration is provided. In development, the following is used by default:
+
+@[](code/log4j2-lagom-dev.xml)
+
+And in production, the following is the default configuration:
+
+@[](code/log4j2-lagom-default.xml)
+
+A few things to note:
+
+* A file appender that writes to `logs/application.log` is created.
+* The file appender logs full stack traces while the console logger limits it to 10 lines.
+* Console logging uses colored log levels by default.
+* In production, all loggers are configured to use [async loggers](https://logging.apache.org/log4j/2.x/manual/async.html) by default using the LMAX Disruptor library.
+
+### Custom configuration
+
+Including a file named `log4j2.xml` in your project's root will override the defaults. All other system properties specified for the logback integration above are also supported here.
+
 ## Using a Custom Logging Framework
 
 Lagom uses Logback by default, but it is possible to configure Lagom to use another logging framework, as long as there is an SLF4J adapter for it.

--- a/docs/manual/java/guide/logging/code/build-log.sbt
+++ b/docs/manual/java/guide/logging/code/build-log.sbt
@@ -16,3 +16,17 @@ lazy val portfolioImpl = (project in file("portfolioImpl"))
   .enablePlugins(LagomJava)
   .disablePlugins(LagomLogback) // this avoids that the Lagom logging module is addedd to the classpath
 //#lagom-logback-plugin-disabled
+
+//#lagom-log4j2-libdep
+// `LagomImport` provides a few handy alias to several Lagom modules
+import com.lightbend.lagom.sbt.LagomImport.lagomLog4j2
+
+lazy val blogApi = (project in file("blogApi"))
+  .settings(libraryDependencies += lagomLog4j2)
+//#lagom-log4j2-libdep
+
+//#lagom-log4j2-plugin-lagomjava
+lazy val blogImpl = (project in file("blogImpl"))
+  .enablePlugins(LagomJava, LagomLog4j2)
+  .disablePlugins(LagomLogback)
+//#lagom-log4j2-plugin-lagomjava

--- a/docs/manual/java/guide/logging/code/build-log2.sbt
+++ b/docs/manual/java/guide/logging/code/build-log2.sbt
@@ -1,12 +1,12 @@
 //#lagom-logback-plugin-disabled-log4j
 lazy val portfolioImpl = (project in file("portfolioImpl"))
   .enablePlugins(LagomJava)
-  .disablePlugins(LagomLogback) // this avoids that the Lagom logging module is addedd to the classpath
+  .disablePlugins(LagomLogback) // this avoids that the Lagom logging module is added to the classpath
   .settings(
     libraryDependencies ++= Seq(
-      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.4.1",
-      "org.apache.logging.log4j" % "log4j-api" % "2.4.1",
-      "org.apache.logging.log4j" % "log4j-core" % "2.4.1"
+      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.7",
+      "org.apache.logging.log4j" % "log4j-api" % "2.7",
+      "org.apache.logging.log4j" % "log4j-core" % "2.7"
     )
   )
 //#lagom-logback-plugin-disabled-log4j

--- a/docs/manual/java/guide/logging/code/docs/logging/Log4j2Example.java
+++ b/docs/manual/java/guide/logging/code/docs/logging/Log4j2Example.java
@@ -1,0 +1,12 @@
+package docs.logging;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Log4j2Example {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public void demonstrateLogging(String msg) {
+        LOGGER.debug("Here is a message at the debug level: {}", msg);
+    }
+}

--- a/docs/manual/java/guide/logging/code/log4j2-lagom-default.xml
+++ b/docs/manual/java/guide/logging/code/log4j2-lagom-default.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+  -->
+<!-- The default log4j2 configuration that Lagom uses if no other configuration is provided -->
+<Configuration name="DefaultLagomConfig">
+  <File name="FILE" fileName="logs/application.log">
+    <PatternLayout>
+      <Pattern>%date [%level] from %logger in %thread - %message%n%xException</Pattern>
+    </PatternLayout>
+  </File>
+
+  <Console name="STDOUT">
+    <PatternLayout>
+      <Pattern>%highlight{%level} %logger{15} - %message%n%xException{10}</Pattern>
+    </PatternLayout>
+  </Console>
+
+  <!-- Set logging for all Play library classes to WARN -->
+  <Logger name="play" level="WARN"/>
+  <!-- Set logging for all Akka library classes to WARN -->
+  <Logger name="akka" level="WARN"/>
+  <!-- Set logging for all Lagom library classes to WARN -->
+  <Logger name="com.lightbend.lagom" level="WARN"/>
+  <!-- Cassandra and the datastax driver are used by the Lagom event sourcing modules -->
+  <Logger name="org.apache.cassandra" level="ERROR"/>
+  <Logger name="com.datastax.driver" level="ERROR"/>
+  <!-- Turn down Kafka noise -->
+  <Logger name="org.apache.kafka" level="WARN"/>
+
+  <AsyncRoot level="WARN">
+    <AppenderRef ref="FILE"/>
+    <AppenderRef ref="STDOUT"/>
+  </AsyncRoot>
+
+</Configuration>

--- a/docs/manual/java/guide/logging/code/log4j2-lagom-dev.xml
+++ b/docs/manual/java/guide/logging/code/log4j2-lagom-dev.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+  -->
+<!-- The default log4j2 configuration that Lagom uses in dev mode if no other configuration is provided -->
+<Configuration name="DevelopmentLagomConfig">
+  <File name="FILE" fileName="logs/application.log">
+    <PatternLayout>
+      <Pattern>%date [%level] from %logger in %thread - %message%n%xException</Pattern>
+    </PatternLayout>
+  </File>
+
+  <Console name="STDOUT">
+    <PatternLayout>
+      <Pattern>%highlight{%level} %logger{15} - %message%n%xException{10}</Pattern>
+    </PatternLayout>
+  </Console>
+
+  <!-- Set logging for all Play library classes to WARN -->
+  <Logger name="play" level="WARN"/>
+  <!-- Set logging for all Akka library classes to WARN -->
+  <Logger name="akka" level="WARN"/>
+  <!-- Set logging for all Lagom library classes to WARN -->
+  <Logger name="com.lightbend.lagom" level="WARN"/>
+  <!-- Cassandra and the datastax driver are used by the Lagom event sourcing modules -->
+  <Logger name="org.apache.cassandra" level="ERROR"/>
+  <Logger name="com.datastax.driver" level="ERROR"/>
+  <!-- Turning off connection error logging to avoid noise when services are forcely stopped -->
+  <Logger name="com.datastax.driver.core.ControlConnection" level="OFF"/>
+  <!-- Turn down Kafka noise -->
+  <Logger name="org.apache.kafka" level="WARN"/>
+
+  <AsyncRoot level="WARN">
+    <AppenderRef ref="FILE"/>
+    <AppenderRef ref="STDOUT"/>
+  </AsyncRoot>
+
+</Configuration>

--- a/log4j2/src/main/resources/log4j2-lagom-default.xml
+++ b/log4j2/src/main/resources/log4j2-lagom-default.xml
@@ -1,0 +1,35 @@
+<!--
+  ~ Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+  -->
+<!-- The default log4j2 configuration that Lagom uses if no other configuration is provided -->
+<Configuration name="DefaultLagomConfig">
+  <File name="FILE" fileName="logs/application.log">
+    <PatternLayout>
+      <Pattern>%date [%level] from %logger in %thread - %message%n%xException</Pattern>
+    </PatternLayout>
+  </File>
+
+  <Console name="STDOUT">
+    <PatternLayout>
+      <Pattern>%highlight{%level} %logger{15} - %message%n%xException{10}</Pattern>
+    </PatternLayout>
+  </Console>
+
+  <!-- Set logging for all Play library classes to WARN -->
+  <Logger name="play" level="WARN"/>
+  <!-- Set logging for all Akka library classes to WARN -->
+  <Logger name="akka" level="WARN"/>
+  <!-- Set logging for all Lagom library classes to WARN -->
+  <Logger name="com.lightbend.lagom" level="WARN"/>
+  <!-- Cassandra and the datastax driver are used by the Lagom event sourcing modules -->
+  <Logger name="org.apache.cassandra" level="ERROR"/>
+  <Logger name="com.datastax.driver" level="ERROR"/>
+  <!-- Turn down Kafka noise -->
+  <Logger name="org.apache.kafka" level="WARN"/>
+
+  <AsyncRoot level="WARN">
+    <AppenderRef ref="FILE"/>
+    <AppenderRef ref="STDOUT"/>
+  </AsyncRoot>
+
+</Configuration>

--- a/log4j2/src/main/resources/log4j2-lagom-dev.xml
+++ b/log4j2/src/main/resources/log4j2-lagom-dev.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+  -->
+<!-- The default log4j2 configuration that Lagom uses in dev mode if no other configuration is provided -->
+<Configuration name="DevelopmentLagomConfig">
+  <File name="FILE" fileName="logs/application.log">
+    <PatternLayout>
+      <Pattern>%date [%level] from %logger in %thread - %message%n%xException</Pattern>
+    </PatternLayout>
+  </File>
+
+  <Console name="STDOUT">
+    <PatternLayout>
+      <Pattern>%highlight{%level} %logger{15} - %message%n%xException{10}</Pattern>
+    </PatternLayout>
+  </Console>
+
+  <!-- Set logging for all Play library classes to WARN -->
+  <Logger name="play" level="WARN"/>
+  <!-- Set logging for all Akka library classes to WARN -->
+  <Logger name="akka" level="WARN"/>
+  <!-- Set logging for all Lagom library classes to WARN -->
+  <Logger name="com.lightbend.lagom" level="WARN"/>
+  <!-- Cassandra and the datastax driver are used by the Lagom event sourcing modules -->
+  <Logger name="org.apache.cassandra" level="ERROR"/>
+  <Logger name="com.datastax.driver" level="ERROR"/>
+  <!-- Turning off connection error logging to avoid noise when services are forcely stopped -->
+  <Logger name="com.datastax.driver.core.ControlConnection" level="OFF"/>
+  <!-- Turn down Kafka noise -->
+  <Logger name="org.apache.kafka" level="WARN"/>
+
+  <AsyncRoot level="WARN">
+    <AppenderRef ref="FILE"/>
+    <AppenderRef ref="STDOUT"/>
+  </AsyncRoot>
+
+</Configuration>

--- a/log4j2/src/main/resources/logger-configurator.properties
+++ b/log4j2/src/main/resources/logger-configurator.properties
@@ -1,0 +1,1 @@
+play.logger.configurator=com.lightbend.lagom.internal.log4j2.Log4j2LoggerConfigurator

--- a/log4j2/src/main/scala/com/lightbend/lagom/internal/log4j2/Log4j2LoggerConfigurator.scala
+++ b/log4j2/src/main/scala/com/lightbend/lagom/internal/log4j2/Log4j2LoggerConfigurator.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.log4j2
+
+import java.io.File
+import java.net.URL
+
+import play.api._
+
+object Log4j2LoggerConfigurator {
+  final private val DevLog4j2Config: String = "log4j2-lagom-dev.xml"
+  final private val DefaultLog4j2Config: String = "log4j2-lagom-default.xml"
+}
+
+class Log4j2LoggerConfigurator extends LoggerConfigurator {
+
+  import Log4j2LoggerConfigurator._
+
+  override def init(rootPath: File, mode: Mode.Mode): Unit = {
+    val properties = Map("application.home" -> rootPath.getAbsolutePath)
+    val resourceName = if (mode == Mode.Dev) DevLog4j2Config else DefaultLog4j2Config
+    val resourceUrl = Option(this.getClass.getClassLoader.getResource(resourceName))
+    configure(properties, resourceUrl)
+  }
+
+  override def configure(env: Environment): Unit = {
+    val properties = Map("application.home" -> env.rootPath.getAbsolutePath)
+
+    // Get an explicitly configured resource URL
+    // Fallback to a file in the conf directory if the resource wasn't found on the classpath
+    def explicitResourceUrl = sys.props.get("logger.resource").flatMap { r =>
+      env.resource(r).map(_.toURI.toURL)
+    }
+
+    // Get an explicitly configured file URL
+    def explicitFileUrl = sys.props.get("logger.file").map(new File(_).toURI.toURL)
+
+    // log4j2.xml is the documented method, log4j2-lagom-default.xml is the fallback that Lagom uses
+    // if no other file is found
+    def resourceUrl = env.resource("log4j2.xml")
+      .orElse(env.resource(
+        if (env.mode == Mode.Dev) DevLog4j2Config else DefaultLog4j2Config
+      ))
+
+    val configUrl = explicitResourceUrl orElse explicitFileUrl orElse resourceUrl
+
+    configure(properties, configUrl)
+  }
+
+  override def configure(properties: Map[String, String], config: Option[URL]): Unit = {
+    import org.apache.logging.log4j.core.config.Configurator
+    import scala.util.control.NonFatal
+
+    if (config.isEmpty) {
+      System.err.println("Could not detect a log4j2 configuration file, not configuring log4j2")
+      return
+    }
+
+    try {
+      val ctx = Configurator.initialize("Lagom", this.getClass.getClassLoader, config.get.toURI)
+    } catch {
+      case NonFatal(e) =>
+        System.err.println("Error encountered while configuring log4j2")
+        e.printStackTrace()
+    }
+  }
+
+  override def shutdown(): Unit = {
+    import org.apache.logging.log4j.LogManager
+
+    LogManager.shutdown()
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)? Yes.
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)? Yes.
* [ ] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)? Yes.
* [ ] Have you added copyright headers to new files? Yes.
* [ ] Have you updated the documentation? Yes.
* [ ] Have you added tests for any changed functionality? Not exactly sure how this is applicable here, but I'm willing to add tests based on feedback.

## Fixes

Fixes #255

## Purpose

This PR adds a Log4j 2 module for easy configuration of Log4j 2 as an alternative to Logback. As mentioned in #255, Log4j 2 is much faster than Logback in production logging environments amongst many other features.

## Background Context

I based all this on the lagom-logback module and documentation. Thanks to some added slf4j dependencies, slightly less configuration is necessary than I initially thought (e.g., adding log4j-jul to support `java.util.logging` is already provided in Lagom by jul-to-slf4j.

## References

This adds an additional module, lagom-log4j2, which can be used instead
of lagom-logback for default logging configuration.

This relates to issue #255.