### PR TITLE
Minor fixes to the 1.3 migration guide

### DIFF
--- a/docs/manual/java/releases/Migration13.md
+++ b/docs/manual/java/releases/Migration13.md
@@ -18,7 +18,7 @@ sbt.version=0.13.13
 
 When creating new projects, the use of Activator is now deprecated. Instead, you should use sbt 0.13.13's `new` support. This requires upgrading your sbt launcher to 0.13.13. This can be done by downloading and installing it from [the sbt website](http://www.scala-sbt.org/download.html).
 
-Once you have upgrade sbt, you then need to upgrade Lagom. This can be done by editing the Lagom plugin version in `project/plugins.sbt`, for example:
+Once you have upgraded sbt, you then need to upgrade Lagom. This can be done by editing the Lagom plugin version in `project/plugins.sbt`, for example:
 
 ```scala
 addSbtPlugin("com.lightbend.lagom" % "sbt-plugin" % "1.3.0")
@@ -26,9 +26,9 @@ addSbtPlugin("com.lightbend.lagom" % "sbt-plugin" % "1.3.0")
 
 In addition, when importing external Lagom projects into the Lagom development environment, `lagomExternalProject` is now deprecated, and should be replaced with `lagomExternalJavadslProject` or `lagomExternalScaladslProject`.
 
-## Service Info 
+## Service Info
 
-It is now compulsory for Play applications to provide a [[ServiceInfo|ServiceInfo]] programmatically to run in the development environment. If you were providing `lagom.play.service-name` and `lagom.play.acls` via `aplication.conf` on your Play application the Developer Mode's `runAll` will still work but this is now deprecated. If your Play app is not implementing a `Module` you should add one and use the new `bindServiceInfo` to setup the service name and `ServiceAcl`s. The suggested location is `<play_app_folder>/app/Module.java` so that Guice will find it automatically.
+It is now compulsory for Play applications to provide a [[ServiceInfo|ServiceInfo]] programmatically to run in the development environment. If you were providing `lagom.play.service-name` and `lagom.play.acls` via `application.conf` in your Play application, the development mode's `runAll` will still work, but this is now deprecated. If your Play app does not currently include a Guice module, you should add one and use the new `bindServiceInfo` method to configure the service name and ACLs that you wish to expose to the service gateway. The suggested location is `<play_app_folder>/app/Module.java` so that Guice will find it automatically.
 
 ## ConductR
 

--- a/docs/manual/scala/releases/Migration13.md
+++ b/docs/manual/scala/releases/Migration13.md
@@ -17,7 +17,7 @@ Generally, across your codebase, you will need to do the following:
 
 ## Lagom Service API changes
 
-The primary change necessary for the Lagom Service API is to declare Play JSON formats for all of your request and response messages. These formats should replace any Jackson annotations on your message classes. These formats are typically best declared as an implicit parameter on your message classes companion objects, using the Play JSON macros as a convenience, for example:
+The primary change necessary for the Lagom Service API is to declare Play JSON formats for all of your request and response messages. These formats should replace any Jackson annotations on your message classes. These formats are typically best declared as an implicit parameter on your message classes' companion objects, using the Play JSON macros as a convenience, for example:
 
 ```scala
 import play.api.libs.json._
@@ -29,7 +29,7 @@ object Post {
 }
 ```
 
-For more details, see [[the message serializer documentation|ServiceDescriptors#Message-serialization]] for more information.
+For more details, see [[the message serializer documentation|ServiceDescriptors#Message-serialization]].
 
 If using custom path parameter serializers, these will need to be passed via implicit parameters, rather than being registered with the service descriptor explicitly.
 
@@ -50,7 +50,7 @@ Furthermore, there is no need for `HeaderServiceCall` in Lagom, since the Scala 
 
 ## Persistence changes
 
-Persistent entities in Lagom express their command, event and state types using abstract types, rather than type parameters, on the `PersistentEntity` class. Lagom's persistent entity Scala behaviour builders also make use of partial functions and other Scala features. The full documentation on Scala's persistent entities is [[here|PersistentEntity]].
+Persistent entities in Lagom express their command, event and state types using abstract types, rather than type parameters on the `PersistentEntity` class. Lagom's persistent entity Scala behavior builders also make use of partial functions and other Scala features. The full documentation on Scala's persistent entities is [[here|PersistentEntity]].
 
 Like the message serializers for services, serializers for messages sent over Akka remoting, and for the persistent entity events and state, need to be defined explicitly, by default this can be done using Play JSON. Since serializers are supplied explicitly, there is no need for a `Jsonable` interface in the Scala API.  For more details, see the [[serialization documentation|Serialization]].
 


### PR DESCRIPTION
Fixes typos and makes small wording changes to https://github.com/lagom/lagom/pull/503

Some of these are typo fixes that should be uncontroversial, others are spelling changes to US standard (which I think is what we use in most places) and others are rewordings that I thought make things clearer, but please feel free to disagree. 😄 

Will need to be backported to the 1.3.x branch after merging.