### PR TITLE
Add more explicit Jackson dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -291,6 +291,9 @@ lazy val jackson = (project in file("jackson"))
   .settings(
     libraryDependencies ++= Seq(      
       "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-annotations" % JacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-pcollections" % JacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % JacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % JacksonVersion,
@@ -350,6 +353,8 @@ lazy val server = (project in file("server"))
   .enablePlugins(RuntimeLibPlugins)
   .settings(runtimeLibCommon: _*)
   .dependsOn(core, client, immutables % "provided")
+  // bring jackson closer to the root of the dependency tree to prompt Maven to choose the right version
+  .dependsOn(jackson)
 
 lazy val testkit = (project in file("testkit"))
   .settings(name := "lagom-javadsl-testkit")


### PR DESCRIPTION
## Fixes

Fixes #285

## Purpose

Sets more direct Jackson dependencies, so that they appear closer to the root of the dependency tree, causing Maven to prefer Jackson 2.7.8 over other versions pulled in by transitive dependencies.

## Background Context

Using a dependency range instead caused problems with sbt/ivy resolution that I was unable to fix.

## Note

This fix is for the 1.2.x branch and should be released with 1.2.1. Due to the restructuring of subprojects on master, a slightly different change will be needed there. I'll submit a separate PR later on.