### PR TITLE
Increase the sbt heap in the docs subproject

### DIFF
--- a/docs/.jvmopts
+++ b/docs/.jvmopts
@@ -1,4 +1,4 @@
 # This is used to configure sbt in development
 # Note that you need to use version 0.13.13+ of the sbt launcher
--Xms1024M
--Xmx1024M
+-Xms1536M
+-Xmx1536M


### PR DESCRIPTION
I was starting to see OutOfMemoryError when running the docs validation locally.