### PR TITLE
Loaded Kafka properties file from the filesystem

### DIFF
--- a/dev/kafka-server/src/main/scala/com/lightbend/lagom/internal/util/PropertiesLoader.scala
+++ b/dev/kafka-server/src/main/scala/com/lightbend/lagom/internal/util/PropertiesLoader.scala
@@ -3,12 +3,32 @@
  */
 package com.lightbend.lagom.internal.util
 
+import java.io.{ File, FileInputStream }
 import java.util.Properties
 
 object PropertiesLoader {
   def from(file: String): Properties = {
     val properties = new Properties()
-    properties.load(getClass.getResourceAsStream(file))
-    properties
+    // First check if the file is on the classpath
+    val is = {
+      getClass.getResourceAsStream(file) match {
+        case null =>
+          // Try and load it as a file
+          val f = new File(file)
+          if (f.isFile) {
+            new FileInputStream(f)
+          } else {
+            throw new IllegalArgumentException(s"File $file not found as classpath resource or on the filesystem")
+          }
+        case found => found
+      }
+    }
+
+    try {
+      properties.load(is)
+      properties
+    } finally {
+      is.close()
+    }
   }
 }

--- a/dev/maven-plugin/src/main/maven/plugin.xml
+++ b/dev/maven-plugin/src/main/maven/plugin.xml
@@ -155,7 +155,7 @@
         </parameter>
         <parameter>
             <name>kafkaPropertiesFile</name>
-            <type>java.lang.String</type>
+            <type>java.util.File</type>
             <required>false</required>
             <editable>true</editable>
             <description>The relative path to the sever.properties to use to start Kafka.</description>

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
@@ -3,6 +3,7 @@
  */
 package com.lightbend.lagom.maven
 
+import java.io.File
 import javax.inject.Inject
 
 import com.lightbend.lagom.core.LagomVersion
@@ -68,7 +69,7 @@ class StartKafkaMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, m
   @BeanProperty
   var kafkaCleanOnStart: Boolean = _
   @BeanProperty
-  var kafkaPropertiesFile: String = _
+  var kafkaPropertiesFile: File = _
   @BeanProperty // I'm not sure if it's possible to specify a default value for a literal list in plugin.xml, so specify it here.
   var kafkaJvmOptions: JList[String] = Seq("-Xms256m", "-Xmx1024m").asJava
 
@@ -108,7 +109,7 @@ class StartKafkaMojo @Inject() (facade: MavenFacade, logger: MavenLoggerProxy, m
       // target directory matches the one used in the Lagom sbt plugin
       val targetDir = new java.io.File(projectTargetDir + / + "lagom-dynamic-projects" + / + "lagom-internal-meta-project-kafka" + / + "target")
       // properties file doesn't need to be provided by users, in which case the default one included with Lagom will be used
-      val kafkaPropertiesFile = Option(this.kafkaPropertiesFile).map(new java.io.File(_))
+      val kafkaPropertiesFile = Option(this.kafkaPropertiesFile)
 
       Servers.KafkaServer.start(logger, cp.map(_.getFile), kafkaPort, zookeeperPort, kafkaPropertiesFile, kafkaJvmOptions.asScala, targetDir, kafkaCleanOnStart)
     }

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -301,7 +301,7 @@ object LagomPlugin extends AutoPlugin {
     // kafka tasks and settings
     val lagomKafkaStart = taskKey[Unit]("Start the local kafka server")
     val lagomKafkaStop = taskKey[Unit]("Stop the local kafka server")
-    val lagomKafkaPropertiesFile = settingKey[Option[File]]("Properties file used by the local kafka broker (file's location is relative to the project's root)")
+    val lagomKafkaPropertiesFile = settingKey[Option[File]]("Properties file used by the local kafka broker")
     val lagomKafkaEnabled = settingKey[Boolean]("Enable/Disable the kafka server")
     val lagomKafkaCleanOnStart = settingKey[Boolean]("Wipe the kafka log before starting")
     val lagomKafkaJvmOptions = settingKey[Seq[String]]("JVM options used by the forked kafka process")
@@ -492,35 +492,7 @@ object LagomPlugin extends AutoPlugin {
         val log = new SbtLoggerProxy(state.value.log)
         val zooKeeperPort = lagomKafkaZookeperPort.value
         val kafkaPort = lagomKafkaPort.value
-        val kafkaPropertiesFile: Option[File] = {
-          lagomKafkaPropertiesFile.value match {
-            case None =>
-              log.debug("Kafka will start using the default server.properties included in Lagom.")
-              None
-            case file @ Some(propertiesFile) =>
-              if (propertiesFile.exists()) {
-                log.debug {
-                  """You have provided an absolute path to a Kafka properties file. I will use the provided path,
-                   | but consider using a relative path instead of an absolute one. If you decide to use a relative path,
-                   | make sure the provided path is relative to this project's build root directory.""".stripMargin
-                }
-                file
-              } else {
-                val rootDir = (Keys.baseDirectory in ThisBuild).value
-                val file = rootDir / propertiesFile.getPath
-                if (file.exists()) Some(file)
-                else {
-                  log.warn {
-                    s"""No properties file can be found at the provided path ${propertiesFile.getPath}. Hence, the local Kafka
-                      | server will be started with the default server.properties included in Lagom. To remove this warning, you
-                      | shall update the path provided in the sbt key ${lagomKafkaPropertiesFile.key.label} to point an existing
-                      | properties file.""".stripMargin
-                  }
-                  None
-                }
-              }
-          }
-        }
+        val kafkaPropertiesFile = lagomKafkaPropertiesFile.value
         val classpath = (managedClasspath in Compile).value.map(_.data)
         val jvmOptions = lagomKafkaJvmOptions.value
         val targetDir = target.value

--- a/docs/manual/common/guide/devmode/KafkaServer.md
+++ b/docs/manual/common/guide/devmode/KafkaServer.md
@@ -36,7 +36,7 @@ In the Maven root project pom:
     <artifactId>lagom-maven-plugin</artifactId>
     <version>${lagom.version}</version>
     <configuration>
-        <kafkaPropertiesFile>path/to/your/own/server.properties</kafkaPropertiesFile>
+        <kafkaPropertiesFile>${basedir}/kafka-server.properties</kafkaPropertiesFile>
     </configuration>
 </plugin>
 ```
@@ -44,8 +44,6 @@ In the Maven root project pom:
 In sbt:
 
 @[kafka-properties](code/build-kafka-opts.sbt)
-
-The path should be *relative* to your project's root. 
 
 ## JVM options
 

--- a/docs/manual/common/guide/devmode/code/build-kafka-opts.sbt
+++ b/docs/manual/common/guide/devmode/code/build-kafka-opts.sbt
@@ -5,7 +5,8 @@ lagomKafkaZookeperPort in ThisBuild := 9999
 //#kafka-port
 
 //#kafka-properties
-lagomKafkaPropertiesFile in ThisBuild := Some(file("path") / "to" / "your" / "own" / "server.properties")
+lagomKafkaPropertiesFile in ThisBuild :=
+  Some((baseDirectory in ThisBuild).value / "project" / "kafka-server.properties")
 //#kafka-properties
 
 //#kafka-jvm-options


### PR DESCRIPTION
Fixes #403.

I updated the docs and removed the checks to try and force it to be a relative path - in neither sbt nor Maven should relative paths ever be used, paths should always be absolute, explicitly building off other paths (basedir/baseDirectory).