### PR TITLE
Add more explicit Jackson dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -359,6 +359,9 @@ lazy val jackson = (project in file("jackson"))
   .settings(
     libraryDependencies ++= Seq(      
       "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-annotations" % JacksonVersion,
+      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-pcollections" % JacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % JacksonVersion,
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % JacksonVersion,
@@ -454,6 +457,8 @@ lazy val `server-javadsl` = (project in file("service/javadsl/server"))
   .enablePlugins(RuntimeLibPlugins)
   .settings(runtimeLibCommon: _*)
   .dependsOn(server, `client-javadsl`, immutables % "provided")
+  // bring jackson closer to the root of the dependency tree to prompt Maven to choose the right version
+  .dependsOn(jackson)
 
 lazy val `server-scaladsl` = (project in file("service/scaladsl/server"))
   .settings(


### PR DESCRIPTION
## Fixes

Fixes #285

## Purpose

Sets more direct Jackson dependencies, so that they appear closer to the root of the dependency tree, causing Maven to prefer Jackson 2.7.8 over other versions pulled in by transitive dependencies.

## Background Context

Using a dependency range instead caused problems with sbt/ivy resolution that I was unable to fix.

## Note

This fix is for the master branch and is based on #296.

Tested against https://github.com/TimMoore/lagom-issue-285 to be sure that it resolves the problem, though it's still possible that some end-user projects have different dependency trees that cause it to resurface, in which case they'll need to use explicit dependency management.