### PR TITLE
Added check that a topic publisher is present

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -491,7 +491,8 @@ lazy val `server-scaladsl` = (project in file("service/scaladsl/server"))
   .settings(
     name := "lagom-scaladsl-server",
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor" % AkkaVersion
+      "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+      scalaTest % Test
     )
   )
   .enablePlugins(RuntimeLibPlugins)

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/internal/scaladsl/api/broker/TopicFactory.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/internal/scaladsl/api/broker/TopicFactory.scala
@@ -26,4 +26,15 @@ trait TopicFactory {
  */
 trait TopicFactoryProvider {
   def optionalTopicFactory: Option[TopicFactory] = None
+
+  /**
+   * The name of the topic publisher.
+   *
+   * Since topic publishers don't actually provide any components, they just consume a LagomServer and publish the
+   * topics they find there, this can be used to signal that a topic publisher has been provided to publish
+   * topics, so that the LagomServerComponents can detect a misconfiguration where one hasn't been provided.
+   *
+   * @return The name of the topic publisher that has published topics, if one has been provided.
+   */
+  def topicPublisherName: Option[String] = None
 }

--- a/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/LagomKafkaComponents.scala
+++ b/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/LagomKafkaComponents.scala
@@ -16,6 +16,12 @@ trait LagomKafkaComponents extends LagomKafkaClientComponents {
   def lagomServer: LagomServer
   def offsetStore: OffsetStore
 
+  override def topicPublisherName: Option[String] = super.topicPublisherName match {
+    case Some(other) =>
+      sys.error(s"Cannot provide the kafka topic factory as the default topic publisher since a default topic publisher has already been mixed into this cake: $other")
+    case None => Some("kafka")
+  }
+
   // Eagerly start topic producers
   new ScaladslRegisterTopicProducers(lagomServer, topicFactory, serviceInfo, actorSystem,
     offsetStore)(executionContext, materializer)

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationSpec.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2009-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.server
+
+import akka.NotUsed
+import com.lightbend.lagom.internal.scaladsl.api.broker.TopicFactoryProvider
+import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.api.{ Service, ServiceCall }
+import com.lightbend.lagom.scaladsl.api.broker.Topic.TopicId
+import com.lightbend.lagom.scaladsl.api.broker.Topic
+import org.scalatest.{ Matchers, WordSpec }
+import play.api.inject.DefaultApplicationLifecycle
+import play.api.libs.ws.ahc.AhcWSComponents
+
+import scala.concurrent.Future
+
+class LagomApplicationSpec extends WordSpec with Matchers {
+
+  "The Lagom Application" should {
+    "fail to start if there are topics to publish but no topic publisher is provided" in {
+      // Need to provide our own lifecycle so we can shutdown any components that started
+      val lifecycle = new DefaultApplicationLifecycle
+      a[LagomServerTopicFactoryVerifier.NoTopicPublisherException] should be thrownBy {
+        new LagomApplication(LagomApplicationContext.Test) with AhcWSComponents {
+          override lazy val applicationLifecycle = lifecycle
+          override def lagomServer = LagomServer.forServices(bindService[AppWithTopics].to(AppWithTopics))
+          override def serviceLocator = NoServiceLocator
+        }
+      }
+      lifecycle.stop()
+    }
+
+    "start if there are topics to publish but and no topic publisher is provided" in {
+      new LagomApplication(LagomApplicationContext.Test) with AhcWSComponents {
+        override def lagomServer = LagomServer.forServices(bindService[AppWithNoTopics].to(AppWithNoTopics))
+        override def serviceLocator = NoServiceLocator
+      }.applicationLifecycle.stop()
+    }
+
+    "start if there are topics to publish and a topic publisher is provided" in {
+      new LagomApplication(LagomApplicationContext.Test) with AhcWSComponents with MockTopicComponents {
+        override def lagomServer = LagomServer.forServices(bindService[AppWithTopics].to(AppWithTopics))
+        override def serviceLocator = NoServiceLocator
+      }.applicationLifecycle.stop()
+    }
+  }
+
+  trait MockTopicComponents extends TopicFactoryProvider {
+    override def topicPublisherName: Option[String] = Some("mock")
+  }
+
+  trait AppWithTopics extends Service {
+    def someTopic: Topic[String]
+
+    override def descriptor = {
+      import Service._
+      named("app-with-topics").withTopics(
+        topic("some-topic", someTopic)
+      )
+    }
+  }
+
+  object AppWithTopics extends AppWithTopics {
+    override def someTopic: Topic[String] = MockTopic
+  }
+
+  object MockTopic extends Topic[String] {
+    override def topicId = TopicId("foo")
+    override def subscribe = ???
+  }
+
+  trait AppWithNoTopics extends Service {
+    def foo: ServiceCall[NotUsed, NotUsed]
+    override def descriptor = Service.named("app-with-no-topics")
+  }
+
+  object AppWithNoTopics extends AppWithNoTopics {
+    override def foo = ServiceCall { _ =>
+      Future.successful(NotUsed)
+    }
+  }
+
+}

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/TestTopicComponents.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/TestTopicComponents.scala
@@ -26,6 +26,12 @@ trait TestTopicComponents extends TopicFactoryProvider {
 
   override def optionalTopicFactory: Option[TopicFactory] = Some(topicFactory)
 
+  override def topicPublisherName: Option[String] = super.topicPublisherName match {
+    case Some(other) =>
+      sys.error(s"Cannot provide the test topic factory as the default topic publisher since a default topic publisher has already been mixed into this cake: $other")
+    case None => Some("test")
+  }
+
   lazy val topicFactory: TopicFactory = new TestTopicFactory(lagomServer)(materializer)
 
 }


### PR DESCRIPTION
Fixes #414.

When no topic publisher is mixed into an application cake, this ensures that the application won't start.