### PR TITLE
Allow disabling JDBC offset table auto-creation

### DIFF
--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStore.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStore.scala
@@ -79,21 +79,23 @@ private[lagom] class SlickOffsetStore(system: ActorSystem, val slick: SlickProvi
 
   private val offsets = TableQuery[OffsetStore]
 
-  val startupTask = ClusterStartupTask(
-    system,
-    "cassandraOffsetStorePrepare",
-    createTables,
-    config.globalPrepareTimeout,
-    config.role,
-    config.minBackoff,
-    config.maxBackoff,
-    config.randomBackoffFactor
-  )
+  private val startupTask = if (slick.autoCreateTables) {
+    implicit val timeout = Timeout(config.globalPrepareTimeout)
+    ClusterStartupTask(
+      system,
+      "cassandraOffsetStorePrepare",
+      createTables,
+      config.globalPrepareTimeout,
+      config.role,
+      config.minBackoff,
+      config.maxBackoff,
+      config.randomBackoffFactor
+    ).askExecute()
+  } else Future.successful(Done)
 
   def runPreparations(eventProcessorId: String, tag: String): Future[Offset] = {
-    implicit val timeout = Timeout(config.globalPrepareTimeout)
     for {
-      _ <- startupTask.askExecute()
+      _ <- startupTask
       offset <- slick.db.run(getOffsetQuery(eventProcessorId, tag))
     } yield offset
   }

--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStore.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStore.scala
@@ -83,7 +83,7 @@ private[lagom] class SlickOffsetStore(system: ActorSystem, val slick: SlickProvi
     implicit val timeout = Timeout(config.globalPrepareTimeout)
     ClusterStartupTask(
       system,
-      "cassandraOffsetStorePrepare",
+      "slickOffsetStorePrepare",
       createTables,
       config.globalPrepareTimeout,
       config.role,

--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickProvider.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickProvider.scala
@@ -23,7 +23,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 
-class SlickProvider(
+private[lagom] class SlickProvider(
   system: ActorSystem,
   dbApi:  DBApi /* Ensures database is initialised before we start anything that needs it */ )(implicit ec: ExecutionContext) {
 
@@ -34,7 +34,8 @@ class SlickProvider(
   private val createTables = jdbcConfig.getConfig("create-tables")
 
   private val slickConfig = new SlickConfiguration(readSideConfig)
-  private val autoCreateTables = createTables.getBoolean("auto")
+
+  val autoCreateTables: Boolean = createTables.getBoolean("auto")
 
   val db = SlickDatabase.forConfig(readSideConfig, slickConfig)
   val profile = SlickDriver.forDriverName(readSideConfig)


### PR DESCRIPTION
Fixes #449

Should also be back ported to 1.2.x.