### PR TITLE
Finished migration guides

### DIFF
--- a/docs/manual/java/index.toc
+++ b/docs/manual/java/index.toc
@@ -4,4 +4,4 @@ gettingstarted:Getting started with Lagom
 concepts:Lagom core concepts
 guide:Lagom reference guide
 appendix:Appendix
-releases:Lagom Releases
+releases:Lagom releases

--- a/docs/manual/java/releases/Migration13.md
+++ b/docs/manual/java/releases/Migration13.md
@@ -28,7 +28,7 @@ In addition, when importing external Lagom projects into the Lagom development e
 
 ## Service Info 
 
-It is now compulsory for Play applications to provide a [[ServiceInfo|ServiceInfo]] programmatically to run in the development unvironment. If you were providing `lagom.play.service-name` and `lagom.play.acls` via `aplication.conf` on your Play application the Developer Mode's `runAll` will still work but this is now deprecated. If your Play app is not implementing a `Module` you should add one and use the new `bindServiceInfo` to setup the service name and `ServiceAcl`s. The suggested location is `<play_app_folder>/app/Module.java` so that Guice will find it automatically.
+It is now compulsory for Play applications to provide a [[ServiceInfo|ServiceInfo]] programmatically to run in the development environment. If you were providing `lagom.play.service-name` and `lagom.play.acls` via `aplication.conf` on your Play application the Developer Mode's `runAll` will still work but this is now deprecated. If your Play app is not implementing a `Module` you should add one and use the new `bindServiceInfo` to setup the service name and `ServiceAcl`s. The suggested location is `<play_app_folder>/app/Module.java` so that Guice will find it automatically.
 
 ## ConductR
 

--- a/docs/manual/java/releases/Migration13.md
+++ b/docs/manual/java/releases/Migration13.md
@@ -1,8 +1,35 @@
 # Lagom 1.3 Migration Guide
 
-This guide explains hot to migrate from Lagom 1.2 to Lagom 1.3
+This guide explains how to migrate from Lagom 1.2 to Lagom 1.3.
+
+## Build changes
+
+### Maven
+
+If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.3.0`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
+
+### sbt
+
+It is not required, but is recommended, that you upgrade to sbt 0.13.13.  To upgrade an existing project to sbt 0.13.13, open `project/build.properties`, and edit the sbt version to be 0.13.13, for example:
+
+```
+sbt.version=0.13.13
+```
+
+When creating new projects, the use of Activator is now deprecated. Instead, you should use sbt 0.13.13's `new` support. This requires upgrading your sbt launcher to 0.13.13. This can be done by downloading and installing it from [the sbt website](http://www.scala-sbt.org/download.html).
+
+Once you have upgrade sbt, you then need to upgrade Lagom. This can be done by editing the Lagom plugin version in `project/plugins.sbt`, for example:
+
+```scala
+addSbtPlugin("com.lightbend.lagom" % "sbt-plugin" % "1.3.0")
+```
+
+In addition, when importing external Lagom projects into the Lagom development environment, `lagomExternalProject` is now deprecated, and should be replaced with `lagomExternalJavadslProject` or `lagomExternalScaladslProject`.
 
 ## Service Info 
 
-It is now compulsory to provide a [[ServiceInfo|ServiceInfo]] programmatically to run in the Development Environment. If you were providing `lagom.play.service-name` and `lagom.play.acls` via `aplication.conf` on your Play application the Developer Mode's `runAll` will still work but this is now deprecated. If your Play app is not implementing a `Module` you should add one and use the new `bindServiceInfo` to setup the service name and `ServiceAcl`s. The suggested location is `<play_app_folder>/app/Module.java` so that Guice will find it automatically.
+It is now compulsory for Play applications to provide a [[ServiceInfo|ServiceInfo]] programmatically to run in the development unvironment. If you were providing `lagom.play.service-name` and `lagom.play.acls` via `aplication.conf` on your Play application the Developer Mode's `runAll` will still work but this is now deprecated. If your Play app is not implementing a `Module` you should add one and use the new `bindServiceInfo` to setup the service name and `ServiceAcl`s. The suggested location is `<play_app_folder>/app/Module.java` so that Guice will find it automatically.
 
+## ConductR
+
+If using ConductR with sbt, you should upgrade the ConductR sbt plugin to at least `2.2.4`.

--- a/docs/manual/scala/index.toc
+++ b/docs/manual/scala/index.toc
@@ -4,3 +4,4 @@ gettingstarted:Getting started with Lagom
 concepts:Lagom core concepts
 guide:Lagom reference guide
 appendix:Appendix
+releases:Lagom releases

--- a/docs/manual/scala/releases/Migration13.md
+++ b/docs/manual/scala/releases/Migration13.md
@@ -1,0 +1,59 @@
+# Lagom 1.3 migration guide
+
+This guide gives a brief description of the steps required to migrate a Lagom 1.2 Java system to a Lagom 1.3 Scala system.
+
+## Build changes
+
+1. Ugrade the Lagom plugin version in `project/plugins.sbt` to `1.3.0`.
+1. Replace `LagomJava` with `LagomScala`, and any references to `javadsl` components to their `scaladsl` equivalents.
+
+## General code changes
+
+Generally, across your codebase, you will need to do the following:
+
+1. Replace any imports on Lagom `javadsl` APIs with imports on the equivalent `scaladsl` APIs. In most cases, these are named the same thing.
+1. Replace any uses of Akka `javadsl` streams with `scaladsl` streams.
+1. Replace any uses of `java.util.concurrent.CompletionStage` with `scala.concurrent.Future`. Remember that `scala.concurrent.Future` needs an implicit execution context in scope.
+
+## Lagom Service API changes
+
+The primary change necessary for the Lagom Service API is to declare Play JSON formats for all of your request and response messages. These formats should replace any Jackson annotations on your message classes. These formats are typically best declared as an implicit parameter on your message classes companion objects, using the Play JSON macros as a convenience, for example:
+
+```scala
+import play.api.libs.json._
+
+case class Post(title: String, content: String)
+
+object Post {
+  implicit val format: Format[Post] = Json.format
+}
+```
+
+For more details, see [[the message serializer documentation|ServiceDescriptors#Message-serialization]] for more information.
+
+If using custom path parameter serializers, these will need to be passed via implicit parameters, rather than being registered with the service descriptor explicitly.
+
+## Service implementation changes
+
+In the Lagom Java API, service calls get implemented using lambdas.  In the Scala API, service calls get implemented by passing lambdas to the `ServiceCall` and `ServerServiceCall` constructors, for example:
+
+```scala
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+import scala.concurrent.Future
+
+def sayHello = ServiceCall { name =>
+  Future.successful(s"Hello $name!")
+}
+```
+
+Furthermore, there is no need for `HeaderServiceCall` in Lagom, since the Scala type system is easily able to distinguish between a function that takes a single message argument, and a function that takes a request header and a message argument, so `ServerServiceCall` is used both for service calls that ignore the headers, and service calls that interact with the headers.
+
+## Persistence changes
+
+Persistent entities in Lagom express their command, event and state types using abstract types, rather than type parameters, on the `PersistentEntity` class. Lagom's persistent entity Scala behaviour builders also make use of partial functions and other Scala features. The full documentation on Scala's persistent entities is [[here|PersistentEntity]].
+
+Like the message serializers for services, serializers for messages sent over Akka remoting, and for the persistent entity events and state, need to be defined explicitly, by default this can be done using Play JSON. Since serializers are supplied explicitly, there is no need for a `Jsonable` interface in the Scala API.  For more details, see the [[serialization documentation|Serialization]].
+
+## Application wiring changes
+
+The Lagom Scala API is designed to be used with compile time dependency injection, not Guice. In general, this means removing all JSR-330 annotations from components, such as `@Inject` and `@Singleton`, and creating an application cake to replace the Guice `Module` that the Java API needs defined. For documentation about how to wire together a Lagom Scala application, see [[Wiring together a Lagom application|ServiceImplementation#Wiring-together-a-Lagom-application]].

--- a/docs/manual/scala/releases/index.toc
+++ b/docs/manual/scala/releases/index.toc
@@ -1,0 +1,1 @@
+Migration13:Lagom 1.3 Migration Guide


### PR DESCRIPTION
Finished the Java 1.3 migration guide.

Added a Scala 1.3 migration guide, which is notes to help for migrating from a Java Lagom 1.2 app to a Scala Lagom 1.3 app.