### PR TITLE
[MINOR] Update CassandraServer.md

### DIFF
--- a/docs/manual/guide/devmode/detailedTopics/CassandraServer.md
+++ b/docs/manual/guide/devmode/detailedTopics/CassandraServer.md
@@ -171,7 +171,7 @@ One good reason to disable the embedded Cassandra server is if you need your ser
 
 ## Connecting to a locally running Cassandra instance
 
-It's possible to connect to an [[externally run|ServiceLocator#communicating-with-external-services]] Cassandra instance in place of the embedded one. All you need to do is adding the following in your build.
+It's possible to connect to an [[externally run|ServiceLocator#communicating-with-external-services]] Cassandra instance in place of the embedded one. All you need to do is adding the following in your build and you should use lagom version 1.2.2 or above.
 
 In the Maven root project pom:
 


### PR DESCRIPTION
While creating lagom maven project you should use lagom version 1.2.2 or above if you want to connect to an externally running Cassandra instance.