### PR TITLE
Upgrade Lightbend markdown

### DIFF
--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -3,7 +3,7 @@ lazy val plugins = (project in file(".")).dependsOn(dev)
 lazy val dev = ProjectRef(Path.fileProperty("user.dir").getParentFile, "sbt-plugin")
 
 resolvers += Resolver.typesafeIvyRepo("releases")
-addSbtPlugin("com.lightbend.markdown" % "sbt-lightbend-markdown" % "1.4.0")
+addSbtPlugin("com.lightbend.markdown" % "sbt-lightbend-markdown" % "1.4.1")
 
 // Needed for bintray configuration code samples
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
This fixes a bug where Ligtbend markdown was using the theme configured
for running the docs in development, rather than the bare theme when
generating the docs for the website, the result being that the
documentation pages are double decorated.