### PR TITLE
Restore execution of scripted tests.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -988,7 +988,7 @@ lazy val `maven-launcher` = (project in file("dev") / "maven-launcher")
 def scriptedSettings: Seq[Setting[_]] = ScriptedPlugin.scriptedSettings ++ 
   Seq(scriptedLaunchOpts += s"-Dproject.version=$version.value") ++
   Seq(
-    scripted <<= scripted.tag(Tags.Test),
+    scripted := scripted.tag(Tags.Test).evaluated,
     scriptedLaunchOpts ++= Seq(
       "-Xmx768m",
       "-XX:MaxMetaspaceSize=384m",

--- a/build.sbt
+++ b/build.sbt
@@ -986,7 +986,7 @@ lazy val `maven-launcher` = (project in file("dev") / "maven-launcher")
     )
 
 def scriptedSettings: Seq[Setting[_]] = ScriptedPlugin.scriptedSettings ++ 
-  Seq(scriptedLaunchOpts += s"-Dproject.version=$version.value") ++
+  Seq(scriptedLaunchOpts += s"-Dproject.version=${version.value}") ++
   Seq(
     scripted := scripted.tag(Tags.Test).evaluated,
     scriptedLaunchOpts ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -988,7 +988,7 @@ lazy val `maven-launcher` = (project in file("dev") / "maven-launcher")
 def scriptedSettings: Seq[Setting[_]] = ScriptedPlugin.scriptedSettings ++ 
   Seq(scriptedLaunchOpts += s"-Dproject.version=$version.value") ++
   Seq(
-    scripted := scripted.tag(Tags.Test).inputTaskValue,
+    scripted <<= scripted.tag(Tags.Test),
     scriptedLaunchOpts ++= Seq(
       "-Xmx768m",
       "-XX:MaxMetaspaceSize=384m",


### PR DESCRIPTION
Fixes #364 (well, not sure, will see how it goes in CI)

This patch restores the runnability of scripted tests but it brings back a deprecation warning on sbt. 
