### PR TITLE
Update sbt to 0.13.13

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-server-disabled-but-defaults-config-still-injected/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-server-disabled-but-defaults-config-still-injected/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -21,7 +21,7 @@ object Scaladoc extends AutoPlugin {
 
   override lazy val projectSettings = {
     inTask(doc)(Seq(
-      scalacOptions in Compile <++= (version, baseDirectory in ThisBuild) map scaladocOptions,
+      scalacOptions in Compile ++= scaladocOptions(version.value, (baseDirectory in ThisBuild).value),
       autoAPIMappings := CliOptions.scaladocAutoAPI.get
     ))
   }

--- a/project/SbtMavenPlugin.scala
+++ b/project/SbtMavenPlugin.scala
@@ -80,7 +80,7 @@ object SbtMavenPlugin extends AutoPlugin {
       outFiles
     },
 
-    resourceGenerators <+= mavenGeneratePluginXml.toTask
+    resourceGenerators += mavenGeneratePluginXml.taskValue
   )
 
   def mavenTestSettings: Seq[Setting[_]] = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
 
 buildInfoSettings
-sourceGenerators in Compile <+= buildInfo
+sourceGenerators in Compile += buildInfo.taskValue
 
 libraryDependencies ++= Seq(
   "org.scala-sbt" % "scripted-plugin" % sbtVersion.value


### PR DESCRIPTION
## Fixes

Fixes #316

Also fixes all of the deprecation warnings other than one that uses `triggeredBy` (see http://www.scala-sbt.org/0.13/docs/Migrating-from-sbt-012x.html#Migrating+when+using+%2C++or)