### PR TITLE
Fixed lagomExternalProject

### DIFF
--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -310,10 +310,7 @@ object LagomPlugin extends AutoPlugin {
     val lagomKafkaAddress = settingKey[String]("Address of the kafka brokers (comma-separated list)")
 
     @deprecated("Use lagomExternalJavadslProject or lagomExternalScaladslProject instead", "1.3.0")
-    def lagomExternalProject(name: String, module: ModuleID): Project =
-      Project(name, file("target") / "lagom-external-projects" / name).
-        enablePlugins(LagomExternalProject).
-        settings(Seq(libraryDependencies += module))
+    def lagomExternalProject(name: String, module: ModuleID): Project = lagomExternalJavadslProject(name, module)
 
     /** Allows to integrate an external Lagom scaladsl project in the current build, so that when runAll is run, this service is also started.*/
     def lagomExternalScaladslProject(name: String, module: ModuleID): Project =

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -55,7 +55,7 @@ object LagomJava extends AutoPlugin {
   )
 
   // service locator dependencies are injected into services only iff dev service locator is enabled
-  private lazy val devServiceLocatorDependencies = Def.setting {
+  private[sbt] lazy val devServiceLocatorDependencies = Def.setting {
     if (LagomPlugin.autoImport.lagomServiceLocatorEnabled.value)
       Seq(
         LagomImport.component("lagom-service-registry-client"),
@@ -309,11 +309,25 @@ object LagomPlugin extends AutoPlugin {
     val lagomKafkaPort = settingKey[Int]("Port used by the local kafka broker")
     val lagomKafkaAddress = settingKey[String]("Address of the kafka brokers (comma-separated list)")
 
-    /** Allows to integrate an external Lagom project in the current build, so that when runAll is run, this service is also started.*/
+    @deprecated("Use lagomExternalJavadslProject or lagomExternalScaladslProject instead", "1.3.0")
     def lagomExternalProject(name: String, module: ModuleID): Project =
       Project(name, file("target") / "lagom-external-projects" / name).
         enablePlugins(LagomExternalProject).
         settings(Seq(libraryDependencies += module))
+
+    /** Allows to integrate an external Lagom scaladsl project in the current build, so that when runAll is run, this service is also started.*/
+    def lagomExternalScaladslProject(name: String, module: ModuleID): Project =
+      Project(name, file("target") / "lagom-external-projects" / name).
+        enablePlugins(LagomExternalProject).
+        settings(Seq(libraryDependencies += module))
+
+    /** Allows to integrate an external Lagom javadsl project in the current build, so that when runAll is run, this service is also started.*/
+    def lagomExternalJavadslProject(name: String, module: ModuleID): Project = {
+      // Same as scaladsl, but Java projects need to have the dev mode service registration explicitly added.
+      lagomExternalScaladslProject(name, module).settings(
+        libraryDependencies ++= LagomJava.devServiceLocatorDependencies.value
+      )
+    }
   }
 
   import autoImport._

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/java/com/example/A.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/java/com/example/A.java
@@ -1,0 +1,16 @@
+package com.example;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.*;
+import static com.lightbend.lagom.javadsl.api.Service.*;
+
+public interface A extends Service {
+    ServiceCall<NotUsed, String> hello(String name);
+
+    @Override
+    default Descriptor descriptor() {
+        return named("a").withCalls(
+                pathCall("/hello/:name", this::hello)
+        ).withAutoAcl(true);
+    }
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/java/com/example/AImpl.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/java/com/example/AImpl.java
@@ -1,0 +1,12 @@
+package com.example;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.*;
+import java.util.concurrent.CompletableFuture;
+
+public class AImpl implements A {
+    @Override
+    public ServiceCall<NotUsed, String> hello(String name) {
+        return req -> CompletableFuture.completedFuture("Hello " + name);
+    }
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/java/com/example/AModule.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/java/com/example/AModule.java
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.google.inject.AbstractModule;
+import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+
+public class AModule extends AbstractModule implements ServiceGuiceSupport {
+    @Override
+    public void configure() {
+        bindServices(serviceBinding(A.class, AImpl.class));
+    }
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/resources/application.conf
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/a/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.modules.enabled += com.example.AModule

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
@@ -1,0 +1,22 @@
+import play.sbt.PlayImport
+
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
+// This is the build for the external project that we will publishLocal so that it can then be imported,
+// it doesn't use the Lagom plugin that way it won't be run when we run runAll
+lazy val a = (project in file("a"))
+  .settings(
+    organization := "com.example",
+    name := "a-java",
+    version := "1.0-SNAPSHOT",
+    libraryDependencies ++= Seq(
+      lagomJavadslServer,
+      PlayImport.component("play-netty-server")
+    )
+  )
+
+// And here's where we import the above project as an external project.
+lazy val `external-a` = lagomExternalJavadslProject("a-external", "com.example" %% "a-java" % "1.0-SNAPSHOT")

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/project/build.properties
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+#
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/project/plugins.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-scripted-tools" % sys.props("project.version"))

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/test
@@ -1,0 +1,13 @@
+# First, publish the a project, so that it can be depended on as an external project
+> a/publishLocal
+
+# Now run all
+> runAll
+
+# Check that external service a is registered with the service locator
+> validateRequest retry-until-success http://localhost:8000/services/a status 200
+
+# Check that external service a is accessible through the gateway
+> validateRequest retry-until-success http://localhost:9000/hello/World status 200 body-contains Hello body-contains World
+
+> stop

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/a/src/main/resources/application.conf
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/a/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.application.loader = com.example.ALoader

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/a/src/main/scala/com/example/A.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/a/src/main/scala/com/example/A.scala
@@ -1,0 +1,42 @@
+package com.example
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api._
+import com.lightbend.lagom.scaladsl.server._
+import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import play.api.libs.ws.ahc.AhcWSComponents
+import scala.concurrent.Future
+
+trait A extends Service {
+  def hello(name: String): ServiceCall[NotUsed, String]
+
+  override def descriptor = {
+    import Service._
+    named("a").withCalls(
+      pathCall("/hello/:name", hello _)
+    ).withAutoAcl(true)
+  }
+}
+
+class AImpl extends A {
+  override def hello(name: String) = ServiceCall { _ =>
+    Future.successful(s"Hello $name")
+  }
+}
+
+abstract class AApplication(context: LagomApplicationContext)
+  extends LagomApplication(context) with AhcWSComponents {
+
+  override def lagomServer = LagomServer.forServices(bindService[A].to(new AImpl))
+}
+
+class ALoader extends LagomApplicationLoader {
+  override def load(context: LagomApplicationContext): LagomApplication =
+    new AApplication(context) {
+      override def serviceLocator = NoServiceLocator
+    }
+
+  override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+    new AApplication(context) with LagomDevModeComponents
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
@@ -1,0 +1,23 @@
+import play.sbt.PlayImport
+
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
+// This is the build for the external project that we will publishLocal so that it can then be imported,
+// it doesn't use the Lagom plugin that way it won't be run when we run runAll
+lazy val a = (project in file("a"))
+  .settings(
+    organization := "com.example",
+    name := "a-scala",
+    version := "1.0-SNAPSHOT",
+    libraryDependencies ++= Seq(
+      lagomScaladslServer,
+      lagomScaladslDevMode,
+      PlayImport.component("play-netty-server")
+    )
+  )
+
+// And here's where we import the above project as an external project.
+lazy val `external-a` = lagomExternalScaladslProject("a-external", "com.example" %% "a-scala" % "1.0-SNAPSHOT")

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/project/build.properties
@@ -1,0 +1,4 @@
+#
+# Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+#
+sbt.version=0.13.13

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/project/plugins.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-scripted-tools" % sys.props("project.version"))

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/test
@@ -1,0 +1,13 @@
+# First, publish the a project, so that it can be depended on as an external project
+> a/publishLocal
+
+# Now run all
+> runAll
+
+# Check that external service a is registered with the service locator
+> validateRequest retry-until-success http://localhost:8000/services/a status 200
+
+# Check that external service a is accessible through the gateway
+> validateRequest retry-until-success http://localhost:9000/hello/World status 200 body-contains Hello body-contains World
+
+> stop

--- a/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
+++ b/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
@@ -69,6 +69,7 @@ object ScriptedTools extends AutoPlugin {
         attempt()
       }
     },
+    aggregate in validateRequest := false,
     validateFile := {
       val validateFile = validateFileParser.parsed
       val file = baseDirectory.value / validateFile.file.get
@@ -87,6 +88,7 @@ object ScriptedTools extends AutoPlugin {
       }
       file
     },
+    aggregate in validateFile := false,
     Internal.Keys.interactionMode := NonBlockingInteractionMode
   )
 

--- a/docs/manual/java/guide/build/MultipleBuilds.md
+++ b/docs/manual/java/guide/build/MultipleBuilds.md
@@ -75,7 +75,7 @@ The `hellowold` Lagom service can be imported by adding the following declaratio
 
 @[hello-external](code/multiple-builds.sbt)
 
-The first argument passed to `lagomExternalProject` is the name that will be used in your build to refer to this externally defined project. While, the second argument provides the dependency to the `hello-impl` JAR, using the conventional sbt syntax for declaring dependencies. Note in fact that the `lagomExternalProject` method returns a sbt `Project`, which you can further customize if needed.
+The first argument passed to `lagomExternalJavadslProject` is the name that will be used in your build to refer to this externally defined project. While, the second argument provides the dependency to the `hello-impl` JAR, using the conventional sbt syntax for declaring dependencies. Note in fact that the `lagomExternalJavadslProject` method returns a sbt `Project`, which you can further customize if needed.
 
 After having added the external Lagom project to your build, just type `reload` in the sbt console. Then, when executing `runAll`, you should see that the `hello` service is started, together with all other services defined in the build:
 

--- a/docs/manual/java/guide/build/code/multiple-builds.sbt
+++ b/docs/manual/java/guide/build/code/multiple-builds.sbt
@@ -28,7 +28,7 @@ lazy val `hello-impl` = (project in file("hello-impl"))
 //#hello-build
 
 //#hello-external
-lazy val hello = lagomExternalProject("hello", "com.example" %% "hello-impl" % "1.0")
+lazy val hello = lagomExternalJavadslProject("hello", "com.example" %% "hello-impl" % "1.0")
 //#hello-external
 
 //#hello-communication

--- a/docs/manual/scala/guide/build/MultipleBuilds.md
+++ b/docs/manual/scala/guide/build/MultipleBuilds.md
@@ -38,7 +38,7 @@ The `hello` Lagom service can be imported by adding the following declaration to
 
 @[hello-external](code/multiple-builds.sbt)
 
-The first argument passed to `lagomExternalProject` is the name that will be used in your build to refer to this externally defined project. While, the second argument provides the dependency to the `hello-impl` JAR, using the conventional sbt syntax for declaring dependencies. Note in fact that the `lagomExternalProject` method returns a sbt `Project`, which you can further customize if needed.
+The first argument passed to `lagomExternalScaladslProject` is the name that will be used in your build to refer to this externally defined project. While, the second argument provides the dependency to the `hello-impl` JAR, using the conventional sbt syntax for declaring dependencies. Note in fact that the `lagomExternalScaladslProject` method returns a sbt `Project`, which you can further customize if needed.
 
 After having added the external Lagom project to your build, just type `reload` in the sbt console. Then, when executing `runAll`, you should see that the `hello` service is started, together with all other services defined in the build:
 

--- a/docs/manual/scala/guide/build/code/multiple-builds.sbt
+++ b/docs/manual/scala/guide/build/code/multiple-builds.sbt
@@ -28,7 +28,7 @@ lazy val `hello-impl` = (project in file("hello-impl"))
 //#hello-build
 
 //#hello-external
-lazy val hello = lagomExternalProject("hello", "com.example" %% "hello-impl" % "1.0")
+lazy val hello = lagomExternalScaladslProject("hello", "com.example" %% "hello-impl" % "1.0")
 //#hello-external
 
 //#hello-communication


### PR DESCRIPTION
Fixes #426.

Java projects needed to have the Java dev mode dependencies added, but there was no way in the existing API to tell if an external project was a Java project or a Scala project, so I deprecated the existing method and created lagomExternalJavadslProject and lagomExternalScaladslProject methods.

Scripted tests for both the javadsl and scaladsl cases have been created.