### PR TITLE
Propose to remove old sentence

### DIFF
--- a/docs/manual/common/concepts/Technologies.md
+++ b/docs/manual/common/concepts/Technologies.md
@@ -20,8 +20,6 @@ Lagom services that persist data are encouraged, but not required, to use an eve
 
 ## Java and Scala
 
-The first version of Lagom provides a Java API for writing microservices.  Before long, a subsequent version will add a Scala API.
-
 Lagom's Java APIs target Java 8. They assume familiarity with Java 8 features such as [lambdas](http://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html), [default methods](http://docs.oracle.com/javase/tutorial/java/IandI/defaultmethods.html), and [`Optional`](http://docs.oracle.com/javase/8/docs/api/java/util/Optional.html).
 
 Most of Lagom is implemented in Scala.  (This is an implementation detail that doesn't normally concern Java programmers using Lagom APIs.)


### PR DESCRIPTION
The following sentence looks a little old, and may not be relevant anymore. I'm reading the documentation from start to finish at the moment, and this feels a little out of place and dated:

"The first version of Lagom provides a Java API for writing microservices.  Before long, a subsequent version will add a Scala API."