### PR TITLE
Docs: Cassandra and cluster are disabled by default. (1.2.x)

### DIFF
--- a/docs/manual/guide/services/Test.md
+++ b/docs/manual/guide/services/Test.md
@@ -48,15 +48,15 @@ Dependencies to other services must be replaced by stub or mock implementations 
 
 Note how the dependency is overridden when constructing the test `Setup` object, which then can be used as parameter to the `withServer` method instead of the `defaultSetup()` in the above `HelloServiceTest`.
 
-The server is by default running with [[persistence|PersistentEntity]], [[pubsub|PubSub]] and [[cluster|Cluster]] features enabled. Cassandra is also started before the test server is started. If your service does not use these features you can disable them in the `Setup`, which will reduce the startup time.
+The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and [[persistence|PersistentEntity]] features disabled. You may want to enable cluster in the `Setup`:
 
-Disable persistence, including Cassandra startup:
+@[setup2](code/docs/services/test/EnablePersistence.java)
 
-@[setup1](code/docs/services/test/DisablePersistence.java)
+If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. Cassandra Persistence requires clustering, so when you enable Cassandra, cluster will also be enabled automatically. Enable Cassandra Persistence:
 
-If cluster is disabled the persistence is also disabled, since cluster is a prerequisite for persistence. Disable cluster and pubsub:
+@[setup1](code/docs/services/test/EnablePersistence.java)
 
-@[setup2](code/docs/services/test/DisablePersistence.java)
+There's no way to explicitly enable or disable [[pubsub|PubSub]]. When cluster is enabled (either explicitly or transitively via enabling Cassandra), pubsub will be available.
 
 There are two different styles that can be used when writing the tests. It is most convenient to use `withServer` as illustrated in the above `HelloServiceTest`. It automatically starts and stops the server before and after the given lambda.
 

--- a/docs/manual/guide/services/code/docs/services/test/EnablePersistence.java
+++ b/docs/manual/guide/services/code/docs/services/test/EnablePersistence.java
@@ -5,13 +5,13 @@ import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
 import com.lightbend.lagom.javadsl.testkit.ServiceTest.Setup;
 
 @SuppressWarnings("unused")
-public class DisablePersistence {
+public class EnablePersistence {
 
   //#setup1
-  private final Setup setup1 = defaultSetup().withPersistence(false);
+  private final Setup setup1 = defaultSetup().withCassandra(true);
   //#setup1
 
   //#setup2
-  private final Setup setup2 = defaultSetup().withCluster(false);
+  private final Setup setup2 = defaultSetup().withCluster(true);
   //#setup2
 }

--- a/testkit/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -51,10 +51,9 @@ import play.inject.guice.GuiceApplicationBuilder
  * Dependencies to other services must be replaced by stub or mock implementations by
  * overriding the bindings of the `GuiceApplicationBuilder` in the `Setup`.
  *
- * The server is by default running with persistence, pubsub and cluster features
- * enabled. Cassandra is also started before the test server is started. If your service
- * does not use these features you can disable them in the `Setup`, which will reduce
- * the startup time.
+ * The server is ran standalone without persistence, pubsub or cluster features
+ * enabled. Cassandra is also disabled by default. If your service require either of these features you
+ * can enable them in the `Setup`.
  *
  * There are two different styles that can be used. It is most convenient to use [[#withServer withServer]],
  * since it automatically starts and stops the server before and after the given lambda.
@@ -78,7 +77,8 @@ object ServiceTest {
      * Enable or disable Cassandra.
      *
      * If enabled, this will start an embedded Cassandra server before the tests start, and shut it down afterwards.
-     * It will also configure Lagom to use the embedded Cassandra server.
+     * It will also configure Lagom to use the embedded Cassandra server. Enabling Cassandra will also enable the
+     * cluster.
      *
      * @param enabled True if Cassandra should be enabled, or false if disabled.
      * @return A copy of this setup.


### PR DESCRIPTION
This backports #291 (required some path review)