### PR TITLE
Fix a small typo in the Java getting started guide

### DIFF
--- a/docs/manual/java/gettingstarted/GettingStartedSbt.md
+++ b/docs/manual/java/gettingstarted/GettingStartedSbt.md
@@ -21,7 +21,7 @@ hello                   → Project root
  └ hello-api            → hello api project
  └ hello-impl           → hello implementation project
  └ hello-stream-api     → hello-stream api project
- └ hello-stream-impl    → hello-steram implementation project
+ └ hello-stream-impl    → hello-stream implementation project
  └ project              → sbt configuration files
    └ build.properties   → Marker for sbt project
    └ plugins.sbt        → sbt plugins including the declaration for Lagom itself


### PR DESCRIPTION
This is the Java equivalent to the change in #374.