### PR TITLE
Start of Swagger support

### DIFF
--- a/api-tools/src/main/scala/com/lightbend/lagom/internal/api/tools/ServiceDetector.scala
+++ b/api-tools/src/main/scala/com/lightbend/lagom/internal/api/tools/ServiceDetector.scala
@@ -37,7 +37,6 @@ object ServiceDetector {
    * Retrieves the service names and acls for the current Lagom project
    * of all services.
    *
-   *
    * @param classLoader The class loader should contain a sbt project in the classpath
    *                    for which the services should be resolved.
    * @return a JSON array of [[com.lightbend.lagom.internal.spi.ServiceDescription]] objects.
@@ -54,8 +53,8 @@ object ServiceDetector {
 
     val serviceDiscoverClass = classLoader.loadClass(serviceDiscoveryClassName)
     val castServiceDiscoveryClass = serviceDiscoverClass.asSubclass(classOf[ServiceDiscovery])
-    val serviceDiscovery = castServiceDiscoveryClass.newInstance()
-    val services = serviceDiscovery.discoverServices(classLoader).asScala.to[immutable.Seq]
+    val serviceDiscovery: ServiceDiscovery = castServiceDiscoveryClass.newInstance()
+    val services: Seq[ServiceDescription] = serviceDiscovery.discoverServices(classLoader).asScala.to[immutable.Seq]
     Json.stringify(Json.toJson(services))
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,8 @@ val coreProjects = Seq[ProjectReference](
   `persistence-jdbc-core`,
   `testkit-core`,
   logback,
-  log4j2
+  log4j2,
+  `open-api`
 )
 
 val otherProjects = Seq[ProjectReference](
@@ -869,6 +870,17 @@ lazy val log4j2 = (project in file("log4j2"))
       "com.typesafe.play" %% "play" % PlayVersion
     )
   )
+
+lazy val `open-api` = (project in file("open-api"))
+  .enablePlugins(RuntimeLibPlugins)
+  .settings(runtimeLibCommon: _*)
+  .settings(
+    name := "lagom-open-api",
+    libraryDependencies ++= Seq(
+      "io.swagger" % "swagger-core" % "1.5.12"
+    )
+  )
+  .dependsOn(`server-javadsl`)
 
 lazy val `dev-environment` = (project in file("dev"))
   .settings(name := "lagom-dev")

--- a/open-api/src/main/java/com/lightbend/lagom/openapi/OpenApiModule.java
+++ b/open-api/src/main/java/com/lightbend/lagom/openapi/OpenApiModule.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.openapi;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provider;
+import com.lightbend.lagom.internal.javadsl.server.JavadslServiceRouter;
+import com.lightbend.lagom.internal.javadsl.server.JavadslServiceRouter.JavadslServiceRoute;
+import com.lightbend.lagom.internal.javadsl.server.JavadslServicesRouter;
+import com.lightbend.lagom.javadsl.api.transport.Method;
+
+import io.swagger.models.Info;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.RefModel;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.properties.RefProperty;
+import scala.collection.JavaConverters;
+
+public class OpenApiModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(Swagger.class).toProvider(SwaggerProvider.class).asEagerSingleton();
+  }
+
+  private static class SwaggerProvider implements Provider<Swagger> {
+
+    private final JavadslServicesRouter servicesRouter;
+
+    @Inject
+    public SwaggerProvider(JavadslServicesRouter servicesRouter) {
+      this.servicesRouter = servicesRouter;
+    }
+
+    @Override
+    public Swagger get() {
+      Swagger swagger = new Swagger();
+
+      // TODO(benmccann): info title and version are required properties
+      Info info = new Info();
+      swagger.setInfo(info);
+
+      for (JavadslServiceRouter serviceRouter : JavaConverters.asJavaCollectionConverter(
+          servicesRouter.serviceRouters()).asJavaCollection()) {
+
+        for (JavadslServiceRoute serviceRoute : JavaConverters.asJavaCollectionConverter(
+            serviceRouter.serviceRoutes()).asJavaCollection()) {
+
+          Operation operation = new Operation();
+
+          // TODO(benmccann): response description is required
+          // should the user express non-200 return codes via annotations?
+          Response response = new Response();
+          operation.setResponses(ImmutableMap.of("200", response));
+
+          Class<?> returnType = serviceRoute.holder().method().getReturnType();
+          if (!returnType.equals(Void.TYPE)) {
+            RefModel responseModel = new RefModel();
+            swagger.addDefinition(returnType.getSimpleName(), responseModel);
+            response.setSchema(new RefProperty("#/definitions/" + returnType.getSimpleName()));
+          }
+
+          // TODO(benmccann): add parameters
+          Path path = new Path();
+          if (Method.GET.equals(serviceRoute.method())) {
+            path.setGet(operation);
+          } else if (Method.POST.equals(serviceRoute.method())) {
+            path.setPost(operation);
+          } else if (Method.PUT.equals(serviceRoute.method())) {
+            path.setPut(operation);
+          } else if (Method.DELETE.equals(serviceRoute.method())) {
+            path.setDelete(operation);
+          } else if (Method.PATCH.equals(serviceRoute.method())) {
+            path.setPatch(operation);
+          } else if (Method.HEAD.equals(serviceRoute.method())) {
+            path.setHead(operation);
+          } else if (Method.OPTIONS.equals(serviceRoute.method())) {
+            path.setOptions(operation);
+          }
+          swagger.path(toSwaggerTemplatedPath(serviceRoute.path().pathSpec()), path);
+        }
+      }
+
+      return swagger;
+    }
+
+    /**
+     * Converts from Lagom's /foo/:var to Swagger's /foo/{var}
+     */
+    private String toSwaggerTemplatedPath(String path) {
+      return Joiner.on("/").join(
+          Arrays.stream(path.split("/"))
+              .map(segment -> segment.startsWith(":") ? "{" + segment.substring(1) + "}" : segment)
+              .collect(Collectors.toList()));
+    }
+    
+  }
+
+}

--- a/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
+++ b/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
@@ -108,7 +108,7 @@ class JavadslServicesRouter @Inject() (resolvedServices: ResolvedServices, httpC
   ec: ExecutionContext,
                                                                                                                  mat: Materializer) extends SimpleRouter {
 
-  private val serviceRouters = resolvedServices.services.map { service =>
+  private[lagom] val serviceRouters = resolvedServices.services.map { service =>
     new JavadslServiceRouter(service.descriptor, service.service, httpConfiguration)
   }
 
@@ -120,7 +120,7 @@ class JavadslServicesRouter @Inject() (resolvedServices: ResolvedServices, httpC
 class JavadslServiceRouter(override protected val descriptor: Descriptor, service: Any, httpConfiguration: HttpConfiguration)(implicit ec: ExecutionContext, mat: Materializer)
   extends ServiceRouter(httpConfiguration) with JavadslServiceApiBridge {
 
-  private class JavadslServiceRoute(override val call: Call[Any, Any]) extends ServiceRoute {
+  private[lagom] class JavadslServiceRoute(override val call: Call[Any, Any]) extends ServiceRoute {
     override val path: Path = JavadslPath.fromCallId(call.callId)
     override val method: Method = call.callId match {
       case rest: RestCallId => rest.method
@@ -133,7 +133,7 @@ class JavadslServiceRouter(override protected val descriptor: Descriptor, servic
     override val isWebSocket: Boolean = call.requestSerializer.isInstanceOf[StreamedMessageSerializer[_]] ||
       call.responseSerializer.isInstanceOf[StreamedMessageSerializer[_]]
 
-    private val holder: MethodServiceCallHolder = call.serviceCallHolder() match {
+    private[lagom] val holder: MethodServiceCallHolder = call.serviceCallHolder() match {
       case holder: MethodServiceCallHolder => holder
     }
 
@@ -142,7 +142,7 @@ class JavadslServiceRouter(override protected val descriptor: Descriptor, servic
     }
   }
 
-  override protected val serviceRoutes: Seq[ServiceRoute] =
+  override protected val serviceRoutes: Seq[JavadslServiceRoute] =
     descriptor.calls.asScala.map(call => new JavadslServiceRoute(call.asInstanceOf[Call[Any, Any]]))
 
   /**


### PR DESCRIPTION
This is a bit of a work in progress to get feedback.

There are three ways I've seen Swagger integrated with Play apps:

* [swagger-api/swagger-play](https://github.com/swagger-api/swagger-play) - Generates a Swagger spec from Play app. [Annotations](https://github.com/swagger-api/swagger-core/wiki/Annotations-1.5.X) used to add attributes. Pluses: compiler validates syntax in IDE, annotations can be processed at runtime (e.g. to get authorization scope)
* [iheartradio/play-swagger](https://github.com/iheartradio/play-swagger) - Generates a Swagger spec. Flesh out attributes via comments in routes file. Pluses: easy to support all Swagger syntax. Minuses: nothing enforces that spec and code remain in sync, need custom syntax in Swagger spec (e.g. to declare date type)
* [zalando/api-first-hand](https://github.com/zalando/api-first-hand) - Generates Play code from a Swagger spec. Minuses: developer has to learn syntax for defining models in Swagger spec, comments interspersed in code like "// ----- Start of unmanaged code area", can't add code to models because they're generated, need code generators for both Java and Scala

The approach I'm taking here is to start with the code and generate the Swagger spec from it like the first two projects above instead of vice versa like zalando does.

## References

Issue: https://github.com/lagom/lagom/issues/280
Reference implementation: [swagger-play PlayReader](https://github.com/swagger-api/swagger-play/blob/master/play-2.5/swagger-play2/app/play/modules/swagger/PlayReader.java)