### PR TITLE
Fix issue with primitives in path

### DIFF
--- a/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslClientMacroImpl.scala
+++ b/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslClientMacroImpl.scala
@@ -90,7 +90,7 @@ private[lagom] object ScaladslClientMacroImpl {
       q"""
         override def ${serviceMethod.name}(...$methodParams) = {
           $serviceContext.createServiceCall(${serviceMethod.name.decodedName.toString},
-            _root_.scala.collection.immutable.Seq(..$methodParamNames))
+            _root_.scala.collection.immutable.Seq[_root_.scala.Any](..$methodParamNames))
         }
       """
     }

--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/ServiceClientSpec.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/ServiceClientSpec.scala
@@ -53,6 +53,14 @@ class ServiceClientSpec extends WordSpec with Matchers with Inside {
           methodName should ===("twoArguments")
           params should ===(Seq("foo", "bar"))
       }
+      inside(mockServiceClient.twoPrimitiveArguments(1L, 2)) {
+        case TestServiceCall(descriptor, methodName, params) =>
+          descriptor.name should ===("mockservice")
+          methodName should ===("twoPrimitiveArguments")
+          params should ===(Seq(1, 2))
+          params(0) shouldBe a[java.lang.Long]
+          params(1) shouldBe an[java.lang.Integer]
+      }
       inside(mockServiceClient.streamNoParamList) {
         case TestTopic(descriptor, methodName) =>
           descriptor.name should ===("mockservice")
@@ -102,6 +110,7 @@ trait MockService extends Service {
   def noArgumentsRef(): ServiceCall[String, String]
   def oneArgument(arg: String): ServiceCall[String, String]
   def twoArguments(arg1: String, arg2: String): ServiceCall[String, String]
+  def twoPrimitiveArguments(arg1: Long, arg2: Int): ServiceCall[String, String]
   def streamNoParamList: Topic[String]
   def streamNoParamListRef: Topic[String]
   def streamNoArguments(): Topic[String]


### PR DESCRIPTION


# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [X] Have you added tests for any changed functionality?

## Fixes

Issue is not registered in the bug tracking. 
Long story short, if I have method with multiple primitive params registered as a service call and I'm trying to create and use client for it, classcastexception is thrown. It happens during serialization params into path. 
Root cause is implicit numeric widening. 
```
scala> Seq(1L, 2)
res0: Seq[Long] = List(1, 2)
// All numbers have been widened to be long
scala> val anySeq: Seq[Any] = Seq(1L, 2)
anySeq: Seq[Any] = List(1, 2)

scala> anySeq(1).getClass
res1: Class[_] = class java.lang.Long
// type annotation on val doesn't help 
```
 
## Purpose

I fixed that by adding explicit type annotation to Seq.apply method in macro. Same principle demonstrated in Scala console:
```
scala> val fixedSeq = Seq[Any](1L, 2)
fixedSeq: Seq[Any] = List(1, 2)

scala> fixedSeq(1).getClass
res2: Class[_] = class java.lang.Integer
```
