### PR TITLE
Refactor the service locator holder to expose a future to avoid polling

### DIFF
--- a/persistence-cassandra/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProvider.scala
+++ b/persistence-cassandra/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProvider.scala
@@ -26,52 +26,21 @@ private[lagom] class ServiceLocatorSessionProvider(system: ActorSystem, config: 
   private val log = Logger(getClass)
 
   override def lookupContactPoints(clusterId: String)(implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] = {
-    val result = ServiceLocatorHolder(system).serviceLocator match {
-      case Some(serviceLocator) =>
-        serviceLocator.locate(clusterId).toScala.map { location =>
-          if (location.isPresent) {
-            val uri = location.get
-            log.debug(s"Found Cassandra contact points: $uri")
-            require(uri.getHost != null, s"missing host in $uri for Cassandra contact points $clusterId")
-            require(uri.getPort != -1, s"missing port in $uri for Cassandra contact points $clusterId")
-            List(new InetSocketAddress(uri.getHost, uri.getPort))
-          } else {
-            // fail the future
-            throw new NoContactPointsException(s"No contact points for [$clusterId]")
-          }
+    ServiceLocatorHolder(system).serviceLocatorEventually flatMap { serviceLocator =>
+      serviceLocator.locate(clusterId).toScala.map { location =>
+        if (location.isPresent) {
+          val uri = location.get
+          log.debug(s"Found Cassandra contact points: $uri")
+          require(uri.getHost != null, s"missing host in $uri for Cassandra contact points $clusterId")
+          require(uri.getPort != -1, s"missing port in $uri for Cassandra contact points $clusterId")
+          List(new InetSocketAddress(uri.getHost, uri.getPort))
+        } else {
+          // fail the future
+          throw new NoContactPointsException(s"No contact points for [$clusterId]")
         }
-
-      case None =>
-        val promise = Promise[immutable.Seq[InetSocketAddress]]()
-
-        // retry a few times to best effort to avoid failure due to startup race condition between Akka Persistence
-        // and the binding of the ServiceLocator in the  Guice module
-        def tryAgain(count: Int): Unit = {
-          if (count == 0)
-            promise.failure(new IllegalStateException("ServiceLocator is not bound"))
-          else {
-            system.scheduler.scheduleOnce(200.millis) {
-              if (ServiceLocatorHolder(system).serviceLocator.isDefined)
-                promise.completeWith(lookupContactPoints(clusterId))
-              else
-                tryAgain(count - 1)
-            }
-          }
-        }
-
-        tryAgain(10)
-
-        promise.future
+      }
     }
-
-    result.onFailure {
-      case e =>
-        log.warn(s"Could not find Cassandra contact points, due to: ${e.getMessage}")
-    }
-
-    result
   }
-
 }
 
 private[lagom] class NoContactPointsException(msg: String) extends RuntimeException(msg) with NoStackTrace

--- a/persistence-cassandra/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/ServiceLocatorSessionProviderSpec.scala
+++ b/persistence-cassandra/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/ServiceLocatorSessionProviderSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence.cassandra
+
+import java.net.{ InetSocketAddress, URI }
+import java.util.Optional
+import java.util.concurrent.{ CompletableFuture, CompletionStage }
+import java.util.function.Function
+
+import akka.actor.ActorSystem
+import com.lightbend.lagom.internal.persistence.ServiceLocatorHolder
+import com.lightbend.lagom.internal.persistence.cassandra.{ NoContactPointsException, ServiceLocatorSessionProvider }
+import com.lightbend.lagom.javadsl.api.Descriptor.Call
+import com.lightbend.lagom.javadsl.api.ServiceLocator
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ MustMatchers, WordSpec }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ServiceLocatorSessionProviderSpec extends WordSpec with MustMatchers {
+  val system = ActorSystem("test")
+  val config: Config = ConfigFactory.load()
+  val uri = new URI("http://localhost:8080")
+
+  val locator = new ServiceLocator {
+    override def locate(name: String, serviceCall: Call[_, _]): CompletionStage[Optional[URI]] = {
+      name match {
+        case "existing" => CompletableFuture.completedFuture(Optional.of(uri))
+        case "absent"   => CompletableFuture.completedFuture(Optional.empty())
+      }
+    }
+
+    override def doWithService[T](name: String, serviceCall: Call[_, _], block: Function[URI, CompletionStage[T]]): CompletionStage[Optional[T]] = ???
+  }
+
+  val providerConfig: Config = config.getConfig("lagom.persistence.read-side.cassandra")
+  val provider = new ServiceLocatorSessionProvider(system, providerConfig)
+  ServiceLocatorHolder(system).setServiceLocator(locator)
+
+  "ServiceLocatorSessionProvider" should {
+    "Get the address when the contact points exist" in {
+      val future = provider.lookupContactPoints("existing")
+
+      Await.result(future, 3 seconds) mustBe Seq(new InetSocketAddress(uri.getHost, uri.getPort))
+    }
+
+    "Fail the future when the contact points do not exist" in {
+      val future = provider.lookupContactPoints("absent")
+
+      intercept[NoContactPointsException] {
+        Await.result(future, 3 seconds)
+      }
+    }
+  }
+}

--- a/persistence/src/main/resources/reference.conf
+++ b/persistence/src/main/resources/reference.conf
@@ -79,6 +79,8 @@ lagom.persistence.cluster.distribution {
   ensure-active-interval = 30s
 }
 
+akka.logger-startup-timeout = 25s
+
 akka.actor {
   serializers {
     lagom-persistence = "com.lightbend.lagom.internal.persistence.protobuf.PersistenceMessageSerializer"

--- a/persistence/src/main/scala/com/lightbend/lagom/internal/persistence/ServiceLocatorHolder.scala
+++ b/persistence/src/main/scala/com/lightbend/lagom/internal/persistence/ServiceLocatorHolder.scala
@@ -6,6 +6,9 @@ package com.lightbend.lagom.internal.persistence
 import akka.actor.{ ActorSystem, ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
 import com.lightbend.lagom.javadsl.api.ServiceLocator
 
+import scala.concurrent.{ Future, Promise }
+import scala.util.Success
+
 private[lagom] object ServiceLocatorHolder extends ExtensionId[ServiceLocatorHolder] with ExtensionIdProvider {
   override def get(system: ActorSystem): ServiceLocatorHolder = super.get(system)
 
@@ -18,8 +21,15 @@ private[lagom] object ServiceLocatorHolder extends ExtensionId[ServiceLocatorHol
 private[lagom] class ServiceLocatorHolder extends Extension {
   @volatile private var _serviceLocator: Option[ServiceLocator] = None
 
+  private val promise = Promise[ServiceLocator]()
+  def serviceLocatorEventually: Future[ServiceLocator] = promise.future
+
   def serviceLocator: Option[ServiceLocator] = _serviceLocator
 
-  def setServiceLocator(locator: ServiceLocator): Unit =
+  def setServiceLocator(locator: ServiceLocator): Unit = {
+    require(_serviceLocator.isEmpty, "Service locator has already been defined")
+
     _serviceLocator = Some(locator)
+    promise.complete(Success(locator))
+  }
 }

--- a/persistence/src/test/scala/com/lightbend/lagom/internal/persistence/ServiceLocatorHolderSpec.scala
+++ b/persistence/src/test/scala/com/lightbend/lagom/internal/persistence/ServiceLocatorHolderSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence
+
+import java.net.URI
+import java.util.concurrent.CompletionStage
+import java.util.function.Function
+
+import com.lightbend.lagom.javadsl.api.Descriptor.Call
+import com.lightbend.lagom.javadsl.api.ServiceLocator
+import org.scalatest.{ MustMatchers, WordSpec }
+
+import scala.util.Success
+
+class ServiceLocatorHolderSpec extends WordSpec with MustMatchers {
+  private val locator = new ServiceLocator {
+    override def doWithService[T](name: String, serviceCall: Call[_, _], block: Function[URI, CompletionStage[T]]) = ???
+    override def locate(name: String, serviceCall: Call[_, _]) = ???
+  }
+
+  "ServiceLocatorHolder" should {
+    "supply the locator when the consumer asks for it before it's ready" in {
+      val holder = new ServiceLocatorHolder()
+      val future = holder.serviceLocatorEventually
+      holder.serviceLocator mustBe None
+
+      holder.setServiceLocator(locator)
+
+      future.isCompleted mustBe true
+      future.value mustBe Some(Success(locator))
+      holder.serviceLocator mustBe Some(locator)
+    }
+
+    "supply the locator when the consumer asks for it after it's been set" in {
+      val holder = new ServiceLocatorHolder()
+      holder.setServiceLocator(locator)
+
+      val future = holder.serviceLocatorEventually
+      future.isCompleted mustBe true
+      future.value mustBe Some(Success(locator))
+      holder.serviceLocator mustBe Some(locator)
+    }
+
+    "throw an exception if the holder is set twice" in {
+      val holder = new ServiceLocatorHolder()
+      holder.setServiceLocator(locator)
+
+      intercept[IllegalArgumentException] {
+        holder.setServiceLocator(locator)
+      }
+    }
+  }
+}


### PR DESCRIPTION
I ran in to some issues running the samples because of various timeout.  I was about to increase the number of polls, but I thought it would be better to refactor to use a future instead.

Also, I had a few issues running the tests with timeouts initialising SLF4J, so I upped the timeout there too.