### PR TITLE
Document cassandra-configuration:dist command

### DIFF
--- a/docs/manual/java/guide/production/ConductRSbt.md
+++ b/docs/manual/java/guide/production/ConductRSbt.md
@@ -6,10 +6,11 @@ To use ConductR with sbt, add the [sbt-conductr plugin](https://github.com/types
 
 sbt-conductr adds several commands to the sbt console:
 
-* `install` to introspect your projects and then load and run them within the sandbox
-* `generateInstallationScript` to produce an installation script to deploy your Lagom system that you can then tailor
+* `install` to introspect your project and deploy all services within the ConductR sandbox
+* `generateInstallationScript` to produce an deployment script for all your services that you can then tailor
 * `bundle:dist` to produce individual ConductR packages for your services
-* `configuration:dist` to produce individual custom ConductR configuration for your services
+* `configuration:dist` to produce individual ConductR configurations for your services
+* `cassandra-configuration:dist` to produce a Cassandra ConductR configuration
 * Commands from the `conductr-cli`
 
 We will use most of these commands in the next sections.


### PR DESCRIPTION
The page http://www.lagomframework.com/documentation/1.3.x/java/ConductRSbt.html explains which sbt commands are available when adding the plugin `sbt-conductr`.

So far the command `cassandra-configuration:dist` was not listed there. Because we are using this command later on the page I thought it makes sense to list it there as well.

I’ve also modified the text of the other respective bullet points.