### PR TITLE
Remove server-javadsl dependency from api-tools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -414,13 +414,13 @@ lazy val `api-tools` = (project in file("api-tools"))
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-json" % PlayVersion,
+      "com.typesafe.play" %% "play" % PlayVersion,
       scalaTest % Test
     )
   )
   .dependsOn(
     spi,
-    `server-javadsl` % "compile->test"
+    `server-javadsl` % Test
   )
 
 lazy val client = (project in file("service/core/client"))


### PR DESCRIPTION
The api-tools project was bringing in a dependency on server-javadsl,
which prevented it from working with Scala projects. This fixes the
scope so that it's only depending on it in Test.