### PR TITLE
Set the context class loader for JPA transactions

### DIFF
--- a/persistence-jpa/javadsl/src/test/resources/META-INF/persistence.xml
+++ b/persistence-jpa/javadsl/src/test/resources/META-INF/persistence.xml
@@ -13,7 +13,6 @@
         <non-jta-data-source>DefaultDS</non-jta-data-source>
         <properties>
             <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.hbm2ddl.auto" value="update"/>
         </properties>
     </persistence-unit>
 

--- a/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaSessionImplSpec.scala
+++ b/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaSessionImplSpec.scala
@@ -3,8 +3,9 @@
  */
 package com.lightbend.lagom.internal.javadsl.persistence.jpa
 
-import javax.persistence.{ EntityManager, EntityTransaction }
+import javax.persistence.{ EntityManager, EntityTransaction, Persistence }
 
+import com.google.common.collect.ImmutableMap
 import com.lightbend.lagom.javadsl.persistence.jpa.TestJpaEntity
 import org.scalatest.matchers.{ BePropertyMatchResult, BePropertyMatcher }
 
@@ -47,6 +48,7 @@ class JpaSessionImplSpec extends JpaPersistenceSpec {
     }
 
     "support saving and reading entities" in {
+      Persistence.generateSchema("default", ImmutableMap.of("hibernate.hbm2ddl.auto", "update"))
       val entity = new TestJpaEntity("1", "test saving and reading entities")
       entity.getId shouldBe null
 


### PR DESCRIPTION
This solves a problem that I found on Thursday when creating the schema from a `globalPrepare` hook rather than configuring Hibernate/JPA to do it automatically (which is not multi-node friendly).

What I originally thought was a thread visibility bug in Hibernate's JPA implementation turned out to actually be caused by different context class loaders on different Slick DB I/O threads. I couldn't quite work out _why_ different Slick threads have different context class loaders, but I suspect that it has to do with when the threads are spawned. It doesn't look like Slick tries to manage the context class loader in any way.

This solves the problem by wrapping any block passed to `JpaSession.withTransaction` with logic to propagate the context class loader to the DB I/O thread for the duration of the call. It caches the context class loader when the session is constructed, mostly for simplicity's sake so that we know it will always use the same one (which I think is what we want here). In development mode, this will be the service's ["`ReloadableClassLoader`"](https://github.com/lagom/lagom/blob/23342691d9cf04e7cb9707848ce8cf5311dcd4df/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Reloader.scala#L299-L303)

Also reworks the JPA specs to use programmatic schema creation rather than automatic, which would have exposed this bug and better represents what we'll recommend people to do in practice.