### PR TITLE
Updated plugins.sbt with correct Markdown version, updated the three …

### DIFF
--- a/docs/manual/java/gettingstarted/GettingStartedMaven.md
+++ b/docs/manual/java/gettingstarted/GettingStartedMaven.md
@@ -1,25 +1,35 @@
-# Getting started with Lagom in Maven
+Getting started with Lagom in Maven
+===================================
 
 This page shows how to create and run your first Lagom project.
 
-## Creating a new Lagom project
+Creating a new Lagom project
+----------------------------
 
-A Lagom system is typically made up of a set of maven projects, each build providing multiple services.  The easiest way to get started with a new Lagom system is to create a new project using the Maven archetype plugin, with the Lagom Maven archetype:
+A Lagom system is typically made up of a set of maven projects, each build
+providing multiple services. The easiest way to get started with a new Lagom
+system is to create a new project using the Maven archetype plugin, with the
+Lagom Maven archetype:
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ mvn archetype:generate -DarchetypeGroupId=com.lightbend.lagom \
   -DarchetypeArtifactId=maven-archetype-lagom-java -DarchetypeVersion=1.1.0
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-> **Note:** Ensure you replace the 1.1.0 archetype version with the latest version of Lagom.
+>   **Note:** Ensure you replace the 1.1.0 archetype version with the latest
+>   version of Lagom.
 
-This will prompt you for a `groupId`, `artifactId` and `version`.  You might choose, for example, `com.example` as a `groupId`, and `my-first-system` for an `artifactId`.  Once you've followed the prompts, it will create a new system with two services in it: `hello` and `stream`.
+This will prompt you for a `groupId`, `artifactId` and `version`. You might
+choose, for example, `com.example` as a `groupId`, and `my-first-system` for an
+`artifactId`. Once you've followed the prompts, it will create a new system with
+two services in it: `hello` and `stream`.
 
-## Anatomy of a Lagom project
+Anatomy of a Lagom project
+--------------------------
 
 The created project contains the following elements:
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 my-first-system          → Project root
  └ hello-api             → hello world api project
  └ hello-impl            → hello world implementation project
@@ -27,32 +37,54 @@ my-first-system          → Project root
  └ stream-impl           → stream implementation project
  └ integration-tests     → Integration tests
  └ pom.xml               → Project root build file
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Notice how each service is broken up into two projects: api and implementation. The api project contains a service interface through which consumers may interact with the service. While the implementation project contains the actual service implementation.
+Notice how each service is broken up into two projects: api and implementation.
+The api project contains a service interface through which consumers may
+interact with the service. While the implementation project contains the actual
+service implementation.
 
-## Understanding services projects
+Understanding services projects
+-------------------------------
 
+-   The service interface is always placed in the api project. For instance, the
+    service interface for the `hello` service can be found in the `hello-api`
+    project (look for the `HelloService.java` source file).
 
-* The service interface is always placed in the api project. For instance, the service interface for the `hello` service can be found in the `hello-api` project (look for the `HelloService.java` source file).
+\@[helloservice-interface](code/docs/javadsl/gettingstarted/helloservice/HelloService.java)
 
-@[helloservice-interface](code/docs/javadsl/gettingstarted/helloservice/HelloService.java)
+-   The service interface needs to inherit from
+    [Service](api/index.html?com/lightbend/lagom/javadsl/api/Service.html) and
+    provide an implementation of
+    [Service.descriptor](api/index.html?com/lightbend/lagom/javadsl/api/Service.html#descriptor--)
+    method.
 
-* The service interface needs to inherit from [`Service`](api/index.html?com/lightbend/lagom/javadsl/api/Service.html) and provide an implementation of [`Service.descriptor`](api/index.html?com/lightbend/lagom/javadsl/api/Service.html#descriptor--) method.
+-   The implementation of `Service.descriptor` returns a
+    [Descriptor](api/index.html?com/lightbend/lagom/javadsl/api/Descriptor.html).
+    A `Descriptor` defines the service name and the REST endpoints offered by a
+    service. For each declared endpoint, an abstract method is declared in the
+    service interface, e.g., see the `HelloService.hello` method.
 
-* The implementation of `Service.descriptor` returns a [`Descriptor`](api/index.html?com/lightbend/lagom/javadsl/api/Descriptor.html). A `Descriptor` defines the service name and the REST endpoints offered by a service. For each declared endpoint, an abstract method is declared in the service interface, e.g., see the `HelloService.hello` method.
+-   The implementation of the service abstract methods is provided by the
+    related implementation project. For instance, the service implementation of
+    the `HelloService.hello` method, for the `hello` service, can be found in
+    the `hello-impl` project (look for the `HelloServiceImpl.java` source file).
 
-* The implementation of the service abstract methods is provided by the related implementation project. For instance, the service implementation of the `HelloService.hello` method, for the `hello` service, can be found in the `hello-impl` project (look for the `HelloServiceImpl.java` source file).
+\@[helloservice-impl](code/docs/javadsl/gettingstarted/helloservice/HelloServiceImpl.java)
 
-@[helloservice-impl](code/docs/javadsl/gettingstarted/helloservice/HelloServiceImpl.java)
+-   The
+    [PersistentEntityRegistry](api/index.html?com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.html)
+    allows to persist data in the database using [[Event Sourcing and
+    CQRS\|ES_CQRS]].
 
-* The [`PersistentEntityRegistry`](api/index.html?com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.html) allows to persist data in the database using [[Event Sourcing and CQRS|ES_CQRS]].
+Running Lagom services
+----------------------
 
-## Running Lagom services
+Lagom includes a development environment that let you start all your services by
+invoking the `runAll` task on the Lagom maven plugin. Open the terminal and `cd`
+to your Lagom project (some log output cut for brevity):
 
-Lagom includes a development environment that let you start all your services by invoking the `runAll` task on the Lagom maven plugin. Open the terminal and `cd` to your Lagom project (some log output cut for brevity):
-
-```console
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
 $ cd my-first-system
 $ mvn lagom:runAll
 ...
@@ -65,20 +97,26 @@ $ mvn lagom:runAll
 [info] Service hello-impl listening for HTTP on 0:0:0:0:0:0:0:0:24266
 [info] Service stream-impl listening for HTTP on 0:0:0:0:0:0:0:0:26230
 (Services started, press enter to stop and go back to the console...)
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can verify that the services are indeed up and running by invoking one of its endpoints, e.g:
+You can verify that the services are indeed up and running by exercising one of
+its endpoints using any HTTP client. On Windows systems for example, you might
+use Postman. On a Linux system, you might use curl:
 
-```console
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
 $ curl http://localhost:9000/api/hello/World
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-And you should get back the message `Hello, World!`.
+A successful invocation returns the message: `Hello, World!`.
 
-If you are wondering why we have created two services in the seed template, instead of having just one, the reason is simply that ([quoting](https://twitter.com/jboner/status/699536472442011648) Jonas Bonér):
+If you are wondering why we have created two services in the seed template,
+instead of having just one, the reason is simply that
+([quoting](https://twitter.com/jboner/status/699536472442011648) Jonas Bonér):
 
-> One microservice is no microservice - they come in systems.
+>   One microservice is no microservice - they come in systems.
 
-Said otherwise, we believe you will be creating several services, and we felt it was important to showcase intra-service communication.
+Said otherwise, we believe you will be creating several services, and we felt it
+was important to showcase intra-service communication.
 
-When developing in Lagom you will run several services in a single Java Virtual Machine. You may need to [[Increase Memory for Maven|JVMMemoryOnDev]].
+When developing in Lagom you will run several services in a single Java Virtual
+Machine. You may need to [[Increase Memory for Maven\|JVMMemoryOnDev]].

--- a/docs/manual/java/gettingstarted/GettingStartedMaven.md
+++ b/docs/manual/java/gettingstarted/GettingStartedMaven.md
@@ -11,10 +11,10 @@ providing multiple services. The easiest way to get started with a new Lagom
 system is to create a new project using the Maven archetype plugin, with the
 Lagom Maven archetype:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 $ mvn archetype:generate -DarchetypeGroupId=com.lightbend.lagom \
   -DarchetypeArtifactId=maven-archetype-lagom-java -DarchetypeVersion=1.1.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 >   **Note:** Ensure you replace the 1.1.0 archetype version with the latest
 >   version of Lagom.
@@ -29,7 +29,7 @@ Anatomy of a Lagom project
 
 The created project contains the following elements:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 my-first-system          → Project root
  └ hello-api             → hello world api project
  └ hello-impl            → hello world implementation project
@@ -37,7 +37,7 @@ my-first-system          → Project root
  └ stream-impl           → stream implementation project
  └ integration-tests     → Integration tests
  └ pom.xml               → Project root build file
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 Notice how each service is broken up into two projects: api and implementation.
 The api project contains a service interface through which consumers may
@@ -84,7 +84,7 @@ Lagom includes a development environment that let you start all your services by
 invoking the `runAll` task on the Lagom maven plugin. Open the terminal and `cd`
 to your Lagom project (some log output cut for brevity):
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
+```
 $ cd my-first-system
 $ mvn lagom:runAll
 ...
@@ -97,17 +97,17 @@ $ mvn lagom:runAll
 [info] Service hello-impl listening for HTTP on 0:0:0:0:0:0:0:0:24266
 [info] Service stream-impl listening for HTTP on 0:0:0:0:0:0:0:0:26230
 (Services started, press enter to stop and go back to the console...)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
 You can verify that the services are indeed up and running by exercising one of
 its endpoints using any HTTP client. On Windows systems for example, you might
 use Postman. On a Linux system, you might use curl:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
+```
 $ curl http://localhost:9000/api/hello/World
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
-A successful invocation returns the message: `Hello, World!`.
+A successful request returns the message: `Hello, World!`.
 
 If you are wondering why we have created two services in the seed template,
 instead of having just one, the reason is simply that

--- a/docs/manual/java/gettingstarted/GettingStartedSbt.md
+++ b/docs/manual/java/gettingstarted/GettingStartedSbt.md
@@ -1,22 +1,30 @@
-# Getting started with Lagom in sbt
+Getting started with Lagom in sbt
+=================================
 
 This page shows how to create and run your first Lagom project using sbt.
 
-## Creating a new Lagom project
+Creating a new Lagom project
+----------------------------
 
-A Lagom system is typically made up of a set of sbt builds, each build providing multiple services.  The easiest way to get started with a new Lagom system is to create a new project using the `lagom` sbt Giter8 template:
+A Lagom system is typically made up of a set of sbt builds, each build providing
+multiple services. The easiest way to get started with a new Lagom system is to
+create a new project using the `lagom` sbt Giter8 template:
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ sbt new lagom/lagom-java.g8
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After following the prompts, this will create a new system with two services, if you went with the default name of `Hello`, these services will be called `hello` and `hello-stream`. The documentation below assumes that you selected the default name of `Hello`.
+After following the prompts, this will create a new system with two services, if
+you went with the default name of `Hello`, these services will be called `hello`
+and `hello-stream`. The documentation below assumes that you selected the
+default name of `Hello`.
 
-## Anatomy of a Lagom project
+Anatomy of a Lagom project
+--------------------------
 
 The created project contains the following elements:
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 hello                   → Project root
  └ hello-api            → hello api project
  └ hello-impl           → hello implementation project
@@ -26,33 +34,59 @@ hello                   → Project root
    └ build.properties   → Marker for sbt project
    └ plugins.sbt        → sbt plugins including the declaration for Lagom itself
  └ build.sbt            → Your project build file
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Notice how each service is broken up into two projects: api and implementation. The api project contains a service interface through which consumers may interact with the service. While the implementation project contains the actual service implementation.
-* The `project` folder contains sbt specific files.
-* The `build.sbt` file, which contains all information necessary to build, run, and deploy your services.   
+-   Notice how each service is broken up into two projects: api and
+    implementation. The api project contains a service interface through which
+    consumers may interact with the service. While the implementation project
+    contains the actual service implementation.
 
-## Understanding services projects
+-   The `project` folder contains sbt specific files.
 
-* The service interface is always placed in the api project. For instance, the service interface for the `hello` service can be found in the `hello-api` project (look for the `HelloService.java` source file).
+-   The `build.sbt` file, which contains all information necessary to build,
+    run, and deploy your services.
 
-@[helloservice-interface](code/docs/javadsl/gettingstarted/helloservice/HelloService.java)
+Understanding services projects
+-------------------------------
 
-* The service interface needs to inherit from [`Service`](api/index.html?com/lightbend/lagom/javadsl/api/Service.html) and provide an implementation of [`Service.descriptor`](api/index.html?com/lightbend/lagom/javadsl/api/Service.html#descriptor--) method.
+-   The service interface is always placed in the api project. For instance, the
+    service interface for the `hello` service can be found in the `hello-api`
+    project (look for the `HelloService.java` source file).
 
-* The implementation of `Service.descriptor` returns a [`Descriptor`](api/index.html?com/lightbend/lagom/javadsl/api/Descriptor.html). A `Descriptor` defines the service name and the REST endpoints offered by a service. For each declared endpoint, an abstract method is declared in the service interface, e.g., see the `HelloService.hello` method.
+\@[helloservice-interface](code/docs/javadsl/gettingstarted/helloservice/HelloService.java)
 
-* The implementation of the service abstract methods is provided by the related implementation project. For instance, the service implementation of the `HelloService.hello` method, for the `hello` service, can be found in the `hello-impl` project (look for the `HelloServiceImpl.java` source file).
+-   The service interface needs to inherit from
+    [Service](api/index.html?com/lightbend/lagom/javadsl/api/Service.html) and
+    provide an implementation of
+    [Service.descriptor](api/index.html?com/lightbend/lagom/javadsl/api/Service.html#descriptor--)
+    method.
 
-@[helloservice-impl](code/docs/javadsl/gettingstarted/helloservice/HelloServiceImpl.java)
+-   The implementation of `Service.descriptor` returns a
+    [Descriptor](api/index.html?com/lightbend/lagom/javadsl/api/Descriptor.html).
+    A `Descriptor` defines the service name and the REST endpoints offered by a
+    service. For each declared endpoint, an abstract method is declared in the
+    service interface, e.g., see the `HelloService.hello` method.
 
-* The [`PersistentEntityRegistry`](api/index.html?com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.html) allows to persist data in the database using [[Event Sourcing and CQRS|ES_CQRS]].
+-   The implementation of the service abstract methods is provided by the
+    related implementation project. For instance, the service implementation of
+    the `HelloService.hello` method, for the `hello` service, can be found in
+    the `hello-impl` project (look for the `HelloServiceImpl.java` source file).
 
-## Running Lagom services
+\@[helloservice-impl](code/docs/javadsl/gettingstarted/helloservice/HelloServiceImpl.java)
 
-Lagom includes a development environment that let you start all your services by simply typing `runAll` in the sbt console. Open the terminal and `cd` to your Lagom project:
+-   The
+    [PersistentEntityRegistry](api/index.html?com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.html)
+    allows to persist data in the database using [[Event Sourcing and
+    CQRS\|ES_CQRS]].
 
-```console
+Running Lagom services
+----------------------
+
+Lagom includes a development environment that let you start all your services by
+simply typing `runAll` in the sbt console. Open the terminal and `cd` to your
+Lagom project:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
 $ cd my-first-system
 $ sbt
 ... (booting up)
@@ -64,21 +98,30 @@ $ sbt
 [info] Service gateway is running at http://localhost:9000
 [info] Service helloworld-impl listening for HTTP on 0:0:0:0:0:0:0:0:24266
 [info] Service hellostream-impl listening for HTTP on 0:0:0:0:0:0:0:0:26230
-(Services started, use Ctrl+D to stop and go back to the console...)
-```
+(Services started, press enter to stop and go back to the console...)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can verify that the services are indeed up and running by exercising one of its endpoints, e.g:
+You can verify that the services are indeed up and running by exercising one of
+its endpoints using any HTTP client. On Windows systems, you might use Postman.
+On a Linux system, you might use curl:
 
-```console
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
 $ curl http://localhost:9000/api/hello/World
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-And you should get back the message `Hello, World!`.
+ 
 
-If you are wondering why we have created two services in the seed template, instead of having just one, the reason is simply that ([quoting](https://twitter.com/jboner/status/699536472442011648) Jonas Bonér):
+A successful invocation returns the message: `Hello, World!`.
 
-> One microservice is no microservice - they come in systems.
+If you are wondering why we have created two services in the seed template,
+instead of having just one, the reason is simply that
+([quoting](https://twitter.com/jboner/status/699536472442011648) Jonas Bonér):
 
-Said otherwise, we believe you will be creating several services, and we felt it was important to showcase intra-service communication.
+>   One microservice is no microservice - they come in systems.
 
-The `lagom-java` template you used to build `my-first-system` uses the `.sbtopts` file to increase the memory used by the `JVM` when starting your project. There's a few more ways to [[Increase Memory in sbt|JVMMemoryOnDev]]
+Said otherwise, we believe you will be creating several services, and we felt it
+was important to showcase intra-service communication.
+
+The `lagom-java` template you used to build `my-first-system` uses the
+`.sbtopts` file to increase the memory used by the `JVM` when starting your
+project. There's a few more ways to [[Increase Memory in sbt\|JVMMemoryOnDev]]

--- a/docs/manual/scala/gettingstarted/GettingStarted.md
+++ b/docs/manual/scala/gettingstarted/GettingStarted.md
@@ -1,22 +1,30 @@
-# Getting started with Lagom
+Getting started with Lagom
+==========================
 
 This page shows how to create and run your first Lagom project using sbt.
 
-## Creating a new Lagom project
+Creating a new Lagom project
+----------------------------
 
-A Lagom system is typically made up of a set of sbt builds, each build providing multiple services.  The easiest way to get started with a new Lagom system is to create a new project using the `lagom` sbt Giter8 template:
+A Lagom system is typically made up of a set of sbt builds, each build providing
+multiple services. The easiest way to get started with a new Lagom system is to
+create a new project using the `lagom` sbt Giter8 template:
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 $ sbt new lagom/lagom-scala.g8
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After following the prompts, this will create a new system with two services, if you went with the default name of `Hello`, these services will be called `hello` and `hello-stream`. The documentation below assumes that you selected the default name of `Hello`.
+After following the prompts, this will create a new system with two services, if
+you went with the default name of `Hello`, these services will be called `hello`
+and `hello-stream`. The documentation below assumes that you selected the
+default name of `Hello`.
 
-## Anatomy of a Lagom project
+Anatomy of a Lagom project
+--------------------------
 
 The created project contains the following elements:
 
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 hello                   → Project root
  └ hello-api            → hello api project
  └ hello-impl           → hello implementation project
@@ -26,33 +34,60 @@ hello                   → Project root
    └ build.properties   → Marker for sbt project
    └ plugins.sbt        → sbt plugins including the declaration for Lagom itself
  └ build.sbt            → Your project build file
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Notice how each service is broken up into two projects: api and implementation. The api project contains a service interface through which consumers may interact with the service. While the implementation project contains the actual service implementation.
-* The `project` folder contains sbt specific files.
-* The `build.sbt` file, which contains all information necessary to build, run, and deploy your services.   
+-   Notice how each service is broken up into two projects: api and
+    implementation. The api project contains a service interface through which
+    consumers may interact with the service. While the implementation project
+    contains the actual service implementation.
 
-## Understanding services projects
+-   The `project` folder contains sbt specific files.
 
-* The service interface is always placed in the api project. For instance, the service interface for the `hello` service can be found in the `hello-api` project (look for the `HelloService.scala` source file).
+-   The `build.sbt` file, which contains all information necessary to build,
+    run, and deploy your services.
 
-@[helloservice](code/GettingStarted.scala)
+Understanding services projects
+-------------------------------
 
-* The service interface needs to inherit from [`Service`](api/com/lightbend/lagom/scaladsl/api/Service.html) and provide an implementation of [`Service.descriptor`](api/com/lightbend/lagom/scaladsl/api/Service.html#descriptor) method.
+-   The service interface is always placed in the api project. For instance, the
+    service interface for the `hello` service can be found in the `hello-api`
+    project (look for the `HelloService.scala` source file).
 
-* The implementation of `Service.descriptor` returns a [`Descriptor`](api/com/lightbend/lagom/scaladsl/api/Descriptor.html). A `Descriptor` defines the service name and the REST endpoints offered by a service. For each declared endpoint, an abstract method is declared in the service interface, e.g., see the `HelloService.hello` method.
+\@[helloservice](code/GettingStarted.scala)
 
-* The implementation of the service abstract methods is provided by the related implementation project. For instance, the service implementation of the `HelloService.hello` method, for the `hello` service, can be found in the `hello-impl` project (look for the `HelloServiceImpl.scala` source file).
+-   The service interface needs to inherit from
+    [Service](api/com/lightbend/lagom/scaladsl/api/Service.html) and provide an
+    implementation of
+    [Service.descriptor](api/com/lightbend/lagom/scaladsl/api/Service.html#descriptor)
+    method.
 
-@[helloserviceimpl](code/GettingStarted.scala)
+-   The implementation of `Service.descriptor` returns a
+    [Descriptor](api/com/lightbend/lagom/scaladsl/api/Descriptor.html). A
+    `Descriptor` defines the service name and the REST endpoints offered by a
+    service. For each declared endpoint, an abstract method is declared in the
+    service interface, e.g., see the `HelloService.hello` method.
 
-* The [`PersistentEntityRegistry`](api/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.html) allows to persist data in the database using [[Event Sourcing and CQRS|ES_CQRS]].
+-   The implementation of the service abstract methods is provided by the
+    related implementation project. For instance, the service implementation of
+    the `HelloService.hello` method, for the `hello` service, can be found in
+    the `hello-impl` project (look for the `HelloServiceImpl.scala` source
+    file).
 
-## Running Lagom services
+\@[helloserviceimpl](code/GettingStarted.scala)
 
-Lagom includes a development environment that let you start all your services by simply typing `runAll` in the sbt console. Open the terminal and `cd` to your Lagom project:
+-   The
+    [PersistentEntityRegistry](api/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.html)
+    allows to persist data in the database using [[Event Sourcing and
+    CQRS\|ES_CQRS]].
 
-```console
+Running Lagom services
+----------------------
+
+Lagom includes a development environment that let you start all your services by
+simply typing `runAll` in the sbt console. Open the terminal and `cd` to your
+Lagom project:
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
 $ cd hello
 $ sbt
 ... (booting up)
@@ -64,21 +99,28 @@ $ sbt
 [info] Service gateway is running at http://localhost:9000
 [info] Service hello-impl listening for HTTP on 0:0:0:0:0:0:0:0:24266
 [info] Service hello-stream-impl listening for HTTP on 0:0:0:0:0:0:0:0:26230
-(Services started, use Ctrl+D to stop and go back to the console...)
-```
+(Services started, press enter to stop and go back to the console...)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can verify that the services are indeed up and running by exercising one of its endpoints, e.g:
+You can verify that the services are indeed up and running by exercising one of
+its endpoints using any HTTP client. On Windows systems, you might use Postman.
+On a Linux system, you might use curl:
 
-```console
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ console
 $ curl http://localhost:9000/api/hello/World
-```
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-And you should get back the message `Hello, World!`.
+A successful request returns the message: `Hello, World!`.
 
-If you are wondering why we have created two services in the seed template, instead of having just one, the reason is simply that ([quoting](https://twitter.com/jboner/status/699536472442011648) Jonas Bonér):
+If you are wondering why we have created two services in the seed template,
+instead of having just one, the reason is simply that
+([quoting](https://twitter.com/jboner/status/699536472442011648) Jonas Bonér):
 
-> One microservice is no microservice - they come in systems.
+>   One microservice is no microservice - they come in systems.
 
-Said otherwise, we believe you will be creating several services, and we felt it was important to showcase intra-service communication.
+Said otherwise, we believe you will be creating several services, and we felt it
+was important to showcase intra-service communication.
 
-The `lagom-scala.g8` template you used to build `hello` uses the `.sbtopts` file to increase the memory used by the `JVM` when starting your project. There's a few more ways to [[Increase Memory in sbt|JVMMemoryOnDev]]
+The `lagom-scala.g8` template you used to build `hello` uses the `.sbtopts` file
+to increase the memory used by the `JVM` when starting your project. There's a
+few more ways to [[Increase Memory in sbt\|JVMMemoryOnDev]]

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -3,7 +3,7 @@ lazy val plugins = (project in file(".")).dependsOn(dev)
 lazy val dev = ProjectRef(Path.fileProperty("user.dir").getParentFile, "sbt-plugin")
 
 resolvers += Resolver.typesafeIvyRepo("releases")
-addSbtPlugin("com.lightbend.markdown" % "sbt-lightbend-markdown" % "1.4.1")
+addSbtPlugin("com.lightbend.markdown" % "sbt-lightbend-markdown" % "1.4.2")
 
 // Needed for bintray configuration code samples
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")


### PR DESCRIPTION
Changes include:
- updating the version of Markdown in the docs/project/plugins.sbt file 
- updating three getting started files with info about using an HTTP client on Windows and, in the sbt files also corrected example of the console output after running sbt runAll (which now shows "press enter" to stop the running services instead of "Control + D")

Discussed all of these previously with someone on the team.
