### PR TITLE
Update documentation to sbt-conductr 2.2.4

### DIFF
--- a/docs/manual/common/guide/production/code/conductr.sbt
+++ b/docs/manual/common/guide/production/code/conductr.sbt
@@ -1,3 +1,3 @@
 //#sbt-conductr
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.1.17")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.4")
 //#sbt-conductr


### PR DESCRIPTION
Update documentation to `sbt-conductr` 2.2.4. This version is supporting Lagom 1.3.0.