### PR TITLE
Upgrade to sbt-conductr 2.2.5

### DIFF
--- a/docs/manual/guide/production/ConductRSbt.md
+++ b/docs/manual/guide/production/ConductRSbt.md
@@ -3,7 +3,7 @@
 To use ConductR with sbt, add the [sbt-conductr plugin](https://github.com/typesafehub/sbt-conductr) to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.4")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.5")
 ```
 
 sbt-conductr adds several commands to the activator console:


### PR DESCRIPTION
Upgrade to sbt-conductr 2.2.5. This version is only compatible with Lagom 1.1.x and 1.2.x, not with Lagom 1.3.x.

Please cherry pick to branch 1.1.x.