### PR TITLE
Adds a debug trace on the Dev mode Service Registry regsitrations

### DIFF
--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceRegistryActor.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceRegistryActor.scala
@@ -47,6 +47,9 @@ class ServiceRegistryActor @Inject() (unmanagedServices: UnmanagedServices) exte
     case Register(name, service) =>
       registry.get(name) match {
         case None =>
+          if (logger.isDebugEnabled) {
+            logger.debug(s"Registering service [$name] with ACLs [${service.acls().asScala.map { acl => acl.toString }.mkString(", ")}] on ${service.uri()}).")
+          }
           registry += (name -> service)
           rebuildRouter()
           sender() ! Done


### PR DESCRIPTION
In Dev mode, every Service registration attempt will trace (on log level) name, acl's and URI.