### PR TITLE
Macro hygiene

### DIFF
--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/javadsl/api/ScalaServiceSupport.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/javadsl/api/ScalaServiceSupport.scala
@@ -74,7 +74,7 @@ object ScalaServiceSupport {
     f match {
       case Expr(Block((_, Function(_, Apply(Select(This(thisType), TermName(methodName)), _))))) =>
         val methodNameString = Literal(Constant(methodName))
-        c.Expr[ScalaMethodCall[T]](q"_root_.com.lightbend.lagom.javadsl.api.ScalaServiceSupport.getMethodWithName[${tType.tpe}](classOf[$thisType], $methodNameString)")
+        c.Expr[ScalaMethodCall[T]](q"_root_.com.lightbend.lagom.javadsl.api.ScalaServiceSupport.getMethodWithName[${tType.tpe}](_root_.scala.Predef.classOf[$thisType], $methodNameString)")
       case other =>
         c.abort(c.enclosingPosition, "methodFor must only be invoked with a reference to a function on this, for example, methodFor(this.someFunction)")
     }

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/Service.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/Service.scala
@@ -399,7 +399,7 @@ object ServiceSupport {
       // namedCall(MyService.this.someServiceCall _)
       // This also happens to be what the type checker will infer when you don't explicitly refer to this, eg:
       // namedCall(someServiceCall _)
-      q"classOf[$thisType]"
+      q"_root_.scala.Predef.classOf[$thisType]"
     }
 
     (thisClassExpr, methodNameLiteral)


### PR DESCRIPTION
Improved the hygiene of the macros by using fully qualified references to `_root_.scala.Predef.classOf`.

See @retronym's comment [here](https://github.com/lagom/lagom/commit/0c9895695ee358362dab646153196a4748aea1b4#commitcomment-20129494).