### PR TITLE
Changed Kafka support to lookup Kafka from the service locator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -859,7 +859,13 @@ lazy val `kafka-client-javadsl` = (project in file("service/javadsl/kafka/client
   .settings(mimaSettings(since12): _*)
   .settings(
     name := "lagom-javadsl-kafka-client",
-    mimaBinaryIssueFilters += ProblemFilters.exclude[MissingTypesProblem]("com.lightbend.lagom.javadsl.broker.kafka.KafkaTopicFactory")
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[MissingTypesProblem]("com.lightbend.lagom.javadsl.broker.kafka.KafkaTopicFactory"),
+      // Needed to add service locator to Kafka topic factory, which required changing
+      // the public constructor. Since this will generally only ever be invoked by Guice,
+      // there should be no bin compat problem here.
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.broker.kafka.KafkaTopicFactory.this")
+    )
   )
   .dependsOn(`api-javadsl`, `kafka-client`)
 

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/LagomConfig.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/LagomConfig.scala
@@ -17,8 +17,6 @@ object LagomConfig {
   def cassandraKeySpace(keyspace: String) = cassandraConfig("keyspace", keyspace)
   def cassandraPort(port: Int) = cassandraConfig("port", port.toString)
 
-  val KafkaAddress = "lagom.broker.defaults.kafka.brokers"
-
   def actorSystemConfig(name: String) = Map(
     "lagom.akka.dev-mode.actor-system.name" -> s"$name-internal-dev-mode",
     "play.akka.actor-system" -> s"$name-application",

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
@@ -85,7 +85,8 @@ private[lagom] object Servers {
       def serviceGatewayAddress: URI
     }
 
-    def start(log: LoggerProxy, parentClassLoader: ClassLoader, classpath: Array[URL], serviceLocatorPort: Int, serviceGatewayPort: Int, unmanagedServices: Map[String, String]): Unit = synchronized {
+    def start(log: LoggerProxy, parentClassLoader: ClassLoader, classpath: Array[URL], serviceLocatorPort: Int,
+      serviceGatewayPort: Int, unmanagedServices: Map[String, String]): Unit = synchronized {
       if (server == null) {
         withContextClassloader(new java.net.URLClassLoader(classpath, parentClassLoader)) { loader =>
           val serverClass = loader.loadClass("com.lightbend.lagom.discovery.ServiceLocatorServer")
@@ -252,6 +253,10 @@ private[lagom] object Servers {
 }
 
 private[lagom] object StaticServiceLocations {
-  def withCassandraLocation(lagomCassandraPort: Int, lagomUnmanagedServices: Map[String, String]): Map[String, String] =
-    Map("cas_native" -> s"tcp://127.0.0.1:$lagomCassandraPort/cas_native") ++ lagomUnmanagedServices
+  def staticServiceLocations(lagomCassandraPort: Int, lagomKafkaAddress: String): Map[String, String] = {
+    Map(
+      "cas_native" -> s"tcp://127.0.0.1:$lagomCassandraPort/cas_native",
+      "kafka_native" -> s"tcp://$lagomKafkaAddress/kafka_native"
+    )
+  }
 }

--- a/dev/maven-plugin/src/main/maven/plugin.xml
+++ b/dev/maven-plugin/src/main/maven/plugin.xml
@@ -409,6 +409,15 @@
                 <parameter>
                     <name>cassandraEnabled</name>
                 </parameter>
+                <parameter>
+                    <name>kafkaPort</name>
+                </parameter>
+                <parameter>
+                    <name>kafkaAddress</name>
+                </parameter>
+                <parameter>
+                    <name>kafkaEnabled</name>
+                </parameter>
             </parameters>
         </mojo>
         <mojo>
@@ -462,12 +471,6 @@
                 </parameter>
                 <parameter>
                     <name>cassandraKeyspace</name>
-                </parameter>
-                <parameter>
-                    <name>kafkaPort</name>
-                </parameter>
-                <parameter>
-                    <name>kafkaAddress</name>
                 </parameter>
                 <parameter>
                     <name>externalProjects</name>
@@ -531,12 +534,6 @@
                 </parameter>
                 <parameter>
                     <name>cassandraPort</name>
-                </parameter>
-                <parameter>
-                    <name>kafkaPort</name>
-                </parameter>
-                <parameter>
-                    <name>kafkaAddress</name>
                 </parameter>
             </parameters>
         </mojo>

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
@@ -143,6 +143,12 @@ class StartServiceLocatorMojo @Inject() (logger: MavenLoggerProxy, facade: Maven
   var cassandraPort: Int = _
   @BeanProperty
   var cassandraEnabled: Boolean = _
+  @BeanProperty
+  var kafkaPort: Int = _
+  @BeanProperty
+  var kafkaAddress: String = _
+  @BeanProperty
+  var kafkaEnabled: Boolean = _
 
   override def execute(): Unit = {
 
@@ -152,12 +158,10 @@ class StartServiceLocatorMojo @Inject() (logger: MavenLoggerProxy, facade: Maven
 
       val scalaClassLoader = scalaClassLoaderManager.extractScalaClassLoader(cp)
 
-      val scalaUnmanagedServices =
-        if (cassandraEnabled) {
-          StaticServiceLocations.withCassandraLocation(cassandraPort, unmanagedServices.asScala.toMap)
-        } else {
-          unmanagedServices.asScala.toMap
-        }
+      val theKafkaAddress = if (kafkaAddress == null) s"127.0.0.1:$kafkaPort" else kafkaAddress
+
+      val scalaUnmanagedServices = StaticServiceLocations.staticServiceLocations(cassandraPort, theKafkaAddress) ++
+        unmanagedServices.asScala.toMap
 
       Servers.ServiceLocator.start(logger, scalaClassLoader, cp.map(_.getFile.toURI.toURL).toArray,
         serviceLocatorPort, serviceGatewayPort, scalaUnmanagedServices)

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceManager.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceManager.scala
@@ -74,8 +74,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
   }
 
   def startServiceDevMode(project: MavenProject, port: Int, serviceLocatorUrl: Option[String],
-    cassandraPort: Option[Int], cassandraKeyspace: String, kafkaAddress: String,
-    playService: Boolean, additionalWatchDirs: Seq[File]): Unit = synchronized {
+    cassandraPort: Option[Int], cassandraKeyspace: String, playService: Boolean, additionalWatchDirs: Seq[File]): Unit = synchronized {
     runningServices.get(project) match {
       case Some(service) =>
         logger.info("Service " + project.getArtifactId + " already running!")
@@ -124,8 +123,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
               cassandraPort.fold(Map.empty[String, String]) { port =>
                 LagomConfig.cassandraPort(port)
               } ++
-              LagomConfig.cassandraKeySpace(cassandraKeyspace) ++
-              Map(LagomConfig.KafkaAddress -> kafkaAddress)
+              LagomConfig.cassandraKeySpace(cassandraKeyspace)
 
           val scalaClassLoader = scalaClassLoaderManager.extractScalaClassLoader(projectDependencies.external)
 
@@ -186,7 +184,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
   }
 
   def startExternalProject(dependency: Dependency, port: Int, serviceLocatorUrl: Option[String],
-    cassandraPort: Option[Int], cassandraKeyspace: String, kafkaAddress: String, playService: Boolean) = synchronized {
+    cassandraPort: Option[Int], cassandraKeyspace: String, playService: Boolean) = synchronized {
     runningExternalProjects.get(dependency) match {
       case Some(service) =>
         logger.info("External project " + dependency.getArtifact.getArtifactId + " already running!")
@@ -207,8 +205,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
           cassandraPort.fold(Map.empty[String, String]) { port =>
             LagomConfig.cassandraPort(port)
           } ++
-          LagomConfig.cassandraKeySpace(cassandraKeyspace) ++
-          Map(LagomConfig.KafkaAddress -> kafkaAddress)
+          LagomConfig.cassandraKeySpace(cassandraKeyspace)
 
         val scalaClassLoader = scalaClassLoaderManager.extractScalaClassLoader(dependencies)
 

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceMojos.scala
@@ -75,12 +75,6 @@ class StartMojo @Inject() (serviceManager: ServiceManager, session: MavenSession
   var cassandraPort: Int = _
 
   @BeanProperty
-  var kafkaPort: Int = _
-
-  @BeanProperty
-  var kafkaAddress: String = _
-
-  @BeanProperty
   var externalProjects: JList[ExternalProject] = Collections.emptyList()
 
   @BeanProperty
@@ -126,10 +120,8 @@ class StartMojo @Inject() (serviceManager: ServiceManager, session: MavenSession
 
     val cassandraKeyspace = LagomConfig.normalizeCassandraKeyspaceName(project.getArtifactId)
 
-    val kafkaAddress = if (this.kafkaAddress == null) s"localhost:${this.kafkaPort}" else this.kafkaAddress
-
     serviceManager.startServiceDevMode(project, selectedPort, serviceLocatorUrl, cassandraPort, cassandraKeyspace,
-      kafkaAddress, playService = playService, resolvedWatchDirs)
+      playService = playService, resolvedWatchDirs)
   }
 }
 
@@ -178,12 +170,6 @@ class StartExternalProjects @Inject() (serviceManager: ServiceManager, session: 
   @BeanProperty
   var cassandraPort: Int = _
 
-  @BeanProperty
-  var kafkaPort: Int = _
-
-  @BeanProperty
-  var kafkaAddress: String = _
-
   override def execute(): Unit = {
 
     val serviceLocatorUrl = (serviceLocatorEnabled, this.serviceLocatorUrl) match {
@@ -195,8 +181,6 @@ class StartExternalProjects @Inject() (serviceManager: ServiceManager, session: 
     val cassandraPort = if (cassandraEnabled) {
       Some(this.cassandraPort)
     } else None
-
-    val kafkaAddress = if (this.kafkaAddress == null) s"localhost:${this.kafkaPort}" else this.kafkaAddress
 
     lazy val portMap = serviceManager.getPortMap(
       servicePortRange,
@@ -225,7 +209,7 @@ class StartExternalProjects @Inject() (serviceManager: ServiceManager, session: 
       val dependency = RepositoryUtils.toDependency(project.artifact, session.getRepositorySession.getArtifactTypeRegistry)
 
       serviceManager.startExternalProject(dependency, selectedPort, serviceLocatorUrl, serviceCassandraPort, cassandraKeyspace,
-        kafkaAddress, playService = project.playService)
+        playService = project.playService)
     }
   }
 

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -457,11 +457,7 @@ object LagomPlugin extends AutoPlugin {
 
       Def.task {
         val unmanagedServices: Map[String, String] =
-          if ((lagomCassandraEnabled in ThisBuild).value) {
-            StaticServiceLocations.withCassandraLocation(lagomCassandraPort.value, lagomUnmanagedServices.value)
-          } else {
-            lagomUnmanagedServices.value
-          }
+          StaticServiceLocations.staticServiceLocations(lagomCassandraPort.value, lagomKafkaAddress.value) ++ lagomUnmanagedServices.value
 
         val serviceLocatorPort = lagomServiceLocatorPort.value
         val serviceGatewayPort = lagomServiceGatewayPort.value
@@ -568,17 +564,13 @@ object LagomPlugin extends AutoPlugin {
     LagomConfig.cassandraPort(port)
   }
 
-  private lazy val kafkaServerConfiguration: Initialize[Map[String, String]] = Def.setting {
-    Map(LagomConfig.KafkaAddress -> lagomKafkaAddress.value)
-  }
-
   private lazy val actorSystemsConfig: Initialize[Map[String, String]] = Def.setting {
     LagomConfig.actorSystemConfig(name.value)
   }
 
   private[sbt] lazy val managedSettings: Initialize[Map[String, String]] = Def.setting {
     serviceLocatorConfiguration.value ++ cassandraServerConfiguration.value ++
-      cassandraKeyspaceConfig.value ++ kafkaServerConfiguration.value ++ actorSystemsConfig.value
+      cassandraKeyspaceConfig.value ++ actorSystemsConfig.value
   }
 }
 

--- a/service/core/kafka/client/src/main/resources/reference.conf
+++ b/service/core/kafka/client/src/main/resources/reference.conf
@@ -6,7 +6,13 @@ lagom.broker.defaults.kafka {
 
 #//#kafka-broker
 lagom.broker.kafka {
+  # The name of the Kafka service to look up out of the service locator.
+  # If this is an empty string, then a service locator lookup will not be done,
+  # and the brokers configuration will be used instead.
+  service-name = "kafka_native"
+
   # The URLs of the Kafka brokers. Separate each URL with a comma.
+  # This will be ignored if the service-name configuration is non empty.
   brokers = ${lagom.broker.defaults.kafka.brokers}
 
   client {

--- a/service/core/kafka/client/src/main/scala/com/lightbend/lagom/internal/broker/kafka/KafkaConfig.scala
+++ b/service/core/kafka/client/src/main/scala/com/lightbend/lagom/internal/broker/kafka/KafkaConfig.scala
@@ -8,8 +8,12 @@ import java.util.concurrent.TimeUnit
 import com.typesafe.config.Config
 
 import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.util.control.NoStackTrace
 
 sealed trait KafkaConfig {
+  /** The name of the Kafka server to look up out of the service locator. */
+  def serviceName: Option[String]
+  /** A comma separated list of Kafka brokers. Will be ignored if useServiceLocator is true. */
   def brokers: String
 }
 
@@ -19,6 +23,7 @@ object KafkaConfig {
 
   private final class KafkaConfigImpl(conf: Config) extends KafkaConfig {
     override val brokers: String = conf.getString("brokers")
+    override val serviceName: Option[String] = Some(conf.getString("service-name")).filter(_.nonEmpty)
   }
 }
 
@@ -73,3 +78,5 @@ object ConsumerConfig {
     }
   }
 }
+
+private[lagom] final class NoKafkaBrokersException(serviceName: String) extends RuntimeException(s"No Kafka brokers found in service locator for Kafka service name [$serviceName]") with NoStackTrace

--- a/service/core/kafka/client/src/main/scala/com/lightbend/lagom/internal/broker/kafka/KafkaConfig.scala
+++ b/service/core/kafka/client/src/main/scala/com/lightbend/lagom/internal/broker/kafka/KafkaConfig.scala
@@ -13,7 +13,7 @@ import scala.util.control.NoStackTrace
 sealed trait KafkaConfig {
   /** The name of the Kafka server to look up out of the service locator. */
   def serviceName: Option[String]
-  /** A comma separated list of Kafka brokers. Will be ignored if useServiceLocator is true. */
+  /** A comma separated list of Kafka brokers. Will be ignored if serviceName is defined. */
   def brokers: String
 }
 

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
@@ -3,17 +3,15 @@
  */
 package com.lightbend.lagom.internal.broker.kafka
 
-import scala.concurrent.ExecutionContext
+import java.net.URI
+
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Failure
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{ Serializer, StringSerializer }
 import akka.Done
 import akka.NotUsed
-import akka.actor.Actor
-import akka.actor.ActorLogging
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.actor.SupervisorStrategy
+import akka.actor.{ Actor, ActorLogging, ActorSystem, Props, SupervisorStrategy }
 import akka.cluster.sharding.ClusterShardingSettings
 import akka.kafka.ProducerMessage
 import akka.kafka.ProducerSettings
@@ -41,6 +39,7 @@ private[lagom] object Producer {
     system:               ActorSystem,
     tags:                 immutable.Seq[String],
     kafkaConfig:          KafkaConfig,
+    locateService:        String => Future[Option[URI]],
     topicId:              String,
     eventStreamFactory:   (String, Offset) => Source[(Message, Offset), _],
     partitionKeyStrategy: Option[Message => String],
@@ -49,8 +48,8 @@ private[lagom] object Producer {
   )(implicit mat: Materializer, ec: ExecutionContext): Unit = {
 
     val producerConfig = ProducerConfig(system.settings.config)
-    val publisherProps = TaggedOffsetProducerActor.props(kafkaConfig, topicId, eventStreamFactory, partitionKeyStrategy,
-      serializer, offsetStore)
+    val publisherProps = TaggedOffsetProducerActor.props(kafkaConfig, locateService, topicId, eventStreamFactory,
+      partitionKeyStrategy, serializer, offsetStore)
 
     val backoffPublisherProps = BackoffSupervisor.propsWithSupervisorStrategy(
       publisherProps, s"producer", producerConfig.minBackoff, producerConfig.maxBackoff,
@@ -68,6 +67,7 @@ private[lagom] object Producer {
 
   private class TaggedOffsetProducerActor[Message](
     kafkaConfig:          KafkaConfig,
+    locateService:        String => Future[Option[URI]],
     topicId:              String,
     eventStreamFactory:   (String, Offset) => Source[(Message, Offset), _],
     partitionKeyStrategy: Option[Message => String],
@@ -85,57 +85,80 @@ private[lagom] object Producer {
     override def receive = {
       case EnsureActive(tag) =>
         offsetStore.prepare(s"topicProducer-$topicId", tag) pipeTo self
-        context.become(preparing(tag))
+
+        kafkaConfig.serviceName match {
+          case None =>
+            context.become(waitingForOffsetDao(dao => run(tag, None, dao)))
+          case Some(name) =>
+            locateService(name) pipeTo self
+
+            // We locate the service and load the offset in parallel, so there's two possibilities, the offset could
+            // be loaded first, or the service could be located first. We combine the handlers for both using an
+            // orElse, and whichever one happens first causes us to switch to waiting for just the other one.
+            context.become(
+              waitingForOffsetDao(dao => context.become(waitingForServiceLocator(name, uri => run(tag, uri, dao))))
+                .orElse(waitingForServiceLocator(name, uri => context.become(waitingForOffsetDao(dao => run(tag, uri, dao)))))
+            )
+        }
     }
 
-    private def preparing(tag: String): Receive = {
-      case dao: OffsetDao =>
-        val readSideSource = eventStreamFactory(tag, dao.loadedOffset)
-
-        val (killSwitch, streamDone) = readSideSource
-          .viaMat(KillSwitches.single)(Keep.right)
-          .via(eventsPublisherFlow(dao))
-          .toMat(Sink.ignore)(Keep.both)
-          .run()
-
-        shutdown = Some(killSwitch)
-        streamDone pipeTo self
-        context.become(active)
-
+    def generalHandler: Receive = {
       case Failure(e) =>
         throw e
 
       case EnsureActive(tagName) =>
-      // We are preparing
     }
 
-    private def active: Receive = {
-      case Failure(e) =>
-        throw e
+    private def waitingForOffsetDao(daoProvided: OffsetDao => Unit): Receive = generalHandler.orElse {
+      case dao: OffsetDao => daoProvided(dao)
+    }
 
+    private def waitingForServiceLocator(name: String, uriProvided: Option[URI] => Unit): Receive = generalHandler.orElse {
+      case None =>
+        log.error("Unable to locate Kafka service named [{}]", name)
+        context.stop(self)
+
+      case Some(uri: URI) =>
+        log.debug("Kafka service [{}] located at URI [{}] for producer of [{}]", name, uri, topicId)
+        uriProvided(Some(uri))
+    }
+
+    private def active: Receive = generalHandler.orElse {
       case Done =>
         log.info("Kafka producer stream for topic {} was completed.", topicId)
         context.stop(self)
-
-      case EnsureActive(tagName) =>
-      // Already active
     }
 
-    private def eventsPublisherFlow(offsetDao: OffsetDao) = Flow.fromGraph(GraphDSL.create(kafkaFlowPublisher) { implicit builder => publishFlow =>
-      import GraphDSL.Implicits._
-      val unzip = builder.add(Unzip[Message, Offset])
-      val zip = builder.add(Zip[Any, Offset])
-      val offsetCommitter = builder.add(Flow.fromFunction { e: (Any, Offset) =>
-        offsetDao.saveOffset(e._2)
+    private def run(tag: String, serviceLocatorUri: Option[URI], dao: OffsetDao) = {
+      val readSideSource = eventStreamFactory(tag, dao.loadedOffset)
+
+      val (killSwitch, streamDone) = readSideSource
+        .viaMat(KillSwitches.single)(Keep.right)
+        .via(eventsPublisherFlow(serviceLocatorUri, dao))
+        .toMat(Sink.ignore)(Keep.both)
+        .run()
+
+      shutdown = Some(killSwitch)
+      streamDone pipeTo self
+      context.become(active)
+    }
+
+    private def eventsPublisherFlow(serviceLocatorUri: Option[URI], offsetDao: OffsetDao) =
+      Flow.fromGraph(GraphDSL.create(kafkaFlowPublisher(serviceLocatorUri)) { implicit builder => publishFlow =>
+        import GraphDSL.Implicits._
+        val unzip = builder.add(Unzip[Message, Offset])
+        val zip = builder.add(Zip[Any, Offset])
+        val offsetCommitter = builder.add(Flow.fromFunction { e: (Any, Offset) =>
+          offsetDao.saveOffset(e._2)
+        })
+
+        unzip.out0 ~> publishFlow ~> zip.in0
+        unzip.out1 ~> zip.in1
+        zip.out ~> offsetCommitter.in
+        FlowShape(unzip.in, offsetCommitter.out)
       })
 
-      unzip.out0 ~> publishFlow ~> zip.in0
-      unzip.out1 ~> zip.in1
-      zip.out ~> offsetCommitter.in
-      FlowShape(unzip.in, offsetCommitter.out)
-    })
-
-    private def kafkaFlowPublisher: Flow[Message, _, _] = {
+    private def kafkaFlowPublisher(serviceLocatorUri: Option[URI]): Flow[Message, _, _] = {
       def keyOf(message: Message): String = {
         partitionKeyStrategy match {
           case Some(strategy) => strategy(message)
@@ -146,29 +169,36 @@ private[lagom] object Producer {
       Flow[Message].map { message =>
         ProducerMessage.Message(new ProducerRecord[String, Message](topicId, keyOf(message), message), NotUsed)
       } via {
-        ReactiveProducer.flow(producerSettings)
+        ReactiveProducer.flow(producerSettings(serviceLocatorUri))
       }
     }
 
-    private def producerSettings: ProducerSettings[String, Message] = {
+    private def producerSettings(serviceLocatorUri: Option[URI]): ProducerSettings[String, Message] = {
       val keySerializer = new StringSerializer
 
-      ProducerSettings(context.system, keySerializer, serializer)
-        .withBootstrapServers(kafkaConfig.brokers)
+      val baseSettings = ProducerSettings(context.system, keySerializer, serializer)
         .withProperty("client.id", self.path.toStringWithoutAddress)
+
+      serviceLocatorUri match {
+        case Some(uri) =>
+          baseSettings.withBootstrapServers(s"${uri.getHost}:${uri.getPort}")
+        case None =>
+          baseSettings.withBootstrapServers(kafkaConfig.brokers)
+      }
     }
   }
 
   private object TaggedOffsetProducerActor {
     def props[Message](
       kafkaConfig:          KafkaConfig,
+      locateService:        String => Future[Option[URI]],
       topicId:              String,
       eventStreamFactory:   (String, Offset) => Source[(Message, Offset), _],
       partitionKeyStrategy: Option[Message => String],
       serializer:           Serializer[Message],
       offsetStore:          OffsetStore
     )(implicit mat: Materializer, ec: ExecutionContext) =
-      Props(new TaggedOffsetProducerActor[Message](kafkaConfig, topicId, eventStreamFactory, partitionKeyStrategy,
-        serializer, offsetStore))
+      Props(new TaggedOffsetProducerActor[Message](kafkaConfig, locateService, topicId, eventStreamFactory,
+        partitionKeyStrategy, serializer, offsetStore))
   }
 }

--- a/service/javadsl/kafka/client/src/main/java/com/lightbend/lagom/javadsl/broker/kafka/KafkaTopicFactory.java
+++ b/service/javadsl/kafka/client/src/main/java/com/lightbend/lagom/javadsl/broker/kafka/KafkaTopicFactory.java
@@ -11,6 +11,7 @@ import com.lightbend.lagom.internal.broker.kafka.KafkaConfig$;
 import com.lightbend.lagom.internal.javadsl.broker.kafka.JavadslKafkaTopic;
 import com.lightbend.lagom.javadsl.api.Descriptor;
 import com.lightbend.lagom.javadsl.api.ServiceInfo;
+import com.lightbend.lagom.javadsl.api.ServiceLocator;
 import com.lightbend.lagom.javadsl.api.broker.Topic;
 import scala.concurrent.ExecutionContext;
 
@@ -25,20 +26,21 @@ public class KafkaTopicFactory implements TopicFactory {
     private final Materializer materializer;
     private final ExecutionContext executionContext;
     private final KafkaConfig config;
+    private final ServiceLocator serviceLocator;
 
     @Inject
     public KafkaTopicFactory(ServiceInfo serviceInfo, ActorSystem system, Materializer materializer,
-            ExecutionContext executionContext) {
+            ExecutionContext executionContext, ServiceLocator serviceLocator) {
         this.serviceInfo = serviceInfo;
         this.system = system;
         this.materializer = materializer;
         this.executionContext = executionContext;
-
         this.config = KafkaConfig$.MODULE$.apply(system.settings().config());
+        this.serviceLocator = serviceLocator;
     }
 
     @Override
     public <Message> Topic<Message> create(Descriptor.TopicCall<Message> topicCall) {
-        return new JavadslKafkaTopic<>(config, topicCall, serviceInfo, system, materializer, executionContext);
+        return new JavadslKafkaTopic<>(config, topicCall, serviceInfo, system, serviceLocator, materializer, executionContext);
     }
 }

--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaTopic.scala
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaTopic.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.broker.kafka.KafkaConfig
 import com.lightbend.lagom.javadsl.api.Descriptor.TopicCall
-import com.lightbend.lagom.javadsl.api.ServiceInfo
+import com.lightbend.lagom.javadsl.api.{ ServiceInfo, ServiceLocator }
 import com.lightbend.lagom.javadsl.api.broker.Topic.TopicId
 import com.lightbend.lagom.javadsl.api.broker.{ Subscriber, Topic }
 
@@ -16,10 +16,11 @@ import scala.concurrent.ExecutionContext
 /**
  * Represents a Kafka topic and allows publishing/consuming messages to/from the topic.
  */
-private[lagom] class JavadslKafkaTopic[Message](kafkaConfig: KafkaConfig, topicCall: TopicCall[Message], info: ServiceInfo, system: ActorSystem)(implicit mat: Materializer, ec: ExecutionContext) extends Topic[Message] {
+private[lagom] class JavadslKafkaTopic[Message](kafkaConfig: KafkaConfig, topicCall: TopicCall[Message],
+                                                info: ServiceInfo, system: ActorSystem, serviceLocator: ServiceLocator)(implicit mat: Materializer, ec: ExecutionContext) extends Topic[Message] {
 
   override def topicId: TopicId = topicCall.topicId
 
   override def subscribe(): Subscriber[Message] = new JavadslKafkaSubscriber(kafkaConfig, topicCall,
-    JavadslKafkaSubscriber.GroupId.default(info), info, system)
+    JavadslKafkaSubscriber.GroupId.default(info), info, system, serviceLocator)
 }

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -19,11 +19,8 @@ import org.scalatest.WordSpecLike
 import org.scalatest.concurrent.ScalaFutures
 import com.google.inject.AbstractModule
 import com.lightbend.lagom.internal.kafka.KafkaLocalServer
-import com.lightbend.lagom.javadsl.api.Descriptor
+import com.lightbend.lagom.javadsl.api._
 import com.lightbend.lagom.javadsl.api.ScalaService._
-import com.lightbend.lagom.javadsl.api.Service
-import com.lightbend.lagom.javadsl.api.ServiceInfo
-import com.lightbend.lagom.javadsl.api.ServiceLocator
 import com.lightbend.lagom.javadsl.api.broker.{ Topic => ApiTopic }
 import com.lightbend.lagom.javadsl.persistence._
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport
@@ -51,12 +48,13 @@ class JavadslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfter
         bind[OffsetStore].toInstance(InMemoryOffsetStore),
         bind[PersistentEntityRegistry].toInstance(NullPersistentEntityRegistry),
         JavadslKafkaApiSpec.testModule,
-        bind[ServiceLocator].to[NoServiceLocator]
+        bind[ServiceLocator].to[ConfigurationServiceLocator]
       ).configure(
           "akka.remote.netty.tcp.port" -> "0",
           "akka.remote.netty.tcp.hostname" -> "127.0.0.1",
           "akka.persistence.journal.plugin" -> "akka.persistence.journal.inmem",
-          "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local"
+          "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
+          "lagom.services.kafka_native" -> s"tcp://localhost:${KafkaLocalServer.DefaultPort}"
         ).build()
   }
 

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/KafkaTopicFactory.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/KafkaTopicFactory.scala
@@ -8,7 +8,7 @@ import akka.stream.Materializer
 import com.lightbend.lagom.internal.broker.kafka.KafkaConfig
 import com.lightbend.lagom.internal.scaladsl.api.broker.TopicFactory
 import com.lightbend.lagom.scaladsl.api.Descriptor.TopicCall
-import com.lightbend.lagom.scaladsl.api.ServiceInfo
+import com.lightbend.lagom.scaladsl.api.{ ServiceInfo, ServiceLocator }
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 
 import scala.concurrent.ExecutionContext
@@ -16,11 +16,11 @@ import scala.concurrent.ExecutionContext
 /**
  * Factory for creating topics instances.
  */
-private[lagom] class KafkaTopicFactory(serviceInfo: ServiceInfo, system: ActorSystem)(implicit materializer: Materializer, executionContext: ExecutionContext) extends TopicFactory {
+private[lagom] class KafkaTopicFactory(serviceInfo: ServiceInfo, system: ActorSystem, serviceLocator: ServiceLocator)(implicit materializer: Materializer, executionContext: ExecutionContext) extends TopicFactory {
 
   private val config = KafkaConfig(system.settings.config)
 
   def create[Message](topicCall: TopicCall[Message]): Topic[Message] = {
-    new ScaladslKafkaTopic(config, topicCall, serviceInfo, system)
+    new ScaladslKafkaTopic(config, topicCall, serviceInfo, system, serviceLocator)
   }
 }

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaTopic.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaTopic.scala
@@ -7,17 +7,17 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.broker.kafka.KafkaConfig
 import com.lightbend.lagom.scaladsl.api.Descriptor.TopicCall
-import com.lightbend.lagom.scaladsl.api.ServiceInfo
+import com.lightbend.lagom.scaladsl.api.{ ServiceInfo, ServiceLocator }
 import com.lightbend.lagom.scaladsl.api.broker.{ Subscriber, Topic }
 import com.lightbend.lagom.scaladsl.api.broker.Topic.TopicId
 
 import scala.concurrent.ExecutionContext
 
 private[lagom] class ScaladslKafkaTopic[Message](kafkaConfig: KafkaConfig, topicCall: TopicCall[Message],
-                                                 info: ServiceInfo, system: ActorSystem)(implicit mat: Materializer, ec: ExecutionContext) extends Topic[Message] {
+                                                 info: ServiceInfo, system: ActorSystem, serviceLocator: ServiceLocator)(implicit mat: Materializer, ec: ExecutionContext) extends Topic[Message] {
 
   override def topicId: TopicId = topicCall.topicId
 
   override def subscribe: Subscriber[Message] = new ScaladslKafkaSubscriber(kafkaConfig, topicCall,
-    ScaladslKafkaSubscriber.GroupId.default(info), info, system)
+    ScaladslKafkaSubscriber.GroupId.default(info), info, system, serviceLocator)
 }

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/LagomKafkaClientComponents.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/LagomKafkaClientComponents.scala
@@ -7,7 +7,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.scaladsl.api.broker.{ TopicFactory, TopicFactoryProvider }
 import com.lightbend.lagom.internal.scaladsl.broker.kafka.KafkaTopicFactory
-import com.lightbend.lagom.scaladsl.api.ServiceInfo
+import com.lightbend.lagom.scaladsl.api.{ ServiceInfo, ServiceLocator }
 
 import scala.concurrent.ExecutionContext
 
@@ -16,7 +16,8 @@ trait LagomKafkaClientComponents extends TopicFactoryProvider {
   def actorSystem: ActorSystem
   def materializer: Materializer
   def executionContext: ExecutionContext
+  def serviceLocator: ServiceLocator
 
-  lazy val topicFactory: TopicFactory = new KafkaTopicFactory(serviceInfo, actorSystem)(materializer, executionContext)
+  lazy val topicFactory: TopicFactory = new KafkaTopicFactory(serviceInfo, actorSystem, serviceLocator)(materializer, executionContext)
   override def optionalTopicFactory: Option[TopicFactory] = Some(topicFactory)
 }

--- a/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslRegisterTopicProducers.scala
+++ b/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslRegisterTopicProducers.scala
@@ -11,7 +11,7 @@ import com.lightbend.internal.broker.TaggedOffsetTopicProducer
 import com.lightbend.lagom.internal.broker.kafka.{ KafkaConfig, Producer }
 import com.lightbend.lagom.internal.scaladsl.api.broker.TopicFactory
 import com.lightbend.lagom.scaladsl.api.Descriptor.TopicCall
-import com.lightbend.lagom.scaladsl.api.ServiceInfo
+import com.lightbend.lagom.scaladsl.api.{ ServiceInfo, ServiceLocator }
 import com.lightbend.lagom.scaladsl.api.ServiceSupport.ScalaMethodTopic
 import com.lightbend.lagom.scaladsl.api.broker.kafka.KafkaProperties
 import com.lightbend.lagom.scaladsl.server.LagomServer
@@ -21,7 +21,8 @@ import org.slf4j.LoggerFactory
 import scala.concurrent.ExecutionContext
 
 class ScaladslRegisterTopicProducers(lagomServer: LagomServer, topicFactory: TopicFactory,
-                                     info: ServiceInfo, actorSystem: ActorSystem, offsetStore: OffsetStore)(implicit ec: ExecutionContext, mat: Materializer) {
+                                     info: ServiceInfo, actorSystem: ActorSystem, offsetStore: OffsetStore,
+                                     serviceLocator: ServiceLocator)(implicit ec: ExecutionContext, mat: Materializer) {
 
   private val log = LoggerFactory.getLogger(classOf[ScaladslRegisterTopicProducers])
   private val kafkaConfig = KafkaConfig(actorSystem.settings.config)
@@ -59,8 +60,8 @@ class ScaladslRegisterTopicProducers(lagomServer: LagomServer, topicFactory: Top
                   }
                 }
 
-                Producer.startTaggedOffsetProducer(actorSystem, tags.map(_.tag), kafkaConfig, topicId.name,
-                  eventStreamFactory, partitionKeyStrategy,
+                Producer.startTaggedOffsetProducer(actorSystem, tags.map(_.tag), kafkaConfig, serviceLocator.locate,
+                  topicId.name, eventStreamFactory, partitionKeyStrategy,
                   new ScaladslKafkaSerializer(topicCall.messageSerializer.serializerForRequest),
                   offsetStore)
               case other => log.warn {

--- a/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/LagomKafkaComponents.scala
+++ b/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/LagomKafkaComponents.scala
@@ -4,6 +4,7 @@
 package com.lightbend.lagom.scaladsl.broker.kafka
 
 import com.lightbend.lagom.internal.scaladsl.broker.kafka.ScaladslRegisterTopicProducers
+import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.server.LagomServer
 import com.lightbend.lagom.spi.persistence.OffsetStore
 
@@ -15,6 +16,7 @@ import com.lightbend.lagom.spi.persistence.OffsetStore
 trait LagomKafkaComponents extends LagomKafkaClientComponents {
   def lagomServer: LagomServer
   def offsetStore: OffsetStore
+  def serviceLocator: ServiceLocator
 
   override def topicPublisherName: Option[String] = super.topicPublisherName match {
     case Some(other) =>
@@ -24,5 +26,5 @@ trait LagomKafkaComponents extends LagomKafkaClientComponents {
 
   // Eagerly start topic producers
   new ScaladslRegisterTopicProducers(lagomServer, topicFactory, serviceInfo, actorSystem,
-    offsetStore)(executionContext, materializer)
+    offsetStore, serviceLocator)(executionContext, materializer)
 }

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -17,6 +17,7 @@ import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceLocator }
 import com.lightbend.lagom.scaladsl.broker.TopicProducer
 import com.lightbend.lagom.scaladsl.broker.kafka.LagomKafkaComponents
+import com.lightbend.lagom.scaladsl.client.ConfigurationServiceLocatorComponents
 import com.lightbend.lagom.scaladsl.kafka.broker.ScaladslKafkaApiSpec.{ InMemoryOffsetStore, TestService, TestServiceImpl }
 import com.lightbend.lagom.scaladsl.persistence.AggregateEvent
 import com.lightbend.lagom.scaladsl.server._
@@ -33,8 +34,7 @@ import scala.concurrent.duration._
 class ScaladslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
 
   private val application = {
-    new LagomApplication(LagomApplicationContext.Test) with AhcWSComponents with LagomKafkaComponents {
-      override lazy val serviceLocator = ServiceLocator.NoServiceLocator
+    new LagomApplication(LagomApplicationContext.Test) with AhcWSComponents with LagomKafkaComponents with ConfigurationServiceLocatorComponents {
       override lazy val offsetStore = InMemoryOffsetStore
       override lazy val lagomServer = LagomServer.forServices(
         bindService[TestService].to(new TestServiceImpl)
@@ -43,7 +43,8 @@ class ScaladslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfte
         "akka.remote.netty.tcp.port" -> "0",
         "akka.remote.netty.tcp.hostname" -> "127.0.0.1",
         "akka.persistence.journal.plugin" -> "akka.persistence.journal.inmem",
-        "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local"
+        "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
+        "lagom.services.kafka_native" -> s"tcp://localhost:${KafkaLocalServer.DefaultPort}"
       ))
 
       lazy val testService = serviceClient.implement[TestService]


### PR DESCRIPTION
The service locator is looked up every time a connection to Kafka is made - I think this is what we want, since generally connections to Kafka are long lived, and in the case that a Kafka node dies and is restarted somewhere else, typically the stream will fail, then when it reconnects, it will need to look up from the service locator again to find out where another node is.

I modified the Kafka tests so that it will use this.

Passing configuration explicitly is still supported, by setting lagom.broker.kafka.service-name to an empty string.

Fixes #511.