### PR TITLE
slight expansion of docs on read-only command

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntity.md
+++ b/docs/manual/java/guide/cluster/PersistentEntity.md
@@ -69,7 +69,7 @@ The command can be validated before persisting state changes. Use `ctx.invalidCo
 
 @[validate-command](code/docs/home/persistence/Post2.java)
 
-A `PersistentEntity` may also process commands that do not change application state, such as query commands  or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). Such command handlers are registered using `setReadOnlyCommandHandler` of the `BehaviorBuilder`. Replies are sent with the `reply` method of the context that is passed to the command handler function.
+A `PersistentEntity` may also process commands that do not change application state, such as query commands  or commands that are not valid in the entity's current state (such as a bid placed after the auction closed). Such command handlers are registered using `setReadOnlyCommandHandler` of the `BehaviorBuilder`. Replies are sent with the `reply` method of the context that is passed to the command handler function.
 
 The `setReadOnlyCommandHandler` is simply a convenience function that avoids you having to return no events followed by a side effect.
 

--- a/docs/manual/java/guide/cluster/PersistentEntity.md
+++ b/docs/manual/java/guide/cluster/PersistentEntity.md
@@ -69,9 +69,7 @@ The command can be validated before persisting state changes. Use `ctx.invalidCo
 
 @[validate-command](code/docs/home/persistence/Post2.java)
 
-A `PersistentEntity` may also process commands that do not change application state, such as query commands  or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). 
-Such command handlers are registered using `setReadOnlyCommandHandler` of the `BehaviorBuilder`. 
-Replies are sent with the `reply` method of the context that is passed to the command handler function.
+A `PersistentEntity` may also process commands that do not change application state, such as query commands  or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). Such command handlers are registered using `setReadOnlyCommandHandler` of the `BehaviorBuilder`. Replies are sent with the `reply` method of the context that is passed to the command handler function.
 
 The `setReadOnlyCommandHandler` is simply a convenience function that avoids you having to return no events followed by a side effect.
 

--- a/docs/manual/java/guide/cluster/PersistentEntity.md
+++ b/docs/manual/java/guide/cluster/PersistentEntity.md
@@ -69,7 +69,12 @@ The command can be validated before persisting state changes. Use `ctx.invalidCo
 
 @[validate-command](code/docs/home/persistence/Post2.java)
 
-A `PersistentEntity` may also process commands that do not change application state, such as query commands. Such command handlers are registered using `setReadOnlyCommandHandler` of the `BehaviorBuilder`. Replies are sent with the `reply` method of the context that is passed to the command handler function.
+A `PersistentEntity` may also process commands that do not change application state, such as query commands  or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). 
+Such command handlers are registered using `setReadOnlyCommandHandler` of the `BehaviorBuilder`. 
+Replies are sent with the `reply` method of the context that is passed to the command handler function.
+
+The `setReadOnlyCommandHandler` is simply a convenience function that avoids you having to return no events followed by a side effect.
+
 
 @[read-only-command-handler](code/docs/home/persistence/Post3.java)
 

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -75,7 +75,7 @@ The command can be validated before persisting state changes. Note that current 
 
 @[validate-command](code/docs/home/scaladsl/persistence/Post2.scala)
 
-A `PersistentEntity` may also process commands that do not change application state, such as query commands or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. Replies are sent with the `reply` method of the context that is passed to the command handler function. 
+A `PersistentEntity` may also process commands that do not change application state, such as query commands or commands that are not valid in the entity's current state (such as a bid placed after the auction closed). Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. Replies are sent with the `reply` method of the context that is passed to the command handler function. 
 
 The `onReadOnlyCommand` is simply a convenience function that avoids you having to return no events followed by a side effect.
 

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -75,7 +75,7 @@ The command can be validated before persisting state changes. Note that current 
 
 @[validate-command](code/docs/home/scaladsl/persistence/Post2.scala)
 
-A `PersistentEntity` may also process commands that do not change application state, such as query commands. Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. Replies are sent with the `reply` method of the context that is passed to the command handler function.
+A `PersistentEntity` may also process commands that do not change application state, such as query commands or commands that are no longer relevant (such as a bid placed after the auction closed). Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. Replies are sent with the `reply` method of the context that is passed to the command handler function.
 
 @[read-only-command-handler](code/docs/home/scaladsl/persistence/Post2.scala)
 

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -75,7 +75,11 @@ The command can be validated before persisting state changes. Note that current 
 
 @[validate-command](code/docs/home/scaladsl/persistence/Post2.scala)
 
-A `PersistentEntity` may also process commands that do not change application state, such as query commands or commands that are no longer relevant (such as a bid placed after the auction closed). Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. Replies are sent with the `reply` method of the context that is passed to the command handler function.
+A `PersistentEntity` may also process commands that do not change application state, such as query commands or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). 
+Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. 
+Replies are sent with the `reply` method of the context that is passed to the command handler function. 
+
+The `onReadOnlyCommand` is simply a convenience function that avoids you having to return no events followed by a side effect.
 
 @[read-only-command-handler](code/docs/home/scaladsl/persistence/Post2.scala)
 

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -75,9 +75,7 @@ The command can be validated before persisting state changes. Note that current 
 
 @[validate-command](code/docs/home/scaladsl/persistence/Post2.scala)
 
-A `PersistentEntity` may also process commands that do not change application state, such as query commands or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). 
-Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. 
-Replies are sent with the `reply` method of the context that is passed to the command handler function. 
+A `PersistentEntity` may also process commands that do not change application state, such as query commands or commands that are not valid in the entity's currernt state (such as a bid placed after the auction closed). Such command handlers are registered using `onReadOnlyCommand` of the `Actions`. Replies are sent with the `reply` method of the context that is passed to the command handler function. 
 
 The `onReadOnlyCommand` is simply a convenience function that avoids you having to return no events followed by a side effect.
 


### PR DESCRIPTION
online auction uses the read-only command for precisely the example I gave - bid arriving after auction closed. Until I saw that I had fixed read-only in my mind as being just for queries.
