### PR TITLE
[1.3.0-M1] Fix off-by-one error in the JDBC event journal query

### DIFF
--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -3,15 +3,15 @@
  */
 package com.lightbend.lagom.javadsl.persistence.cassandra
 
-import akka.NotUsed
-import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
-import akka.persistence.query.PersistenceQuery
-import akka.stream.javadsl.Source
-import com.lightbend.lagom.internal.javadsl.persistence.OffsetAdapter
-import com.lightbend.lagom.internal.javadsl.persistence.cassandra.{ CassandraReadSideImpl, JavadslCassandraOffsetStore }
+import java.util.concurrent.CompletionStage
+
+import com.google.inject.Guice
+import com.lightbend.lagom.internal.javadsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, JavadslCassandraOffsetStore }
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.javadsl.persistence._
 import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration._
 
 object CassandraReadSideSpec {
 
@@ -22,28 +22,25 @@ object CassandraReadSideSpec {
 }
 
 class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.config) with AbstractReadSideSpec {
-  lazy val testSession: CassandraSession = new CassandraSession(system)
-  lazy val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+  import system.dispatcher
 
-  override def eventStream[Event <: AggregateEvent[Event]](
-    aggregateTag: AggregateEventTag[Event],
-    fromOffset:   Offset
-  ): Source[akka.japi.Pair[Event, Offset], NotUsed] = {
-    val tag = aggregateTag.tag
-    queries.eventsByTag(tag, OffsetAdapter.dslOffsetToOffset(fromOffset))
-      .map { env => akka.japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset)) }
-      .asJava
-  }
+  private lazy val injector = Guice.createInjector()
+  override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system, injector)
 
-  val readSide = new TestEntityReadSide(testSession)
-  val cassandraReadSide = new CassandraReadSideImpl(system, testSession, new JavadslCassandraOffsetStore(system, testSession,
-    ReadSideConfig())(system.dispatcher), null, null)
+  private lazy val testSession: CassandraSession = new CassandraSession(system)
+  private lazy val offsetStore = new JavadslCassandraOffsetStore(system, testSession, ReadSideConfig())
+  private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore, null, injector)
 
-  override def getAppendCount(id: String) = readSide.getAppendCount(id)
-
-  override def processorFactory(): ReadSideProcessor[TestEntity.Evt] = {
+  override def processorFactory(): ReadSideProcessor[TestEntity.Evt] =
     new TestEntityReadSide.TestEntityReadSideProcessor(cassandraReadSide, testSession)
+
+  private lazy val readSide = new TestEntityReadSide(testSession)
+
+  override def getAppendCount(id: String): CompletionStage[java.lang.Long] = readSide.getAppendCount(id)
+
+  override def afterAll(): Unit = {
+    persistentEntityRegistry.gracefulShutdown(5.seconds)
+    super.afterAll()
   }
 
 }
-

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -3,15 +3,14 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
-import akka.NotUsed
-import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
-import akka.persistence.query.{ NoOffset, Offset, PersistenceQuery, TimeBasedUUID }
-import akka.stream.scaladsl.Source
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.scaladsl.persistence.PersistentEntityActor
-import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ ScaladslCassandraOffsetStore, CassandraReadSideImpl }
+import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
+import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
 import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
 
 object CassandraReadSideSpec {
 
@@ -22,27 +21,24 @@ object CassandraReadSideSpec {
 }
 
 class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.config) with AbstractReadSideSpec {
-  lazy val testSession: CassandraSession = new CassandraSession(system)
-  lazy val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+  import system.dispatcher
 
-  override def eventStream[Event <: AggregateEvent[Event]](
-    aggregateTag: AggregateEventTag[Event],
-    fromOffset:   Offset
-  ): Source[EventStreamElement[Event], NotUsed] = {
-    queries.eventsByTag(aggregateTag.tag, fromOffset)
-      .map { env => new EventStreamElement[Event](PersistentEntityActor.extractEntityId(env.persistenceId), env.event.asInstanceOf[Event], env.offset) }
+  override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system)
 
-  }
+  private lazy val testSession: CassandraSession = new CassandraSession(system)
+  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, ReadSideConfig())
+  private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore)
 
-  val readSide = new TestEntityReadSide(system, testSession)
-  val cassandraReadSide = new CassandraReadSideImpl(system, testSession, new ScaladslCassandraOffsetStore(system, testSession,
-    ReadSideConfig())(system.dispatcher))
-
-  override def getAppendCount(id: String) = readSide.getAppendCount(id)
-
-  override def processorFactory(): ReadSideProcessor[TestEntity.Evt] = {
+  override def processorFactory(): ReadSideProcessor[Evt] =
     new TestEntityReadSide.TestEntityReadSideProcessor(system, cassandraReadSide, testSession)
-  }
 
+  private lazy val readSide = new TestEntityReadSide(system, testSession)
+
+  override def getAppendCount(id: String): Future[Long] = readSide.getAppendCount(id)
+
+  override def afterAll(): Unit = {
+    persistentEntityRegistry.gracefulShutdown(5.seconds)
+    super.afterAll()
+  }
 }
 

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -5,8 +5,8 @@ package com.lightbend.lagom.internal.scaladsl.persistence.jdbc
 
 import akka.actor.ActorSystem
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
-import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery2
+import akka.persistence.query.{ NoOffset, Offset, PersistenceQuery, Sequence }
 import com.lightbend.lagom.internal.persistence.jdbc.SlickProvider
 import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntityRegistry
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
@@ -27,4 +27,12 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
   override protected val journalId: String = JdbcReadJournal.Identifier
   private val jdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](journalId)
   override protected val eventsByTagQuery: Option[EventsByTagQuery2] = Some(jdbcReadJournal)
+
+  override protected def mapStartingOffset(storedOffset: Offset): Offset = storedOffset match {
+    case NoOffset        => NoOffset
+    case Sequence(value) => Sequence(value + 1)
+    case other =>
+      throw new IllegalArgumentException(s"JDBC does not support ${other.getClass.getSimpleName} offsets")
+  }
+
 }

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
@@ -3,43 +3,26 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.jdbc
 
-import akka.NotUsed
-import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
-import akka.persistence.query.{ NoOffset, Offset, PersistenceQuery, Sequence }
-import akka.stream.scaladsl.Source
-import com.lightbend.lagom.internal.scaladsl.persistence.PersistentEntityActor
+import com.lightbend.lagom.internal.scaladsl.persistence.jdbc.JdbcPersistentEntityRegistry
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class JdbcReadSideSpec extends JdbcPersistenceSpec with AbstractReadSideSpec {
+  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, slick)
+
+  override def processorFactory(): ReadSideProcessor[Evt] =
+    new JdbcTestEntityReadSide.TestEntityReadSideProcessor(jdbcReadSide)
 
   lazy val readSide = new JdbcTestEntityReadSide(session)
-  lazy val queries = PersistenceQuery(system).readJournalFor[JdbcReadJournal](JdbcReadJournal.Identifier)
 
-  override def eventStream[Event <: AggregateEvent[Event]](aggregateTag: AggregateEventTag[Event], fromOffset: Offset): Source[EventStreamElement[Event], NotUsed] = {
-    val tag = aggregateTag.tag
-    val offset = fromOffset match {
-      case NoOffset        => 0l
-      case Sequence(value) => value + 1
-      case other           => throw new IllegalArgumentException(s"JDBC does not support ${other.getClass.getSimpleName} offsets")
-    }
-    queries.eventsByTag(tag, offset)
-      .map { env =>
-        new EventStreamElement[Event](
-          PersistentEntityActor.extractEntityId(env.persistenceId),
-          env.event.asInstanceOf[Event],
-          Sequence(env.offset): Offset
-        )
-      }
+  override def getAppendCount(id: String): Future[Long] = readSide.getAppendCount(id)
+
+  override def afterAll(): Unit = {
+    persistentEntityRegistry.gracefulShutdown(5.seconds)
+    super.afterAll()
   }
 
-  override def processorFactory(): ReadSideProcessor[Evt] = {
-    new JdbcTestEntityReadSide.TestEntityReadSideProcessor(jdbcReadSide)
-  }
-
-  override def getAppendCount(id: String): Future[Long] = {
-    readSide.getAppendCount(id)
-  }
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
@@ -3,17 +3,15 @@
  */
 package com.lightbend.lagom.javadsl.persistence
 
-import java.util.Optional
-import java.util.UUID
+import java.util.concurrent.CompletionStage
+import java.util.{ Optional, UUID }
 
-import scala.concurrent.duration._
 import akka.japi.Pair
 import akka.stream.javadsl
-import akka.NotUsed
-import java.util.concurrent.CompletionStage
-
-import akka.Done
+import akka.{ Done, NotUsed }
 import com.lightbend.lagom.javadsl.persistence.Offset.{ Sequence, TimeBasedUUID }
+
+import scala.concurrent.duration._
 
 /**
  * At system startup all [[PersistentEntity]] classes must be registered here
@@ -44,6 +42,11 @@ trait PersistentEntityRegistry {
    * UUID offsets, while others use sequence numbers. The passed in `fromOffset`
    * must either be [[Offset#NONE]], or an offset that has previously been produced
    * by this journal.
+   *
+   * The stream will begin with events starting ''after'' `fromOffset`.
+   * To resume an event stream, store the `Offset` corresponding to the most
+   * recently processed `Event`, and pass that back as the value for
+   * `fromOffset` to start the stream from events following that one.
    *
    * @throws IllegalArgumentException If the `fromOffset` type is not supported
    *   by this journal.

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
@@ -6,32 +6,32 @@ package com.lightbend.lagom.javadsl.persistence
 import java.util.Optional
 import java.util.concurrent.CompletionStage
 
-import akka.{ Done, NotUsed }
 import akka.stream.ActorMaterializer
 import akka.stream.javadsl.Source
 import akka.testkit.ImplicitSender
-
-import scala.compat.java8.FutureConverters._
-import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
+import akka.{ Done, NotUsed }
 import com.lightbend.lagom.internal.javadsl.persistence.{ PersistentEntityActor, ReadSideActor }
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
-import com.lightbend.lagom.javadsl.persistence.TestEntity.InPrependMode
-
-import scala.concurrent.Await
 import com.lightbend.lagom.persistence.ActorSystemSpec
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration._
 
 trait AbstractReadSideSpec extends ImplicitSender { spec: ActorSystemSpec =>
   import system.dispatcher
 
   implicit val mat = ActorMaterializer()
 
+  protected val persistentEntityRegistry: PersistentEntityRegistry
+
   def eventStream[Event <: AggregateEvent[Event]](
     aggregateTag: AggregateEventTag[Event],
     fromOffset:   Offset
-  ): Source[akka.japi.Pair[Event, Offset], NotUsed]
+  ): Source[akka.japi.Pair[Event, Offset], NotUsed] =
+    persistentEntityRegistry.eventStream(aggregateTag, fromOffset)
 
   def processorFactory(): ReadSideProcessor[TestEntity.Evt]
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
@@ -48,6 +48,11 @@ trait PersistentEntityRegistry {
    * must either be [[akka.persistence.query.NoOffset]], or an offset that has previously been produced
    * by this journal.
    *
+   * The stream will begin with events starting ''after'' `fromOffset`.
+   * To resume an event stream, store the `Offset` corresponding to the most
+   * recently processed `Event`, and pass that back as the value for
+   * `fromOffset` to start the stream from events following that one.
+   *
    * @throws IllegalArgumentException If the `fromOffset` type is not supported
    *   by this journal.
    */

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -3,34 +3,32 @@
  */
 package com.lightbend.lagom.scaladsl.persistence
 
-import java.util.Optional
-
 import akka.persistence.query.Offset
-import akka.{ Done, NotUsed }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.testkit.ImplicitSender
-
-import scala.concurrent.duration._
-import com.lightbend.lagom.internal.scaladsl.persistence.{ PersistentEntityActor, ReadSideActor }
+import akka.{ Done, NotUsed }
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
-
-import scala.concurrent.Await
+import com.lightbend.lagom.internal.scaladsl.persistence.{ PersistentEntityActor, ReadSideActor }
 import com.lightbend.lagom.persistence.ActorSystemSpec
 
-import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
 
 trait AbstractReadSideSpec extends ImplicitSender { spec: ActorSystemSpec =>
   import system.dispatcher
 
   implicit val mat = ActorMaterializer()
 
+  protected val persistentEntityRegistry: PersistentEntityRegistry
+
   def eventStream[Event <: AggregateEvent[Event]](
     aggregateTag: AggregateEventTag[Event],
     fromOffset:   Offset
-  ): Source[EventStreamElement[Event], NotUsed]
+  ): Source[EventStreamElement[Event], NotUsed] =
+    persistentEntityRegistry.eventStream(aggregateTag, fromOffset)
 
   def processorFactory(): ReadSideProcessor[TestEntity.Evt]
 


### PR DESCRIPTION
There was a change in Lagom 1.3 to use the new Akka Offset type for journal queries.

This introduced a bug when resuming JDBC read side processors: rather than starting with the first unseen event, it's re-processing the last seen event.

This is caused by the way that akka-persistence-jdbc is handling offset in queries: it treats the offset as an _inclusive_ bound https://github.com/dnvriend/akka-persistence-jdbc/blob/master/src/main/scala/akka/persistence/jdbc/query/dao/ReadJournalQueries.scala#L50

In released versions of Lagom, this is accounted for by incrementing sequence offsets before making the query, but in Lagom 1.3 this was removed.

Here is the specific change https://github.com/lagom/lagom/commit/58c900eda2ed66552bb93653e3769d44db850e43#diff-b00d9e70042b9ecf936fb5cc01bb8d1fL123

I'm not sure what the expected behavior is for the `eventsByTag` query. It isn't specified very clearly by the interface.

1. Should the query only return events _after_ the given offset rather than including the event _at_ that offset? That would imply that akka-persistence-jdbc is implementing it incorrectly.
2. Or is it expected that sequence offsets and UUID offsets behave differently in this respect? That is what the 1.2.x Lagom code assumes, but it seems strange.
3. Or is it fully implementation-dependent? In that case, `AbstractPersistentEntityRegistry` needs to delegate mapping the last stored offset to the query offset to its subclasses.

I have implemented option 3. I think it would be better if Akka persistence specified the role of the offset more clearly, but I guess that ship has sailed.

Any other thoughts, @jroper, @ignasi35, @johanandren or @patriknw?