### PR TITLE
Make PersistentEntity.Persist compile to valid Java code so it can be referenced in Eclipse

### DIFF
--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
@@ -387,7 +387,7 @@ abstract class PersistentEntity[Command, Event, State] {
    * if any, to persist. Use the `thenPersist`, `thenPersistAll` or `done` methods of the context
    * that is passed to the command handler function to create the `Persist` directive.
    */
-  trait Persist[B <: Event]
+  abstract class Persist[B <: Event]
 
   /**
    * INTERNAL API


### PR DESCRIPTION
Fixes https://github.com/lagom/lagom/issues/396

You can't have an inner interface referencing a type parameter of the enclosing class in Java. Since Persist is code that can't be written in Java, you can't load a project where it is reference in Eclipse without the Eclipse compiler throwing an error. I've verified that this fixes the issue by publishing the change to my local Maven repo and consuming the class in Eclipse.