### PR TITLE
Move JpaPersistenceModule to the public package

### DIFF
--- a/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImpl.java
+++ b/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImpl.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
 import static scala.collection.JavaConversions.asJavaIterable;
 
 @Singleton
-class JpaReadSideImpl implements JpaReadSide {
+public class JpaReadSideImpl implements JpaReadSide {
     private final Logger log = LoggerFactory.getLogger(this.getClass());
 
     private final JpaSession jpa;

--- a/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaSessionImpl.java
+++ b/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaSessionImpl.java
@@ -30,7 +30,7 @@ import java.util.function.Function;
 import static play.utils.Threads.withContextClassLoader;
 
 @Singleton
-class JpaSessionImpl implements JpaSession {
+public class JpaSessionImpl implements JpaSession {
     private final Logger log = LoggerFactory.getLogger(this.getClass());
     private final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 

--- a/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaPersistenceModule.java
+++ b/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaPersistenceModule.java
@@ -1,10 +1,10 @@
 /*
  * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-package com.lightbend.lagom.internal.javadsl.persistence.jpa;
+package com.lightbend.lagom.javadsl.persistence.jpa;
 
-import com.lightbend.lagom.javadsl.persistence.jpa.JpaReadSide;
-import com.lightbend.lagom.javadsl.persistence.jpa.JpaSession;
+import com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaReadSideImpl;
+import com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaSessionImpl;
 import play.api.Configuration;
 import play.api.Environment;
 import play.api.inject.Binding;

--- a/persistence-jpa/javadsl/src/main/resources/reference.conf
+++ b/persistence-jpa/javadsl/src/main/resources/reference.conf
@@ -16,4 +16,4 @@ lagom.persistence.jpa {
   }
 }
 
-play.modules.enabled += com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaPersistenceModule
+play.modules.enabled += com.lightbend.lagom.javadsl.persistence.jpa.JpaPersistenceModule


### PR DESCRIPTION
This publishes it in the API documentation so people know that it can be disabled.