### PR TITLE
Upgrade to sbt-conductr 2.3.0-RC1

### DIFF
--- a/docs/manual/common/guide/production/code/conductr.sbt
+++ b/docs/manual/common/guide/production/code/conductr.sbt
@@ -1,3 +1,3 @@
 //#sbt-conductr
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.2.4")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.3.0-RC1")
 //#sbt-conductr


### PR DESCRIPTION
Upgrade to sbt-conductr 2.3.0-rc.1. This version is only compatible with Lagom 1.3.x, not Lagom 1.1.x or 1.2.x.

Please cherry pick to branch 1.3.x.