### PR TITLE
Ensure consistent use of before/afterAll in specs

### DIFF
--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -24,7 +24,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
 
   def this() = this(ConfigFactory.empty())
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
     val cassandraDirectory = new File("target/" + system.name)
@@ -36,7 +36,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
     cluster.join(cluster.selfAddress)
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     CassandraLauncher.stop()
     super.afterAll()
   }

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -24,7 +24,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
 
   def this() = this(ConfigFactory.empty())
 
-  override def beforeAll {
+  override def beforeAll() {
     super.beforeAll()
 
     val cassandraDirectory = new File("target/" + system.name)
@@ -36,7 +36,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
     cluster.join(cluster.selfAddress)
   }
 
-  override def afterAll {
+  override def afterAll() {
     CassandraLauncher.stop()
     super.afterAll()
   }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -24,7 +24,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
 
   def this() = this(ConfigFactory.empty())
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
     val cassandraDirectory = new File("target/" + system.name)
@@ -36,7 +36,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
     cluster.join(cluster.selfAddress)
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     CassandraLauncher.stop()
     super.afterAll()
   }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -24,7 +24,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
 
   def this() = this(ConfigFactory.empty())
 
-  override def beforeAll {
+  override def beforeAll() {
     super.beforeAll()
 
     val cassandraDirectory = new File("target/" + system.name)
@@ -36,7 +36,7 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
     cluster.join(cluster.selfAddress)
   }
 
-  override def afterAll {
+  override def afterAll() {
     CassandraLauncher.stop()
     super.afterAll()
   }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
@@ -37,6 +37,7 @@ class PersistentEntityRefSpec extends WordSpecLike with Matchers with BeforeAndA
   private val system: ActorSystem = ActorSystem("PersistentEntityRefSpec", config)
 
   override def beforeAll(): Unit = {
+    super.beforeAll()
 
     Cluster.get(system).join(Cluster.get(system).selfAddress)
     val cassandraDirectory: File = new File("target/PersistentEntityRefTest")
@@ -47,6 +48,8 @@ class PersistentEntityRefSpec extends WordSpecLike with Matchers with BeforeAndA
   override def afterAll() {
     CassandraLauncher.stop()
     TestKit.shutdownActorSystem(system)
+
+    super.afterAll()
   }
 
   class AnotherEntity extends PersistentEntity {

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
@@ -45,7 +45,7 @@ class PersistentEntityRefSpec extends WordSpecLike with Matchers with BeforeAndA
     TestUtil.awaitPersistenceInit(system)
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     CassandraLauncher.stop()
     TestKit.shutdownActorSystem(system)
 

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -56,7 +56,7 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     )
   )
 
-  override def beforeAll {
+  override def beforeAll() {
     super.beforeAll()
 
     // Join ourselves - needed because we're using cluster singleton to create tables
@@ -72,9 +72,9 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     TestUtil.awaitPersistenceInit(system)
   }
 
-  override def afterAll {
-    super.afterAll()
+  override def afterAll() {
     _database.foreach(_.shutdown())
+    super.afterAll()
   }
 
 }

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -56,7 +56,7 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     )
   )
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
     // Join ourselves - needed because we're using cluster singleton to create tables
@@ -72,7 +72,7 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     TestUtil.awaitPersistenceInit(system)
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     _database.foreach(_.shutdown())
     super.afterAll()
   }

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -51,7 +51,7 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     )
   )
 
-  override def beforeAll() {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
     // Join ourselves - needed because we're using cluster singleton to create tables
@@ -67,7 +67,7 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     TestUtil.awaitPersistenceInit(system)
   }
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     _database.foreach(_.shutdown())
     super.afterAll()
   }

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -51,7 +51,7 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     )
   )
 
-  override def beforeAll {
+  override def beforeAll() {
     super.beforeAll()
 
     // Join ourselves - needed because we're using cluster singleton to create tables
@@ -67,9 +67,9 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
     TestUtil.awaitPersistenceInit(system)
   }
 
-  override def afterAll {
-    super.afterAll()
+  override def afterAll() {
     _database.foreach(_.shutdown())
+    super.afterAll()
   }
 
 }

--- a/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
@@ -34,8 +34,9 @@ abstract class ActorSystemSpec(system: ActorSystem) extends TestKit(system)
 
   def this() = this(ConfigFactory.empty())
 
-  override def afterAll {
+  override def afterAll() {
     shutdown()
+    super.afterAll()
   }
 
   val log: LoggingAdapter = Logging(system, this.getClass)

--- a/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
@@ -34,7 +34,7 @@ abstract class ActorSystemSpec(system: ActorSystem) extends TestKit(system)
 
   def this() = this(ConfigFactory.empty())
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     shutdown()
     super.afterAll()
   }

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/STMultiNodeSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/STMultiNodeSpec.scala
@@ -14,7 +14,13 @@ import org.scalatest.WordSpecLike
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
   with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  override def beforeAll() = multiNodeSpecBeforeAll()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    multiNodeSpecBeforeAll()
+  }
 
-  override def afterAll() = multiNodeSpecAfterAll()
+  override def afterAll(): Unit = {
+    multiNodeSpecAfterAll()
+    super.afterAll()
+  }
 }

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/STMultiNodeSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/STMultiNodeSpec.scala
@@ -14,7 +14,13 @@ import org.scalatest.WordSpecLike
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
   with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  override def beforeAll() = multiNodeSpecBeforeAll()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    multiNodeSpecBeforeAll()
+  }
 
-  override def afterAll() = multiNodeSpecAfterAll()
+  override def afterAll(): Unit = {
+    multiNodeSpecAfterAll()
+    super.afterAll()
+  }
 }

--- a/pubsub/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/pubsub/STMultiNodeSpec.scala
+++ b/pubsub/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/pubsub/STMultiNodeSpec.scala
@@ -14,7 +14,13 @@ import org.scalatest.WordSpecLike
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
   with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  override def beforeAll() = multiNodeSpecBeforeAll()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    multiNodeSpecBeforeAll()
+  }
 
-  override def afterAll() = multiNodeSpecAfterAll()
+  override def afterAll(): Unit = {
+    multiNodeSpecAfterAll()
+    super.afterAll()
+  }
 }

--- a/pubsub/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/pubsub/STMultiNodeSpec.scala
+++ b/pubsub/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/pubsub/STMultiNodeSpec.scala
@@ -14,7 +14,13 @@ import org.scalatest.WordSpecLike
 trait STMultiNodeSpec extends MultiNodeSpecCallbacks
   with WordSpecLike with Matchers with BeforeAndAfterAll {
 
-  override def beforeAll() = multiNodeSpecBeforeAll()
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    multiNodeSpecBeforeAll()
+  }
 
-  override def afterAll() = multiNodeSpecAfterAll()
+  override def afterAll(): Unit = {
+    multiNodeSpecAfterAll()
+    super.afterAll()
+  }
 }

--- a/pubsub/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/pubsub/PubSubSpec.scala
+++ b/pubsub/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/pubsub/PubSubSpec.scala
@@ -36,7 +36,7 @@ class PubSubSpec extends WordSpec with Matchers with BeforeAndAfterAll {
   implicit val mat = ActorMaterializer.create(system)
   val registry = app.pubSubRegistry
 
-  override def afterAll() {
+  override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     super.afterAll()
   }

--- a/pubsub/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/pubsub/PubSubSpec.scala
+++ b/pubsub/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/pubsub/PubSubSpec.scala
@@ -38,6 +38,7 @@ class PubSubSpec extends WordSpec with Matchers with BeforeAndAfterAll {
 
   override def afterAll() {
     TestKit.shutdownActorSystem(system)
+    super.afterAll()
   }
 
   def awaitHasSubscribers(ref: PubSubRef[_], expected: Boolean) = {

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -63,6 +63,8 @@ class JavadslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfter
   @volatile private var kafkaServer = KafkaLocalServer(cleanOnStart = true)
 
   override def beforeAll() = {
+    super.beforeAll()
+
     kafkaServer.start()
     val system = application.injector.instanceOf(classOf[ActorSystem])
     Cluster(system).join(Cluster(system).selfAddress)
@@ -71,6 +73,8 @@ class JavadslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfter
   override def afterAll() = {
     application.stop().futureValue
     kafkaServer.stop()
+
+    super.afterAll()
   }
 
   implicit val patience = PatienceConfig(30.seconds, 150.millis)

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -62,7 +62,7 @@ class JavadslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfter
 
   @volatile private var kafkaServer = KafkaLocalServer(cleanOnStart = true)
 
-  override def beforeAll() = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
     kafkaServer.start()
@@ -70,7 +70,7 @@ class JavadslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfter
     Cluster(system).join(Cluster(system).selfAddress)
   }
 
-  override def afterAll() = {
+  override def afterAll(): Unit = {
     application.stop().futureValue
     kafkaServer.stop()
 

--- a/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslMockServiceSpec.scala
+++ b/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslMockServiceSpec.scala
@@ -201,5 +201,6 @@ class ScaladslMockServiceSpec extends WordSpec with Matchers with BeforeAndAfter
 
   override protected def afterAll(): Unit = {
     server.stop()
+    super.afterAll()
   }
 }

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -56,14 +56,14 @@ class ScaladslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfte
 
   private val kafkaServer = KafkaLocalServer(cleanOnStart = true)
 
-  override def beforeAll() = {
+  override def beforeAll(): Unit = {
     super.beforeAll()
 
     kafkaServer.start()
     Cluster(application.actorSystem).join(Cluster(application.actorSystem).selfAddress)
   }
 
-  override def afterAll() = {
+  override def afterAll(): Unit = {
     application.application.stop().futureValue
     kafkaServer.stop()
 

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -57,6 +57,8 @@ class ScaladslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfte
   private val kafkaServer = KafkaLocalServer(cleanOnStart = true)
 
   override def beforeAll() = {
+    super.beforeAll()
+
     kafkaServer.start()
     Cluster(application.actorSystem).join(Cluster(application.actorSystem).selfAddress)
   }
@@ -64,6 +66,8 @@ class ScaladslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfte
   override def afterAll() = {
     application.application.stop().futureValue
     kafkaServer.stop()
+
+    super.afterAll()
   }
 
   implicit val patience = PatienceConfig(30.seconds, 150.millis)


### PR DESCRIPTION
Just some style fixes I noticed while working on specs:

- Add parentheses to defs and calls (as these are methods with side effects)
- Call super.beforeAll() at the beginning of overridden beforeAll()
- Call super.afterAll() at the end of overridden afterAll()
- Avoid procedure syntax (use `: Unit =` in defs)