### PR TITLE
Sets circuit breaking to described settings or defaults but never None

### DIFF
--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceResolverSpec.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceResolverSpec.scala
@@ -1,16 +1,18 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package com.lightbend.lagom.internal.scaladsl.client
 
 import akka.NotUsed
 import com.lightbend.lagom.scaladsl.api.deser.DefaultExceptionSerializer
-import com.lightbend.lagom.scaladsl.api.{CircuitBreaker, Descriptor, Service, ServiceCall}
+import com.lightbend.lagom.scaladsl.api.{ CircuitBreaker, Descriptor, Service, ServiceCall }
 import com.lightbend.lagom.scaladsl.client.TestServiceClient
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{ FlatSpec, Matchers }
 
 /**
-  *
-  */
+ *
+ */
 class ScaladslServiceResolverSpec extends FlatSpec with Matchers {
-
 
   behavior of "ScaladslServiceResolver"
 
@@ -25,9 +27,9 @@ class ScaladslServiceResolverSpec extends FlatSpec with Matchers {
   }
 
   // --------------------------------------------------------------------------------------------
-  def assertCircuitBreaking(service: Service, expected:CircuitBreaker) = {
+  def assertCircuitBreaking(service: Service, expected: CircuitBreaker) = {
     val resolved = new ScaladslServiceResolver(DefaultExceptionSerializer.Unresolved).resolve(service.descriptor)
-    resolved.calls.head.circuitBreaker should be (Some(expected))
+    resolved.calls.head.circuitBreaker should be(Some(expected))
   }
 
   trait Unspecified extends Service {
@@ -48,8 +50,8 @@ class ScaladslServiceResolverSpec extends FlatSpec with Matchers {
       named(
         "Unspecified"
       ).withCalls(
-        namedCall("one", one)
-      ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
+          namedCall("one", one)
+        ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
     }
   }
 
@@ -60,10 +62,9 @@ class ScaladslServiceResolverSpec extends FlatSpec with Matchers {
       named(
         "Unspecified"
       ).withCalls(
-        namedCall("one", one).withCircuitBreaker(CircuitBreaker.identifiedBy("one-cb")) // overwrites default.
-      ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
+          namedCall("one", one).withCircuitBreaker(CircuitBreaker.identifiedBy("one-cb")) // overwrites default.
+        ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
     }
   }
 
 }
-

--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceResolverSpec.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceResolverSpec.scala
@@ -1,0 +1,69 @@
+package com.lightbend.lagom.internal.scaladsl.client
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api.deser.DefaultExceptionSerializer
+import com.lightbend.lagom.scaladsl.api.{CircuitBreaker, Descriptor, Service, ServiceCall}
+import com.lightbend.lagom.scaladsl.client.TestServiceClient
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  *
+  */
+class ScaladslServiceResolverSpec extends FlatSpec with Matchers {
+
+
+  behavior of "ScaladslServiceResolver"
+
+  it should "setup circuit-breakers for all method calls using default values when nothing is specified" in {
+    assertCircuitBreaking(TestServiceClient.implement[Unspecified], CircuitBreaker.PerNode)
+  }
+  it should "setup circuit-breakers for all method calls using descriptor value when only descriptor's CB is specified" in {
+    assertCircuitBreaking(TestServiceClient.implement[General], CircuitBreaker.identifiedBy("general-cb"))
+  }
+  it should "setup circuit-breakers with each specific CB when each call has a CB described" in {
+    assertCircuitBreaking(TestServiceClient.implement[PerCall], CircuitBreaker.identifiedBy("one-cb"))
+  }
+
+  // --------------------------------------------------------------------------------------------
+  def assertCircuitBreaking(service: Service, expected:CircuitBreaker) = {
+    val resolved = new ScaladslServiceResolver(DefaultExceptionSerializer.Unresolved).resolve(service.descriptor)
+    resolved.calls.head.circuitBreaker should be (Some(expected))
+  }
+
+  trait Unspecified extends Service {
+    import Service._
+    def one: ServiceCall[NotUsed, NotUsed]
+    override def descriptor: Descriptor = {
+      named("Unspecified").
+        withCalls(
+          namedCall("one", one)
+        )
+    }
+  }
+
+  trait General extends Service {
+    import Service._
+    def one: ServiceCall[NotUsed, NotUsed]
+    override def descriptor: Descriptor = {
+      named(
+        "Unspecified"
+      ).withCalls(
+        namedCall("one", one)
+      ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
+    }
+  }
+
+  trait PerCall extends Service {
+    import Service._
+    def one: ServiceCall[NotUsed, NotUsed]
+    override def descriptor: Descriptor = {
+      named(
+        "Unspecified"
+      ).withCalls(
+        namedCall("one", one).withCircuitBreaker(CircuitBreaker.identifiedBy("one-cb")) // overwrites default.
+      ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
+    }
+  }
+
+}
+

--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceResolverSpec.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslServiceResolverSpec.scala
@@ -9,9 +9,6 @@ import com.lightbend.lagom.scaladsl.api.{ CircuitBreaker, Descriptor, Service, S
 import com.lightbend.lagom.scaladsl.client.TestServiceClient
 import org.scalatest.{ FlatSpec, Matchers }
 
-/**
- *
- */
 class ScaladslServiceResolverSpec extends FlatSpec with Matchers {
 
   behavior of "ScaladslServiceResolver"
@@ -19,51 +16,63 @@ class ScaladslServiceResolverSpec extends FlatSpec with Matchers {
   it should "setup circuit-breakers for all method calls using default values when nothing is specified" in {
     assertCircuitBreaking(TestServiceClient.implement[Unspecified], CircuitBreaker.PerNode)
   }
+
   it should "setup circuit-breakers for all method calls using descriptor value when only descriptor's CB is specified" in {
     assertCircuitBreaking(TestServiceClient.implement[General], CircuitBreaker.identifiedBy("general-cb"))
   }
+
   it should "setup circuit-breakers with each specific CB when each call has a CB described" in {
     assertCircuitBreaking(TestServiceClient.implement[PerCall], CircuitBreaker.identifiedBy("one-cb"))
   }
 
   // --------------------------------------------------------------------------------------------
-  def assertCircuitBreaking(service: Service, expected: CircuitBreaker) = {
+  private def assertCircuitBreaking(service: Service, expected: CircuitBreaker) = {
     val resolved = new ScaladslServiceResolver(DefaultExceptionSerializer.Unresolved).resolve(service.descriptor)
     resolved.calls.head.circuitBreaker should be(Some(expected))
   }
 
   trait Unspecified extends Service {
+
     import Service._
+
     def one: ServiceCall[NotUsed, NotUsed]
+
     override def descriptor: Descriptor = {
-      named("Unspecified").
-        withCalls(
+      named("Unspecified")
+        .withCalls(
           namedCall("one", one)
         )
     }
   }
 
   trait General extends Service {
+
     import Service._
+
     def one: ServiceCall[NotUsed, NotUsed]
+
     override def descriptor: Descriptor = {
-      named(
-        "Unspecified"
-      ).withCalls(
+      named("Unspecified")
+        .withCalls(
           namedCall("one", one)
-        ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
+        )
+        .withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
     }
   }
 
   trait PerCall extends Service {
+
     import Service._
+
     def one: ServiceCall[NotUsed, NotUsed]
+
     override def descriptor: Descriptor = {
-      named(
-        "Unspecified"
-      ).withCalls(
-          namedCall("one", one).withCircuitBreaker(CircuitBreaker.identifiedBy("one-cb")) // overwrites default.
-        ).withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
+      named("Unspecified")
+        .withCalls(
+          namedCall("one", one)
+            .withCircuitBreaker(CircuitBreaker.identifiedBy("one-cb")) // overwrites default.
+        )
+        .withCircuitBreaker(CircuitBreaker.identifiedBy("general-cb"))
     }
   }
 

--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/ServiceClientSpec.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/ServiceClientSpec.scala
@@ -84,7 +84,6 @@ class ServiceClientSpec extends WordSpec with Matchers with Inside {
     }
   }
 
-
 }
 
 trait MockService extends Service {

--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/ServiceClientSpec.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/ServiceClientSpec.scala
@@ -84,22 +84,6 @@ class ServiceClientSpec extends WordSpec with Matchers with Inside {
     }
   }
 
-  object TestServiceClient extends ServiceClientConstructor {
-    override def construct[S <: Service](constructor: (ServiceClientImplementationContext) => S): S = {
-      constructor(new ServiceClientImplementationContext {
-        override def resolve(descriptor: Descriptor): ServiceClientContext = {
-          new ServiceClientContext {
-            override def createServiceCall[Request, Response](methodName: String, params: immutable.Seq[Any]): ServiceCall[Request, Response] = {
-              TestServiceCall(descriptor, methodName, params)
-            }
-            override def createTopic[Message](methodName: String): Topic[Message] = {
-              TestTopic(descriptor, methodName)
-            }
-          }
-        }
-      })
-    }
-  }
 
 }
 

--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/TestServiceClient.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/TestServiceClient.scala
@@ -1,0 +1,24 @@
+package com.lightbend.lagom.scaladsl.client
+
+import com.lightbend.lagom.scaladsl.api.{Descriptor, Service, ServiceCall}
+import com.lightbend.lagom.scaladsl.api.broker.Topic
+
+import scala.collection.immutable
+
+
+object TestServiceClient extends ServiceClientConstructor {
+  override def construct[S <: Service](constructor: (ServiceClientImplementationContext) => S): S = {
+    constructor(new ServiceClientImplementationContext {
+      override def resolve(descriptor: Descriptor): ServiceClientContext = {
+        new ServiceClientContext {
+          override def createServiceCall[Request, Response](methodName: String, params: immutable.Seq[Any]): ServiceCall[Request, Response] = {
+            TestServiceCall(descriptor, methodName, params)
+          }
+          override def createTopic[Message](methodName: String): Topic[Message] = {
+            TestTopic(descriptor, methodName)
+          }
+        }
+      }
+    })
+  }
+}

--- a/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/TestServiceClient.scala
+++ b/service/scaladsl/client/src/test/scala/com/lightbend/lagom/scaladsl/client/TestServiceClient.scala
@@ -1,10 +1,12 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package com.lightbend.lagom.scaladsl.client
 
-import com.lightbend.lagom.scaladsl.api.{Descriptor, Service, ServiceCall}
+import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceCall }
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 
 import scala.collection.immutable
-
 
 object TestServiceClient extends ServiceClientConstructor {
   override def construct[S <: Service](constructor: (ServiceClientImplementationContext) => S): S = {


### PR DESCRIPTION
* adds missing feature in `ScaladslServiceResolver` to ensure all method calls have a CB setup
 * adds test for added feature
 * extracts `TestServiceClient` for reuse in added test.

Fixes #532 