### PR TITLE
Fixed mentioning Java source i.s.o Scala sources and missing reference to code sample

### DIFF
--- a/docs/manual/scala/guide/build/LagomBuild.md
+++ b/docs/manual/scala/guide/build/LagomBuild.md
@@ -54,7 +54,7 @@ A Lagom API project is an ordinary sbt project. Our first project looks like thi
 
 The first line defines the project itself, by declaring a `lazy val` of type `Project`. (sbt tip: declaring projects using `lazy val` instead of just `val` can prevent some issues with initialization order.)
 
-The project is defined to be the `hello-api` directory, as indicated by `project in file("hello-api")`.  This means all the source code for this project will be under that directory, laid out according to the usual Maven structure (which sbt adopts as well).  So our main Java sources go in `hello-api/src/main/scala`.
+The project is defined to be the `hello-api` directory, as indicated by `project in file("hello-api")`.  This means all the source code for this project will be under that directory, laid out according to the usual Maven structure (which sbt adopts as well).  So our main Scala sources go in `hello-api/src/main/scala`.
 
 More settings follow, in which we set the project version and add a library dependency.  The Lagom plugin provides some predefined values to make the Lagom libraries easy to add. In this case, we're using `lagomScaladslApi`. (You can add other dependencies using the usual sbt shorthand for specifying the library's `groupId`, `artifactId` and `version`; see [Library dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html) in the sbt documentation.)
 

--- a/docs/manual/scala/guide/services/code/ServiceClients.scala
+++ b/docs/manual/scala/guide/services/code/ServiceClients.scala
@@ -62,7 +62,7 @@ package circuitbreakers {
     def hiAgain: ServiceCall[String, String]
 
     // @formatter:off
-    //#circuit-breakers
+    //#circuit-breaker
     import com.lightbend.lagom.scaladsl.api.CircuitBreaker
 
     def descriptor: Descriptor = {
@@ -74,7 +74,7 @@ package circuitbreakers {
           .withCircuitBreaker(CircuitBreaker.identifiedBy("hello2"))
       )
     }
-    //#circuit-breakers
+    //#circuit-breaker
     // @formatter:on
   }
 


### PR DESCRIPTION
I signed the Lightbend CLA online

## Fixes
Fixed mentioning Java source when it should be Scala sources
Fixes error message on 1.3.x/scala/ServiceClients.html "Unable to find label circuit-breaker in source file code/ServiceClients.scala"

## Purpose

Fixes Documentation issues