### PR TITLE
Adds OptionalSerializer (branch 1.2.x)

### DIFF
--- a/persistence/src/main/resources/reference.conf
+++ b/persistence/src/main/resources/reference.conf
@@ -17,22 +17,22 @@ lagom.persistence {
   # events. Snapshots are used to reduce recovery times.
   # It may be configured to "off" to disable snapshots.
   snapshot-after = 100
-  
+
   # A persistent entity is passivated automatically if it does not receive 
   # any messages during this timeout. Passivation is performed to reduce
   # memory consumption. Objects referenced by the entity can be garbage
   # collected after passivation. Next message will activate the entity
   # again, which will recover its state from persistent storage.  
   passivate-after-idle-timeout = 120s
-  
+
   # Specifies that entities run on cluster nodes with a specific role.
   # If the role is not specified (or empty) all nodes in the cluster are used.
   # The entities can still be accessed from other nodes.
   run-entities-on-role = ""
-  
+
   # Default timeout for PersistentEntityRef.ask replies.
   ask-timeout = 5s
-  
+
   dispatcher {
     type = Dispatcher
     executor = "thread-pool-executor"
@@ -43,7 +43,7 @@ lagom.persistence {
   }
 }
 #//#persistence  
-  
+
 #//#persistence-read-side
 lagom.persistence.read-side {
 
@@ -52,10 +52,10 @@ lagom.persistence.read-side {
     # minimum (initial) duration until processor is started again
     # after failure
     min = 3s
-    
+
     # the exponential back-off is capped to this duration
     max = 30s
-    
+
     # additional random delay is based on this factor
     random-factor = 0.2
   }
@@ -82,6 +82,7 @@ lagom.persistence.cluster.distribution {
 akka.actor {
   serializers {
     lagom-persistence = "com.lightbend.lagom.internal.persistence.protobuf.PersistenceMessageSerializer"
+    lagom-java-optional = "com.lightbend.lagom.internal.persistence.akkaserializer.OptionalSerializer"
   }
   serialization-bindings {
     "com.lightbend.lagom.javadsl.persistence.CommandEnvelope" = lagom-persistence
@@ -89,9 +90,12 @@ akka.actor {
     "com.lightbend.lagom.javadsl.persistence.PersistentEntity$UnhandledCommandException" = lagom-persistence
     "com.lightbend.lagom.javadsl.persistence.PersistentEntity$PersistException" = lagom-persistence
     "com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution$EnsureActive" = lagom-persistence
+    "java.util.Optional" = lagom-java-optional
   }
   serialization-identifiers {
     "com.lightbend.lagom.internal.persistence.protobuf.PersistenceMessageSerializer" = 1000001
+    "com.lightbend.lagom.internal.persistence.akkaserializer.OptionalSerializer" = 581884278
   }
+
 }
 

--- a/persistence/src/main/scala/com/lightbend/lagom/internal/persistence/akkaserializer/OptionalSerializer.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/internal/persistence/akkaserializer/OptionalSerializer.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.akkaserializer
+
+import java.util.Optional
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.{ BaseSerializer, SerializationExtension, Serializer, SerializerWithStringManifest }
+
+/**
+ * Base Serializer to support Optional<T> as a State or ReplyType on a PersistentEntity.
+ */
+class OptionalSerializer(val system: ExtendedActorSystem)
+  extends SerializerWithStringManifest with BaseSerializer {
+
+  private val separator = ':'
+
+  private val emptyManifest: String = "E"
+
+  // Must be lazy otherwise there's an infinite loop when loading the SerializationExtension
+  lazy val serialization = SerializationExtension(system)
+
+  def serializer(clazz: Class[_]): Serializer = serialization.serializerFor(clazz) // .asInstanceOf[SerializerWithStringManifest]
+
+  override def manifest(obj: AnyRef): String = {
+    val optional: Optional[AnyRef] = obj.asInstanceOf[Optional[AnyRef]]
+    if (optional.isPresent) {
+      val obj1 = optional.get()
+      val fqcn = obj1.getClass.getCanonicalName
+      val srlzr = serializer(obj1.getClass)
+
+      if (srlzr.includeManifest) {
+        val manifest = srlzr.asInstanceOf[SerializerWithStringManifest].manifest(obj1)
+        s"P$separator$fqcn$separator$manifest"
+      } else {
+        s"P$separator$fqcn"
+      }
+
+    } else {
+      emptyManifest
+    }
+  }
+
+  override def toBinary(obj: AnyRef): Array[Byte] = {
+    val optional: Optional[AnyRef] = obj.asInstanceOf[Optional[AnyRef]]
+    if (optional.isPresent) {
+      val obj1 = optional.get()
+      serializer(obj1.getClass).toBinary(obj1)
+    } else
+      Array.emptyByteArray
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    val splits: Array[String] = manifest.split(":")
+    splits(0) match {
+      case `emptyManifest` => Optional.empty()
+      case _ => {
+        val clazz = system.dynamicAccess.classLoader.loadClass(splits(1))
+        val srlrz = serializer(clazz)
+        if (srlrz.includeManifest) {
+          Optional.of(srlrz.asInstanceOf[SerializerWithStringManifest].fromBinary(bytes, splits(2)))
+        } else {
+          Optional.of(srlrz.fromBinary(bytes, clazz))
+        }
+      }
+    }
+  }
+
+}

--- a/persistence/src/test/scala/com/lightbend/lagom/internal/persistence/akkaserializer/OptionalSerializerSpec.scala
+++ b/persistence/src/test/scala/com/lightbend/lagom/internal/persistence/akkaserializer/OptionalSerializerSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.akkaserializer
+
+import java.util.Optional
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.SerializationExtension
+import com.lightbend.lagom.javadsl.persistence.{ ActorSystemSpec, CommandEnvelope, TestEntity }
+
+class OptionalSerializerSpec extends ActorSystemSpec {
+
+  val serializer = new OptionalSerializer(system.asInstanceOf[ExtendedActorSystem])
+
+  private def checkSerialization(obj: AnyRef) = {
+    SerializationExtension(system).serializerFor(obj.getClass).getClass should be(classOf[OptionalSerializer])
+    val bytes = serializer.toBinary(obj)
+    val restored = serializer.fromBinary(bytes, serializer.manifest(obj))
+    restored should be(obj)
+  }
+
+  "OptionalSerializer" must {
+
+    "serialize Optional.empty()" in {
+      checkSerialization(Optional.empty)
+    }
+
+    "serialize Optional.of(String)" in {
+      checkSerialization(Optional.of("1234"))
+    }
+
+    "serialize Optional.of(CommandEnvelope)" in {
+      checkSerialization(Optional.of(CommandEnvelope("entityId", TestEntity.Add.of("a"))))
+    }
+  }
+}


### PR DESCRIPTION
Fixes #277

The `OptionalSerializer` will use `Serializer`'s `includeManifest` to decide what manifest should be created. At the moment, is a manifest is required, the `Serializer` will be cast to a `SerializerWithStringManifest`. If when we support more `Serializer` using a manifest this casting will fail.

@james, please review file location wrt package and module.