### PR TITLE
Add private[lagom] to the Retry companion object

### DIFF
--- a/persistence-jpa/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/Retry.scala
+++ b/persistence-jpa/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/Retry.scala
@@ -41,7 +41,7 @@ private[lagom] class Retry(delay: FiniteDuration, delayFactor: Double, maxRetrie
     fromNanos((duration.toNanos * factor).toLong)
 }
 
-object Retry {
+private[lagom] object Retry {
   def apply[T](delay: FiniteDuration, delayFactor: Double, maxRetries: Int)(op: => T)(implicit ec: ExecutionContext, s: Scheduler): Future[T] =
     (new Retry(delay, delayFactor, maxRetries))(op)
 }


### PR DESCRIPTION
Forgot this in my previous pull request (#342)