### PR TITLE
Add a new transport exception to represent BadRequest

### DIFF
--- a/service/core/api/src/main/scala/com/lightbend/lagom/internal/api/transport/LagomServiceApiBridge.scala
+++ b/service/core/api/src/main/scala/com/lightbend/lagom/internal/api/transport/LagomServiceApiBridge.scala
@@ -115,6 +115,7 @@ trait LagomServiceApiBridge {
 
   // Exceptions
   def newPayloadTooLarge(msg: String): Throwable
+  def newBadRequest(msg: String): Throwable
   def newPolicyViolation(msg: String, detail: String): Throwable
   def newTransportException(errorCode: ErrorCode, message: String): Exception
 

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/BadRequest.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/BadRequest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.api.transport;
+
+import com.lightbend.lagom.javadsl.api.deser.ExceptionMessage;
+
+/**
+ * Thrown when the request is bad.
+ */
+public class BadRequest extends TransportException {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final TransportErrorCode ERROR_CODE = TransportErrorCode.BadRequest;
+
+    public BadRequest(String message) {
+        super(ERROR_CODE, message);
+    }
+
+    public BadRequest(Throwable cause) {
+        super(ERROR_CODE, cause);
+    }
+
+    public BadRequest(TransportErrorCode errorCode, ExceptionMessage exceptionMessage) {
+        super(errorCode, exceptionMessage);
+    }
+}

--- a/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/javadsl/client/JavadslServiceApiBridge.scala
+++ b/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/javadsl/client/JavadslServiceApiBridge.scala
@@ -17,6 +17,7 @@ import com.lightbend.lagom.javadsl.api
 import com.lightbend.lagom.javadsl.api.Descriptor.RestCallId
 import com.lightbend.lagom.javadsl.api.deser.ExceptionMessage
 import com.lightbend.lagom.javadsl.api.security.ServicePrincipal
+import com.lightbend.lagom.javadsl.api.transport.BadRequest
 import org.pcollections.{ HashTreePMap, PSequence, TreePVector }
 
 import scala.compat.java8.OptionConverters._
@@ -150,6 +151,7 @@ trait JavadslServiceApiBridge extends LagomServiceApiBridge {
 
   // Exceptions
   override def newPayloadTooLarge(msg: String): Throwable = new transport.PayloadTooLarge(msg)
+  override def newBadRequest(msg: String): Throwable = new transport.BadRequest(msg)
   override def newPolicyViolation(msg: String, detail: String): Throwable =
     new transport.TransportException(transport.TransportErrorCode.PolicyViolation, new ExceptionMessage(msg, detail))
   override def newTransportException(errorCode: ErrorCode, message: String): Exception =

--- a/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/javadsl/client/JavadslServiceClientImplementor.scala
+++ b/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/javadsl/client/JavadslServiceClientImplementor.scala
@@ -136,7 +136,6 @@ private class JavadslClientServiceCallInvoker[Request, Response](
                                             requestHeader: RequestHeader): Future[(ResponseHeader, Source[ByteString, NotUsed])] = {
     webSocketClient.connect(descriptor.exceptionSerializer, WebSocketVersion.V13, requestHeader, requestStream)
   }
-
 }
 
 case object NoTopicFactory

--- a/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
+++ b/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
@@ -180,7 +180,7 @@ class JavadslServiceRouter(override protected val descriptor: Descriptor, servic
 
   override protected def maybeLogException(exc: Throwable, log: => Logger, call: Call[_, _]) = {
     exc match {
-      case _: NotFound | _: Forbidden => // no logging
+      case _: NotFound | _: Forbidden | _: BadRequest => // no logging
       case e @ (_: UnsupportedMediaType | _: PayloadTooLarge | _: NotAcceptable) =>
         log.warn(e.getMessage)
       case e =>

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/Exceptions.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/Exceptions.scala
@@ -240,6 +240,7 @@ object TransportException {
     NotAcceptable.ErrorCode -> ((tec, em) => new NotAcceptable(tec, em)),
     PolicyViolation.ErrorCode -> ((tec, em) => new PolicyViolation(tec, em)),
     PayloadTooLarge.ErrorCode -> ((tec, em) => new PayloadTooLarge(tec, em)),
+    BadRequest.ErrorCode -> ((tec, em) => new BadRequest(tec, em)),
     Forbidden.ErrorCode -> ((tec, em) => new Forbidden(tec, em))
   )
 
@@ -377,5 +378,23 @@ object PayloadTooLarge {
   def apply(cause: Throwable) = new PayloadTooLarge(
     ErrorCode,
     new ExceptionMessage(classOf[PayloadTooLarge].getSimpleName, cause.getMessage), cause
+  )
+}
+
+final class BadRequest(errorCode: TransportErrorCode, exceptionMessage: ExceptionMessage, cause: Throwable) extends TransportException(errorCode, exceptionMessage, cause) {
+  def this(errorCode: TransportErrorCode, exceptionMessage: ExceptionMessage) = this(errorCode, exceptionMessage, null)
+}
+
+object BadRequest {
+  val ErrorCode = TransportErrorCode.BadRequest
+
+  def apply(message: String) = new BadRequest(
+    ErrorCode,
+    new ExceptionMessage(classOf[BadRequest].getSimpleName, message), null
+  )
+
+  def apply(cause: Throwable) = new BadRequest(
+    ErrorCode,
+    new ExceptionMessage(classOf[BadRequest].getSimpleName, cause.getMessage), cause
   )
 }

--- a/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceApiBridge.scala
+++ b/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceApiBridge.scala
@@ -130,6 +130,7 @@ trait ScaladslServiceApiBridge extends LagomServiceApiBridge {
 
   // Exceptions
   override def newPayloadTooLarge(msg: String): Throwable = transport.PayloadTooLarge(msg)
+  override def newBadRequest(msg: String): Throwable = transport.BadRequest(msg)
   override def newPolicyViolation(msg: String, detail: String): Throwable =
     new transport.TransportException(transport.TransportErrorCode.PolicyViolation, new ExceptionMessage(msg, detail))
   override def newTransportException(errorCode: ErrorCode, message: String): Exception =


### PR DESCRIPTION
I noticed that there is no exception to represent a BadRequest.  I needed this for when my entity returns an InvalidCommand.