### PR TITLE
Update RunningServices.md

### DIFF
--- a/docs/manual/common/guide/devmode/RunningServices.md
+++ b/docs/manual/common/guide/devmode/RunningServices.md
@@ -13,3 +13,9 @@ $ mvn -pl <your-project-name> lagom:run
 In sbt, you can specify the project to run on the sbt console by simply prefixing the service project's name, i.e., `<your-lagom-project-name>/run`.
 
 One thing you should remember is that `run` only starts the specific service, it doesn't start neither the Service Locator, nor the Cassandra server. Hence, prior to manually starting services, you may want to manually start both the [[Service Locator|ServiceLocator#Start-and-stop]], and the [[Cassandra server|CassandraServer#Start-and-stop]].
+
+If you are using external Cassandra/Kafka , then you need to start the Service Locator and your project services concurrently as described in below steps : - 
+
+sbt lagomServiceLocatorStart <your-project-name>/run 
+
+Once started you can now run your other services using the above commmand : - `<your-lagom-project-name>/run`.


### PR DESCRIPTION
Added Line 17 and 19 and 21. 
If you start lagom ServiceLocator individually on one terminal and then try to start you individual lagom project services then it will give error : - 
java.net.ConnectException: Connection refused: localhost/127.0.0.1:8000
(when you are using external cassandra) 

but starting lagomServiceLocatorStart and your project in single command ( as mentioned in line 19) will start it successfully .

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

This PR updates the RunningServices.md file , states the way to run individual lagom services successfully .

## Background Context

I am building Lagon - scala applicaiton , A simple World Count using the Hello-API example . Also my team have created another Lagom-Service that fetch data from twitter . Now I need to run only one service at the time to perform testing at development time .

## References

Are there any relevant issues / PRs / mailing lists discussions?
No

Have signed Lightbend Contributors License Agreement.