### PR TITLE
Moves additionalConfiguration to last so it has precedence

### DIFF
--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -176,7 +176,7 @@ abstract class LagomApplication(context: LagomApplicationContext)
 
   override implicit lazy val executionContext: ExecutionContext = actorSystem.dispatcher
   override lazy val configuration: Configuration = Configuration.load(environment) ++
-    additionalConfiguration.configuration ++ context.playContext.initialConfiguration
+    context.playContext.initialConfiguration ++ additionalConfiguration.configuration
 
   override lazy val actorSystem: ActorSystem = {
     val (system, stopHook) = ActorSystemProvider.start(configuration, environment, optionalJsonSerializerRegistry)


### PR DESCRIPTION
Fixes #564 

Both `context.playContext.initialConfiguration` and `Configuration.load(environment)` include `akka.cluster.seed-nodes` and both set it to `SimpleConfigList([])` so for this particular issue `additionalConfiguration.configuration` must be listed last.

But user-defined configuration (by means of `application.conf`) is only available on `context.playContext.initialConfiguration` and `Configuration.load(environment)`. So a Component exploiting `additionalConfiguration` could override user-defined config values. I think that's unlikely.

I found that the [Java bundle-lib](https://github.com/typesafehub/conductr-lib/blob/7c5ccf670abf96bbba31901b56e77c219a5af48b/lagom1-java-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/javadsl/ConductRApplicationLoader.scala#L19) also adds ConductR config over `context.initialConfiguration`.

I'm down to two options: (previous comments where just a hunch)

```
Configuration.load(environment) ++
    context.playContext.initialConfiguration ++
    additionalConfiguration.configuration
```
and 

```
context.playContext.initialConfiguration ++
    Configuration.load(environment) ++
    additionalConfiguration.configuration
```

and given the values provided by each config group I'm confident of the committed solution.