### PR TITLE
Created dependency whitelist validation

### DIFF
--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -2,7 +2,7 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-runSbt scalariformFormat test:scalariformFormat mimaCheckOneAtATime
+runSbt scalariformFormat test:scalariformFormat validateDependencies mimaCheckOneAtATime
 
 git diff --exit-code || (
   echo "ERROR: Scalariform check failed, see differences above."

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,11 @@ def common: Seq[Setting[_]] = releaseSettings ++ bintraySettings ++ Seq(
     "-parameters",
     "-Xlint:unchecked",
     "-Xlint:deprecation"
-  )
+  ),
+
+  ScalariformKeys.preferences in Compile  := formattingPreferences,
+  ScalariformKeys.preferences in Test     := formattingPreferences,
+  ScalariformKeys.preferences in MultiJvm := formattingPreferences
 )
 
 def bintraySettings: Seq[Setting[_]] = Seq(
@@ -116,14 +120,13 @@ def releaseSettings: Seq[Setting[_]] = Seq(
 )
 
 def runtimeLibCommon: Seq[Setting[_]] = common ++ Seq(
-  crossScalaVersions := Seq("2.11.8"),
+  crossScalaVersions := Seq(Dependencies.ScalaVersion),
   scalaVersion := crossScalaVersions.value.head,
   crossVersion := CrossVersion.binary,
   crossPaths := false,
 
-  // todo Remove when #528 is done
-  dependencyOverrides += "com.typesafe.akka" %% "akka-actor" % Dependencies.AkkaVersion,
-  dependencyOverrides += "com.typesafe.akka" %% "akka-slf4j" % Dependencies.AkkaVersion,
+  Dependencies.validateDependenciesSetting,
+  Dependencies.dependencyWhitelistSetting,
 
   // compile options
   scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.8", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint", "-deprecation"),
@@ -134,11 +137,7 @@ def runtimeLibCommon: Seq[Setting[_]] = common ++ Seq(
   testOptions in Test += Tests.Argument("-oDF"),
   // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
   // -a Show stack traces and exception class name for AssertionErrors.
-  testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-
-  ScalariformKeys.preferences in Compile  := formattingPreferences,
-  ScalariformKeys.preferences in Test     := formattingPreferences,
-  ScalariformKeys.preferences in MultiJvm := formattingPreferences
+  testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 )
 
 def formattingPreferences = {
@@ -696,7 +695,8 @@ lazy val `persistence-jpa-javadsl` = (project in file("persistence-jpa/javadsl")
   .settings(forkedTests: _*)
   .settings(
     name := "lagom-javadsl-persistence-jpa",
-    Dependencies.`persistence-jpa-javadsl`
+    Dependencies.`persistence-jpa-javadsl`,
+    Dependencies.dependencyWhitelist ++= Dependencies.JpaTestWhitelist
   )
 
 lazy val `broker-javadsl` = (project in file("service/javadsl/broker"))
@@ -770,7 +770,8 @@ lazy val `kafka-broker-javadsl` = (project in file("service/javadsl/kafka/server
   .settings(forkedTests: _*)
   .settings(
     name := "lagom-javadsl-kafka-broker",
-    Dependencies.`kafka-broker-javadsl`
+    Dependencies.`kafka-broker-javadsl`,
+    Dependencies.dependencyWhitelist ++= Dependencies.KafkaTestWhitelist
   )
   .dependsOn(`broker-javadsl`, `kafka-broker`, `kafka-client-javadsl`, `server-javadsl`, `kafka-server` % Test, logback % Test)
 
@@ -780,7 +781,8 @@ lazy val `kafka-broker-scaladsl` = (project in file("service/scaladsl/kafka/serv
   .settings(forkedTests: _*)
   .settings(
     name := "lagom-scaladsl-kafka-broker",
-    Dependencies.`kafka-broker-scaladsl`
+    Dependencies.`kafka-broker-scaladsl`,
+    Dependencies.dependencyWhitelist ++= Dependencies.KafkaTestWhitelist
   )
   .dependsOn(`broker-scaladsl`, `kafka-broker`, `kafka-client-scaladsl`, `server-scaladsl`, `kafka-server` % Test, logback % Test)
 
@@ -1006,19 +1008,21 @@ lazy val `play-integration-javadsl` = (project in file("dev") / "service-registr
   .dependsOn(`service-registry-client-javadsl`)
 
 lazy val `cassandra-server` = (project in file("dev") / "cassandra-server")
-  .settings(runtimeLibCommon: _*)
+  .settings(common: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-cassandra-server",
-    Dependencies.`cassandra-server`
+    Dependencies.`cassandra-server`,
+    scalaVersion := Dependencies.ScalaVersion
   )
 
 lazy val `kafka-server` = (project in file("dev") / "kafka-server")
-  .settings(runtimeLibCommon: _*)
+  .settings(common: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-kafka-server",
-    Dependencies.`kafka-server`
+    Dependencies.`kafka-server`,
+    scalaVersion := Dependencies.ScalaVersion
   )
 
 // Provides macros for testing macros. Is not aggregated or published.

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/ClassLoaders.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/ClassLoaders.scala
@@ -14,7 +14,7 @@ class NamedURLClassLoader(name: String, urls: Array[URL], parent: ClassLoader) e
 }
 
 class DelegatingClassLoader(commonLoader: ClassLoader, sharedClasses: Set[String], buildLoader: ClassLoader,
-    applicationClassLoader: () => Option[ClassLoader]) extends ClassLoader(commonLoader) {
+                            applicationClassLoader: () => Option[ClassLoader]) extends ClassLoader(commonLoader) {
 
   lazy val findResourceMethod = {
     val method = classOf[ClassLoader].getDeclaredMethod("findResource", classOf[String])

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Reloader.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Reloader.scala
@@ -143,7 +143,7 @@ object Reloader {
    * Start the Lagom server without hot reloading
    */
   def startNoReload(parentClassLoader: ClassLoader, dependencyClasspath: Seq[File], buildProjectPath: File,
-    devSettings: Seq[(String, String)], httpPort: Int): DevServer = {
+                    devSettings: Seq[(String, String)], httpPort: Int): DevServer = {
     val buildLoader = this.getClass.getClassLoader
 
     lazy val delegatingLoader: ClassLoader = new DelegatingClassLoader(
@@ -193,13 +193,13 @@ object Reloader {
 import Reloader._
 
 class Reloader(
-    reloadCompile: () => CompileResult,
-    baseLoader: ClassLoader,
-    val projectPath: File,
-    devSettings: Seq[(String, String)],
-    monitoredFiles: Seq[File],
-    fileWatchService: FileWatchService,
-    reloadLock: AnyRef
+  reloadCompile:    () => CompileResult,
+  baseLoader:       ClassLoader,
+  val projectPath:  File,
+  devSettings:      Seq[(String, String)],
+  monitoredFiles:   Seq[File],
+  fileWatchService: FileWatchService,
+  reloadLock:       AnyRef
 ) extends BuildLink {
 
   // The current classloader for the application

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
@@ -86,7 +86,7 @@ private[lagom] object Servers {
     }
 
     def start(log: LoggerProxy, parentClassLoader: ClassLoader, classpath: Array[URL], serviceLocatorPort: Int,
-      serviceGatewayPort: Int, unmanagedServices: Map[String, String]): Unit = synchronized {
+              serviceGatewayPort: Int, unmanagedServices: Map[String, String]): Unit = synchronized {
       if (server == null) {
         withContextClassloader(new java.net.URLClassLoader(classpath, parentClassLoader)) { loader =>
           val serverClass = loader.loadClass("com.lightbend.lagom.discovery.ServiceLocatorServer")

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/MavenFacade.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/MavenFacade.scala
@@ -34,8 +34,8 @@ import scala.collection.JavaConverters._
  */
 @Singleton
 class MavenFacade @Inject() (repoSystem: RepositorySystem, session: MavenSession,
-    buildPluginManager: BuildPluginManager, lifecycleExecutionPlanCalculator: LifecycleExecutionPlanCalculator,
-    logger: MavenLoggerProxy) {
+                             buildPluginManager: BuildPluginManager, lifecycleExecutionPlanCalculator: LifecycleExecutionPlanCalculator,
+                             logger: MavenLoggerProxy) {
 
   /**
    * Resolve the classpath for the given artifact.
@@ -168,7 +168,7 @@ class MavenFacade @Inject() (repoSystem: RepositorySystem, session: MavenSession
 
   private def isLagomOrPlayService(project: MavenProject): Option[Boolean] = {
     LagomKeys.LagomService.get(project).flatMap {
-      case true => Some(true)
+      case true  => Some(true)
       case false => LagomKeys.PlayService.get(project)
     }
   }

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
@@ -128,7 +128,7 @@ class StopKafkaMojo @Inject() (logger: MavenLoggerProxy) extends LagomAbstractMo
 }
 
 class StartServiceLocatorMojo @Inject() (logger: MavenLoggerProxy, facade: MavenFacade,
-    scalaClassLoaderManager: ScalaClassLoaderManager) extends LagomAbstractMojo {
+                                         scalaClassLoaderManager: ScalaClassLoaderManager) extends LagomAbstractMojo {
 
   @BeanProperty
   var serviceLocatorEnabled: Boolean = _

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceManager.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceManager.scala
@@ -27,7 +27,7 @@ import scala.util.control.NonFatal
  */
 @Singleton
 class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession, facade: MavenFacade,
-    scalaClassLoaderManager: ScalaClassLoaderManager) {
+                                scalaClassLoaderManager: ScalaClassLoaderManager) {
 
   private var runningServices = Map.empty[MavenProject, DevServer]
   private var runningExternalProjects = Map.empty[Dependency, DevServer]
@@ -45,7 +45,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
   }
 
   private def calculateDevModeDependencies(scalaBinaryVersion: String, playService: Boolean,
-    serviceLocatorUrl: Option[String], cassandraPort: Option[Int]): Seq[Dependency] = {
+                                           serviceLocatorUrl: Option[String], cassandraPort: Option[Int]): Seq[Dependency] = {
     if (playService) {
       devModeDependencies(scalaBinaryVersion, Seq("lagom-play-integration", "lagom-reloadable-server"))
     } else {
@@ -74,7 +74,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
   }
 
   def startServiceDevMode(project: MavenProject, port: Int, serviceLocatorUrl: Option[String],
-    cassandraPort: Option[Int], cassandraKeyspace: String, playService: Boolean, additionalWatchDirs: Seq[File]): Unit = synchronized {
+                          cassandraPort: Option[Int], cassandraKeyspace: String, playService: Boolean, additionalWatchDirs: Seq[File]): Unit = synchronized {
     runningServices.get(project) match {
       case Some(service) =>
         logger.info("Service " + project.getArtifactId + " already running!")
@@ -179,12 +179,12 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
   def stopService(project: MavenProject) = synchronized {
     runningServices.get(project) match {
       case Some(service) => service.close()
-      case None => logger.info("Service " + project.getArtifactId + " was not running!")
+      case None          => logger.info("Service " + project.getArtifactId + " was not running!")
     }
   }
 
   def startExternalProject(dependency: Dependency, port: Int, serviceLocatorUrl: Option[String],
-    cassandraPort: Option[Int], cassandraKeyspace: String, playService: Boolean) = synchronized {
+                           cassandraPort: Option[Int], cassandraKeyspace: String, playService: Boolean) = synchronized {
     runningExternalProjects.get(dependency) match {
       case Some(service) =>
         logger.info("External project " + dependency.getArtifact.getArtifactId + " already running!")
@@ -219,7 +219,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
   def stopExternalProject(dependency: Dependency) = synchronized {
     runningExternalProjects.get(dependency) match {
       case Some(service) => service.close()
-      case None => logger.info("Service " + dependency.getArtifact.getArtifactId + " was not running!")
+      case None          => logger.info("Service " + dependency.getArtifact.getArtifactId + " was not running!")
     }
   }
 
@@ -232,7 +232,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
       val artifact = dep.getArtifact
       val projectKey = ArtifactUtils.key(artifact.getGroupId, artifact.getArtifactId, artifact.getVersion)
       session.getProjectMap.get(projectKey) match {
-        case null => Left(dep)
+        case null       => Left(dep)
         case projectDep => Right(projectDep)
       }
     }

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceMojos.scala
@@ -96,8 +96,8 @@ class StartMojo @Inject() (serviceManager: ServiceManager, session: MavenSession
     }
 
     val serviceLocatorUrl = (serviceLocatorEnabled, this.serviceLocatorUrl) match {
-      case (false, _) => None
-      case (true, null) => Some(s"http://localhost:$serviceLocatorPort")
+      case (false, _)         => None
+      case (true, null)       => Some(s"http://localhost:$serviceLocatorPort")
       case (true, configured) => Some(configured)
     }
 
@@ -173,8 +173,8 @@ class StartExternalProjects @Inject() (serviceManager: ServiceManager, session: 
   override def execute(): Unit = {
 
     val serviceLocatorUrl = (serviceLocatorEnabled, this.serviceLocatorUrl) match {
-      case (false, _) => None
-      case (true, null) => Some(s"http://localhost:$serviceLocatorPort")
+      case (false, _)         => None
+      case (true, null)       => Some(s"http://localhost:$serviceLocatorPort")
       case (true, configured) => Some(configured)
     }
 

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/run/RunSupport.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/run/RunSupport.scala
@@ -104,7 +104,7 @@ private[sbt] object RunSupport {
 
   def getScopedKey(incomplete: Incomplete): Option[ScopedKey[_]] = incomplete.node flatMap {
     case key: ScopedKey[_] => Option(key)
-    case task: Task[_] => task.info.attributes get taskDefinitionKey
+    case task: Task[_]     => task.info.attributes get taskDefinitionKey
   }
 
   def getProblems(incomplete: Incomplete, streams: Option[Streams]): Seq[xsbti.Problem] = {
@@ -161,7 +161,7 @@ private[sbt] object RunSupport {
   def problems(es: Seq[Throwable]): Seq[xsbti.Problem] = {
     es flatMap {
       case cf: xsbti.CompileFailed => cf.problems
-      case _ => Nil
+      case _                       => Nil
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   // Version numbers
   val PlayVersion = "2.5.13"
   val AkkaVersion = "2.4.17"
+  val ScalaVersion = "2.11.8"
   val AkkaPersistenceCassandraVersion = "0.22"
   val ScalaTestVersion = "3.0.1"
   val JacksonVersion = "2.7.8"
@@ -14,31 +15,259 @@ object Dependencies {
   val MavenVersion = "3.3.9"
   val NettyVersion = "4.0.42.Final"
   val KafkaVersion = "0.10.0.1"
-  val AkkaStreamKafka = "0.13"
+  val AkkaStreamKafkaVersion = "0.13"
   val Log4j = "1.2.17"
   val ScalaJava8CompatVersion = "0.7.0"
+  val ScalaXmlVersion = "1.0.5"
 
   // Specific libraries that get reused
-  val scalaTest = "org.scalatest" %% "scalatest" % ScalaTestVersion
-  val guava = "com.google.guava" % "guava" % GuavaVersion
-  val log4J = "log4j" % "log4j" % Log4j
-  val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % ScalaJava8CompatVersion
+  private val scalaTest = "org.scalatest" %% "scalatest" % ScalaTestVersion
+  private val guava = "com.google.guava" % "guava" % GuavaVersion
+  private val log4J = "log4j" % "log4j" % Log4j
+  private val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % ScalaJava8CompatVersion
+  private val scalaXml = "org.scala-lang.modules" %% "scala-xml" % ScalaXmlVersion
+  private val jbossLogging = "org.jboss.logging" % "jboss-logging" % "3.3.0.Final"
 
+  private val akkaActor = "com.typesafe.akka" %% "akka-actor" % AkkaVersion
+  private val akkaCluster = "com.typesafe.akka" %% "akka-cluster" % AkkaVersion
+  private val akkaClusterSharding = "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion
+  private val akkaClusterTools = "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion
+  private val akkaMultiNodeTestkit = "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion
+  private val akkaPersistence = "com.typesafe.akka" %% "akka-persistence" % AkkaVersion
+  private val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query-experimental" % AkkaVersion
+  private val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion
+  private val akkaStream = "com.typesafe.akka" %% "akka-stream" % AkkaVersion
+  private val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion
+  private val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
+
+  private val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion
+  private val akkaStreamKafka = "com.typesafe.akka" %% "akka-stream-kafka" % AkkaStreamKafkaVersion
+
+  private val play = "com.typesafe.play" %% "play" % PlayVersion
+  private val playBuildLink = "com.typesafe.play" % "build-link" % PlayVersion
+  private val playExceptions =  "com.typesafe.play" % "play-exceptions" % PlayVersion
+  private val playJava = "com.typesafe.play" %% "play-java" % PlayVersion
+  private val playJdbc = "com.typesafe.play" %% "play-jdbc" % PlayVersion
+  private val playJson = "com.typesafe.play" %% "play-json" % PlayVersion
+  private val playNettyServer = "com.typesafe.play" %% "play-netty-server" % PlayVersion
+  private val playServer = "com.typesafe.play" %% "play-server" % PlayVersion
+  private val playWs = "com.typesafe.play" %% "play-ws" % PlayVersion
+
+  // A whitelist of dependencies that Lagom is allowed to depend on, either directly or transitively.
+  // This list is used to validate all of Lagom's dependencies.
+  // By maintaining this whitelist, we can be absolutely sure of what we depend on, that we consistently depend on the
+  // same versions of libraries across our modules, we can ensure also that we have no partial upgrades of families of
+  // libraries (such as Play or Akka), and we will also be alerted when a transitive dependency is upgraded (because
+  // the validation task will fail) which means we can manually check that it is safe to upgrade that dependency.
+  val DependencyWhitelist: Def.Initialize[Seq[ModuleID]] = Def.setting {
+    val scalaVersion = Keys.scalaVersion.value
+
+    Seq(
+      "aopalliance" % "aopalliance" % "1.0",
+      "com.addthis.metrics" % "reporter-config-base" % "3.0.0",
+      "com.addthis.metrics" % "reporter-config3" % "3.0.0",
+      "com.boundary" % "high-scale-lib" % "1.0.6",
+      "com.clearspring.analytics" % "stream" % "2.5.2",
+      "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.0",
+      "com.fasterxml" % "classmate" % "1.3.0",
+      "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
+      "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.6.8",
+      "com.github.jbellis" % "jamm" % "0.3.0",
+      "com.github.jnr" % "jffi" % "1.2.10",
+      "com.github.jnr" % "jffi" % "1.2.10",
+      "com.github.jnr" % "jnr-constants" % "0.9.0",
+      "com.github.jnr" % "jnr-ffi" % "2.0.7",
+      "com.github.jnr" % "jnr-posix" % "3.0.27",
+      "com.github.jnr" % "jnr-x86asm" % "1.0.2",
+      "com.google.code.findbugs" % "jsr305" % "3.0.1",
+      "com.google.guava" % "guava" % GuavaVersion,
+      "com.google.inject" % "guice" % "4.0",
+      "com.google.inject.extensions" % "guice-assistedinject" % "4.0",
+      "com.googlecode.concurrentlinkedhashmap" % "concurrentlinkedhashmap-lru" % "1.4",
+      "com.googlecode.json-simple" % "json-simple" % "1.1",
+      "com.googlecode.usc" % "jdbcdslog" % "1.0.6.2",
+      "com.h2database" % "h2" % "1.4.192",
+      "com.jolbox" % "bonecp" % "0.8.0.RELEASE",
+      "com.lmax" % "disruptor" % "3.3.6",
+      "com.ning" % "compress-lzf" % "0.8.4",
+      "com.novocode" % "junit-interface" % "0.11",
+      "com.thinkaurelius.thrift" % "thrift-server" % "0.3.7",
+      "com.typesafe" % "config" % "1.3.0",
+      "com.typesafe" %% "ssl-config-core" % "0.2.1",
+      akkaStreamKafka,
+      akkaPersistenceCassandra,
+      "com.typesafe.netty" % "netty-reactive-streams" % "1.0.8",
+      "com.typesafe.netty" % "netty-reactive-streams-http" % "1.0.8",
+      "com.typesafe.play" %% "twirl-api" % "1.1.1",
+      "com.typesafe.slick" %% "slick" % "3.1.1",
+      "com.typesafe.slick" %% "slick-hikaricp" % "3.1.1",
+      "com.zaxxer" % "HikariCP" % "2.5.1",
+      "commons-cli" % "commons-cli" % "1.1",
+      "commons-codec" % "commons-codec" % "1.10",
+      "commons-logging" % "commons-logging" % "1.1.1",
+      "io.aeron" % "aeron-client" % "1.1.0",
+      "io.aeron" % "aeron-driver" % "1.1.0",
+      "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
+      "io.dropwizard.metrics" % "metrics-jvm" % "3.1.0",
+      // Netty 3 uses a different package to Netty 4, and a different artifact ID, so can safely coexist
+      "io.netty" % "netty" % "3.10.6.Final",
+      "it.unimi.dsi" % "fastutil" % "6.5.7",
+      "javax.el" % "javax.el-api" % "3.0.0",
+      "javax.inject" % "javax.inject" % "1",
+      "javax.transaction" % "jta" % "1.1",
+      "javax.validation" % "validation-api" % "1.1.0.Final",
+      "joda-time" % "joda-time" % "2.9.6",
+      "junit" % "junit" % "4.11",
+      "net.java.dev.jna" % "jna" % "4.0.0",
+      "net.jodah" % "typetools" % "0.4.4",
+      "net.jpountz.lz4" % "lz4" % "1.3.0",
+      "oauth.signpost" % "signpost-commonshttp4" % "1.2.1.2",
+      "oauth.signpost" % "signpost-core" % "1.2.1.2",
+      "org.agrona" % "agrona" % "0.9.2",
+      "org.antlr" % "ST4" % "4.0.8",
+      "org.antlr" % "antlr" % "3.5.2",
+      "org.antlr" % "antlr-runtime" % "3.5.2",
+      "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion,
+      "org.apache.cassandra" % "cassandra-thrift" % CassandraAllVersion,
+      "org.apache.commons" % "commons-lang3" % "3.4",
+      "org.apache.commons" % "commons-math3" % "3.2",
+      "org.apache.httpcomponents" % "httpclient" % "4.2.5",
+      "org.apache.httpcomponents" % "httpcore" % "4.2.4",
+      "org.apache.kafka" % "kafka-clients" % "0.10.0.1",
+      "org.apache.thrift" % "libthrift" % "0.9.2",
+      "org.apache.tomcat" % "tomcat-servlet-api" % "8.0.33",
+      "org.caffinitas.ohc" % "ohc-core" % "0.4.3",
+      "org.codehaus.jackson" % "jackson-core-asl" % "1.9.2",
+      "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.2",
+      "org.eclipse.jdt.core.compiler" % "ecj" % "4.4.2",
+      "org.fusesource" % "sigar" % "1.6.4",
+      "org.hibernate" % "hibernate-validator" % "5.2.4.Final",
+      "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final",
+      "org.immutables" % "value" % "2.3.2",
+      "org.javassist" % "javassist" % "3.20.0-GA",
+      jbossLogging,
+      "org.joda" % "joda-convert" % "1.8.1",
+      "org.hamcrest" % "hamcrest-core" % "1.3",
+      "org.mindrot" % "jbcrypt" % "0.3m",
+      "org.pcollections" % "pcollections" % "2.1.2",
+      "org.reactivestreams" % "reactive-streams" % "1.0.0",
+      "org.reflections" % "reflections" % "0.9.10",
+      "org.scalactic" %% "scalactic" % ScalaTestVersion,
+      "org.scalatest" %% "scalatest" % ScalaTestVersion,
+      "org.scala-lang.modules" %% "scala-java8-compat" % ScalaJava8CompatVersion,
+      "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
+      scalaXml,
+      "org.scala-sbt" % "test-interface" % "1.0",
+      "org.scala-stm" %% "scala-stm" % "0.7",
+      "org.springframework" % "spring-beans" % "4.2.7.RELEASE",
+      "org.springframework" % "spring-context" % "4.2.7.RELEASE",
+      "org.springframework" % "spring-core" % "4.2.7.RELEASE",
+      "org.uncommons.maths" % "uncommons-maths" % "1.2.2a",
+      "org.xerial.snappy" % "snappy-java" % "1.1.2.6",
+      "org.yaml" % "snakeyaml" % "1.16",
+      "tyrex" % "tyrex" % "1.0.1",
+      "xerces" % "xercesImpl" % "2.11.0",
+      "xml-apis" % "xml-apis" % "1.4.01"
+
+    ) ++ libraryFamily("com.fasterxml.jackson.core", JacksonVersion)(
+      "jackson-annotations", "jackson-core", "jackson-databind"
+
+    ) ++ libraryFamily("com.fasterxml.jackson.datatype", JacksonVersion)(
+      "jackson-datatype-jdk8", "jackson-datatype-jsr310", "jackson-datatype-guava", "jackson-datatype-pcollections"
+
+    ) ++ crossLibraryFamily("com.typesafe.akka", AkkaVersion)(
+      "akka-actor", "akka-cluster", "akka-cluster-sharding", "akka-cluster-tools", "akka-multi-node-testkit",
+      "akka-persistence", "akka-persistence-query-experimental", "akka-protobuf", "akka-remote", "akka-slf4j",
+      "akka-stream", "akka-stream-testkit", "akka-testkit"
+
+    ) ++ libraryFamily("com.typesafe.play", PlayVersion)(
+      "build-link", "play-exceptions", "play-netty-utils"
+
+    ) ++ crossLibraryFamily("com.typesafe.play", PlayVersion)(
+      "play", "play-datacommons", "play-functional", "play-iteratees", "play-java", "play-jdbc", "play-jdbc-api",
+      "play-json", "play-netty-server", "play-server", "play-streams", "play-ws"
+
+    ) ++ libraryFamily("ch.qos.logback", "1.1.3")(
+      "logback-classic", "logback-core"
+
+    ) ++ libraryFamily("io.netty", NettyVersion)(
+      "netty-buffer", "netty-codec", "netty-codec-http", "netty-common", "netty-handler", "netty-transport",
+      "netty-transport-native-epoll"
+
+    ) ++ libraryFamily("org.apache.logging.log4j", "2.7")(
+      "log4j-api", "log4j-core", "log4j-slf4j-impl"
+
+    ) ++ libraryFamily("org.asynchttpclient", "2.0.11")(
+      "async-http-client", "netty-codec-dns", "netty-resolver", "netty-resolver-dns"
+
+    ) ++ libraryFamily("org.ow2.asm", "5.0.3")(
+      "asm", "asm-analysis", "asm-commons", "asm-tree", "asm-util"
+
+    ) ++ libraryFamily("org.scala-lang", scalaVersion)(
+      "scala-library", "scala-reflect"
+
+    ) ++ libraryFamily("org.slf4j", "1.7.21")(
+      "jcl-over-slf4j", "jul-to-slf4j", "log4j-over-slf4j", "slf4j-api"
+    )
+  }
+
+  // These dependencies are used by JPA to test, but we don't want to export them as part of our regular whitelist,
+  // so we maintain it separately.
+  val JpaTestWhitelist = Seq(
+    "antlr" % "antlr" % "2.7.7",
+    "dom4j" % "dom4j" % "1.6.1",
+    "javax.annotation" % "jsr250-api" % "1.0",
+    "javax.el" % "el-api" % "2.2",
+    "javax.enterprise" % "cdi-api" % "1.1",
+    "org.apache.geronimo.specs" % "geronimo-jta_1.1_spec" % "1.1.1",
+    "org.hibernate" % "hibernate-core" % "5.2.5.Final",
+    "org.hibernate.common" % "hibernate-commons-annotations" % "5.0.1.Final",
+    "org.jboss" % "jandex" % "2.0.3.Final",
+    "org.jboss.spec.javax.interceptor" % "jboss-interceptors-api_1.1_spec" % "1.0.0.Beta1"
+  )
+
+  // These dependencies are used by the Kafka tests, but we don't want to export them as part of our regular
+  // whitelist, so we maintain it separately.
+  val KafkaTestWhitelist = Seq(
+    "com.101tec" % "zkclient" % "0.8",
+    "com.yammer.metrics" % "metrics-core" % "2.2.0",
+    "jline" % "jline" % "0.9.94",
+    "log4j" % "log4j" % "1.2.17",
+    "net.sf.jopt-simple" % "jopt-simple" % "4.9",
+    "org.apache.commons" % "commons-math" % "2.2",
+    "org.apache.curator" % "curator-client" % "2.10.0",
+    "org.apache.curator" % "curator-framework" % "2.10.0",
+    "org.apache.curator" % "curator-test" % "2.10.0",
+    "org.apache.kafka" %% "kafka" % "0.10.0.1",
+    "org.apache.zookeeper" % "zookeeper" % "3.4.6"
+  )
+
+  private def crossLibraryFamily(groupId: String, version: String)(artifactIds: String*) = {
+    artifactIds.map(aid => groupId %% aid % version)
+  }
+
+  private def libraryFamily(groupId: String, version: String)(artifactIds: String*) = {
+    artifactIds.map(aid => groupId % aid % version)
+  }
 
   // Dependencies for each module
   val api = libraryDependencies ++= Seq(
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4",
-    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-    "com.typesafe.play" %% "play" % PlayVersion
+    scalaXml,
+    akkaActor,
+    akkaSlf4j,
+    akkaStream,
+    play,
+    guava
   )
 
   val `api-javadsl` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-java" % PlayVersion,
-    // todo Remove as part of #530
-    guava,
+    playJava,
     "org.pcollections" % "pcollections" % "2.1.2",
+    // Needed to upgrade from 3.18 to ensure everything is on 3.20
+    "org.javassist" % "javassist" % "3.20.0-GA",
+    "com.fasterxml" % "classmate" % "1.3.0",
+    jbossLogging,
     scalaTest % Test,
     "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion % Test
   )
@@ -59,26 +288,43 @@ object Dependencies {
     "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % JacksonVersion,
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % JacksonVersion,
     "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonVersion,
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
+    akkaTestkit % Test,
     scalaTest % Test,
-    "com.novocode" % "junit-interface" % "0.11" % "test"
+    "com.novocode" % "junit-interface" % "0.11" % Test
   )
 
   val `play-json` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-json" % PlayVersion,
-    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
+    playJson,
+    akkaActor,
+    akkaTestkit % Test,
     scalaTest % Test
   )
 
   val `api-tools` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play" % PlayVersion,
-    scalaTest % Test
+    play,
+    scalaTest % Test,
+
+    // Upgrades for Play dependencies
+    akkaActor,
+    akkaSlf4j,
+    akkaStream,
+    scalaXml,
+    guava,
+    jbossLogging
   )
 
   val client = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-ws" % PlayVersion,
-    "io.dropwizard.metrics" % "metrics-core" % "3.1.2"
+    playWs,
+    "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
+
+    // Needed to match whitelist versions
+    "io.netty" % "netty-codec-http" % NettyVersion,
+    "io.netty" % "netty-transport-native-epoll" % NettyVersion,
+    "com.typesafe.netty" % "netty-reactive-streams" % "1.0.8",
+    // These are required by signpost, which are required by play-ws. Can be removed when
+    // https://github.com/playframework/playframework/issues/5905 is fixed.
+    "org.apache.httpcomponents" % "httpclient" % "4.2.5",
+    "org.apache.httpcomponents" % "httpcore" % "4.2.4"
   )
 
   val `client-javadsl` = libraryDependencies ++= Nil
@@ -91,108 +337,144 @@ object Dependencies {
 
   val server = libraryDependencies ++= Seq(
     // todo probably not needed when #530 is done
-    "com.typesafe.akka" %% "akka-actor" % AkkaVersion
+    akkaActor
   )
 
   val `server-javadsl` = libraryDependencies ++= Seq(
     // todo probably not needed when #530 is done
-    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+    akkaActor,
     guava
   )
 
   val `server-scaladsl` = libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
+    akkaActor,
     scalaTest % Test
   )
 
   val `testkit-core` = libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-stream" % AkkaVersion
+    akkaActor,
+    akkaStream
   )
 
   val `testkit-javadsl` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-netty-server" % PlayVersion,
+    playNettyServer,
     "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion exclude("io.netty", "netty-all"),
-    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
+    akkaStream,
+    akkaStreamTestkit,
+    akkaPersistenceCassandra,
     scalaTest % Test,
-    scalaJava8Compat
+    scalaJava8Compat,
+    "junit" % "junit" % "4.11",
+
+    // These deps are depended on by cassandra-all, and need to be upgraded in order to be consistent with transitive
+    // dependencies from our other libraries
+    "com.lmax" % "disruptor" % "3.3.6",
+    "javax.validation" % "validation-api" % "1.1.0.Final",
+    "org.hibernate" % "hibernate-validator" % "5.2.4.Final",
+    "org.slf4j" % "log4j-over-slf4j" % "1.7.21",
+    "org.xerial.snappy" % "snappy-java" % "1.1.2.6",
+    "org.yaml" % "snakeyaml" % "1.16"
   )
 
   val `testkit-scaladsl` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-netty-server" % PlayVersion,
+    playNettyServer,
     "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion exclude("io.netty", "netty-all"),
-    "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-    scalaTest % Test
+    akkaStreamTestkit,
+    akkaPersistenceCassandra,
+    scalaTest % Test,
+    "junit" % "junit" % "4.11",
+
+    // These deps are depended on by cassandra-all, and need to be upgraded in order to be consistent with transitive
+    // dependencies from our other libraries
+    "com.lmax" % "disruptor" % "3.3.6",
+    "javax.validation" % "validation-api" % "1.1.0.Final",
+    "org.hibernate" % "hibernate-validator" % "5.2.4.Final",
+    jbossLogging,
+    "org.slf4j" % "log4j-over-slf4j" % "1.7.21",
+    "org.xerial.snappy" % "snappy-java" % "1.1.2.6",
+    "org.yaml" % "snakeyaml" % "1.16",
+    "com.fasterxml" % "classmate" % "1.3.0"
   )
 
   val `integration-tests-javadsl` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-netty-server" % PlayVersion,
-    "com.novocode" % "junit-interface" % "0.11" % "test",
+    playNettyServer,
+    "com.novocode" % "junit-interface" % "0.11" % Test,
     scalaTest
   )
 
   val `integration-tests-scaladsl` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-netty-server" % PlayVersion,
-    "com.novocode" % "junit-interface" % "0.11" % "test",
+    playNettyServer,
+    "com.novocode" % "junit-interface" % "0.11" % Test,
     scalaTest
   )
 
   val `cluster-core` = libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-cluster" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
+    akkaCluster,
+    akkaTestkit % Test,
     scalaTest % Test,
-    "com.novocode" % "junit-interface" % "0.11" % "test"
+    "com.novocode" % "junit-interface" % "0.11" % Test
   )
 
   val `cluster-javadsl` = libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % "test",
+    akkaTestkit % Test,
+    akkaMultiNodeTestkit % Test,
     scalaJava8Compat,
     scalaTest % Test,
-    "com.novocode" % "junit-interface" % "0.11" % "test",
+    "com.novocode" % "junit-interface" % "0.11" % Test,
     "com.google.inject" % "guice" % "4.0"
   )
 
   val `cluster-scaladsl` = libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % "test",
+    akkaTestkit % Test,
+    akkaMultiNodeTestkit % Test,
     scalaTest % Test,
-    "com.novocode" % "junit-interface" % "0.11" % "test"
+    "com.novocode" % "junit-interface" % "0.11" % Test
   )
 
   val `pubsub-javadsl` = libraryDependencies ++= Seq(
     "com.google.inject" % "guice" % "4.0",
-    "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,
+    akkaClusterTools,
     scalaJava8Compat,
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % "test",
+    akkaTestkit % Test,
+    akkaMultiNodeTestkit % Test,
+    akkaStreamTestkit % Test,
     scalaTest % Test,
-    "com.novocode" % "junit-interface" % "0.11" % "test"
+    "com.novocode" % "junit-interface" % "0.11" % Test
   )
 
   val `pubsub-scaladsl` = libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % "test",
+    akkaClusterTools,
+    akkaTestkit % Test,
+    akkaMultiNodeTestkit % Test,
+    akkaStreamTestkit % Test,
     scalaTest % Test
   )
 
   val `persistence-core` = libraryDependencies ++= Seq(
     scalaJava8Compat,
-    "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-persistence-query-experimental" % AkkaVersion,
-    "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion,
-    "com.typesafe.play" %% "play" % PlayVersion,
-    "com.typesafe.akka" %% "akka-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % "test",
-    "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % "test",
+    scalaXml,
+    guava,
+    akkaPersistence,
+    akkaPersistenceQuery,
+    akkaClusterSharding,
+    akkaSlf4j,
+    play,
+    akkaTestkit % Test,
+    akkaMultiNodeTestkit % Test,
+    akkaStreamTestkit % Test,
     scalaTest % Test,
-    "com.novocode" % "junit-interface" % "0.11" % "test"
+    "com.novocode" % "junit-interface" % "0.11" % Test,
+
+    // These dependencies get upgraded in Test so that we can ensure that our tests are using the same dependencies
+    // as the users will have in their tests
+    "com.lmax" % "disruptor" % "3.3.6" % Test,
+    "javax.validation" % "validation-api" % "1.1.0.Final" % Test,
+    "org.hibernate" % "hibernate-validator" % "5.2.4.Final" % Test,
+    jbossLogging % Test,
+    "org.slf4j" % "log4j-over-slf4j" % "1.7.21" % Test,
+    "org.xerial.snappy" % "snappy-java" % "1.1.2.6" % Test,
+    "org.yaml" % "snakeyaml" % "1.16" % Test,
+    "com.fasterxml" % "classmate" % "1.3.0" % Test
   )
 
   val `persistence-javadsl` = libraryDependencies ++= Nil
@@ -200,10 +482,18 @@ object Dependencies {
   val `persistence-scaladsl` = libraryDependencies ++= Nil
 
   val `persistence-cassandra-core` = libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-    "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion % "test" exclude("io.netty", "netty-all"),
-    "io.netty" % "netty-codec-http" % NettyVersion % "test",
-    "io.netty" % "netty-transport-native-epoll" % NettyVersion % "test" classifier "linux-x86_64"
+    akkaPersistenceCassandra,
+
+    // cassandra-driver-core pulls in an older version of all these
+    "io.netty" % "netty-buffer" % NettyVersion,
+    "io.netty" % "netty-codec" % NettyVersion,
+    "io.netty" % "netty-common" % NettyVersion,
+    "io.netty" % "netty-handler" % NettyVersion,
+    "io.netty" % "netty-transport" % NettyVersion,
+
+    "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion % Test exclude("io.netty", "netty-all"),
+    "io.netty" % "netty-codec-http" % NettyVersion % Test,
+    "io.netty" % "netty-transport-native-epoll" % NettyVersion % Test classifier "linux-x86_64"
   )
 
   val `persistence-cassandra-javadsl` = libraryDependencies ++= Nil
@@ -212,7 +502,7 @@ object Dependencies {
 
   val `persistence-jdbc-core` = libraryDependencies ++= Seq(
     "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.6.8",
-    "com.typesafe.play" %% "play-jdbc" % PlayVersion
+    playJdbc
   )
 
   val `persistence-jdbc-javadsl` = libraryDependencies ++= Nil
@@ -230,8 +520,7 @@ object Dependencies {
 
   val `kafka-client` = libraryDependencies ++= Seq(
     "org.slf4j" % "log4j-over-slf4j" % "1.7.21",
-    "com.typesafe.akka" %% "akka-stream-kafka" % AkkaStreamKafka exclude("org.slf4j","slf4j-log4j12"),
-    "org.apache.kafka" %% "kafka" % KafkaVersion exclude("org.slf4j","slf4j-log4j12") exclude("javax.jms", "jms") exclude("com.sun.jdmk", "jmxtools") exclude("com.sun.jmx", "jmxri"),
+    akkaStreamKafka exclude("org.slf4j", "slf4j-log4j12"),
     scalaTest % Test
   )
 
@@ -242,16 +531,25 @@ object Dependencies {
   val `kafka-broker` = libraryDependencies ++= Nil
 
   val `kafka-broker-javadsl` = libraryDependencies ++= Seq(
-    scalaTest % Test
+    scalaTest % Test,
+    "junit" % "junit" % "4.11" % Test
   )
 
   val `kafka-broker-scaladsl` = libraryDependencies ++= Seq(
-    scalaTest % Test
+    scalaTest % Test,
+    "junit" % "junit" % "4.11" % Test
   )
 
   val logback = libraryDependencies ++= Seq(
     // needed only because we use play.utils.Colors
-    "com.typesafe.play" %% "play" % PlayVersion
+    play,
+
+    // Upgrades for Play libraries
+    akkaActor,
+    akkaSlf4j,
+    akkaStream,
+    scalaXml,
+    guava
   ) ++ Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % "1.1.3")
 
   val log4j2 = libraryDependencies ++= Seq(
@@ -260,17 +558,31 @@ object Dependencies {
     "log4j-slf4j-impl"
   ).map("org.apache.logging.log4j" % _ % "2.7") ++ Seq(
     "com.lmax" % "disruptor" % "3.3.6",
-    "com.typesafe.play" %% "play" % PlayVersion
+    play,
+
+    // Upgrades for Play dependencies
+    akkaActor,
+    akkaSlf4j,
+    akkaStream,
+    scalaXml,
+    guava
   )
 
   val `build-link` = libraryDependencies ++= Seq(
-    "com.typesafe.play" % "play-exceptions" % PlayVersion,
-    "com.typesafe.play" % "build-link" % PlayVersion
+    playExceptions,
+    playBuildLink
   )
 
   val `reloadable-server` = libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play" % PlayVersion,
-    "com.typesafe.play" %% "play-server" % PlayVersion
+    play,
+    playServer,
+
+    // Upgrades for Play dependencies
+    akkaActor,
+    akkaSlf4j,
+    akkaStream,
+    guava,
+    scalaXml
   )
 
   val `build-tool-support` = libraryDependencies ++= Seq(
@@ -310,8 +622,8 @@ object Dependencies {
 
   val `service-locator` = libraryDependencies ++= Seq(
     // Explicit akka dependency because maven chooses the wrong version
-    "com.typesafe.akka" %% "akka-actor" % AkkaVersion,
-    "com.typesafe.play" %% "play-netty-server" % PlayVersion,
+    akkaActor,
+    playNettyServer,
     // Need to upgrade Netty due to encountering this deadlock in the service gateway
     // https://github.com/netty/netty/pull/5110
     "io.netty" % "netty-codec-http" % NettyVersion,
@@ -332,14 +644,14 @@ object Dependencies {
     // all netty transitive dependencies of akka-persistence-cassandra. Mind that dependencies are
     // excluded one-by-one because exclusion rules do not work with maven dependency resolution - see
     // https://github.com/lagom/lagom/issues/26#issuecomment-196718818
-    "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion
+    akkaPersistenceCassandra
       exclude("io.netty", "netty-all") exclude("io.netty", "netty-handler") exclude("io.netty", "netty-buffer")
       exclude("io.netty", "netty-common") exclude("io.netty", "netty-transport") exclude("io.netty", "netty-codec"),
     "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion
   )
 
   val `kafka-server` = libraryDependencies ++= Seq(
-    "org.apache.kafka" %% "kafka" % KafkaVersion,
+    "org.apache.kafka" %% "kafka" % KafkaVersion exclude("org.slf4j", "slf4j-log4j12"),
     // log4j version prior to 1.2.17 required javax.jms, and that artifact could not properly resolved when using maven
     // without adding a resolver. The problem doesn't appear with sbt because the log4j version brought by both zookeeper
     // and curator dependencies are evicted to version 1.2.17. Unfortunately, because of how maven resolution works, we
@@ -356,4 +668,68 @@ object Dependencies {
     scalaJava8Compat,
     scalaTest % Test
   )
+
+  val validateDependencies = taskKey[Unit]("Validate Lagom dependencies to ensure they are whitelisted")
+  val dependencyWhitelist = settingKey[Seq[ModuleID]]("The whitelist of dependencies")
+
+  val validateDependenciesTask: Def.Initialize[Task[Unit]] = Def.task {
+    // We validate compile dependencies to ensure that whatever we are exporting, we are exporting the right
+    // versions. We validate test dependencies to ensure that our tests run against the same versions that we are
+    // exporting
+    val compileClasspath = (managedClasspath in Compile).value
+    val testClasspath = (managedClasspath in Test).value
+    val cross = CrossVersion(scalaVersion.value, scalaBinaryVersion.value)
+    val log = streams.value.log
+    val svb = scalaBinaryVersion.value
+
+    val whitelist = dependencyWhitelist.value.map { moduleId =>
+      val crossModuleId = cross(moduleId)
+      (crossModuleId.organization, crossModuleId.name) -> crossModuleId.revision
+    }.toMap
+
+    def collectProblems(scope: String, classpath: Classpath) = {
+      classpath.collect(Function.unlift { dep =>
+        val moduleId = dep.get(moduleID.key).getOrElse {
+          sys.error(s"Managed classpath dependency without moduleID: $dep")
+        }
+
+        whitelist.get((moduleId.organization, moduleId.name)) match {
+          case None =>
+            Some(moduleId -> s"$scope dependency not in whitelist: $moduleId")
+          case Some(unmatched) if moduleId.revision != unmatched =>
+            Some(moduleId -> s"$scope dependency ${moduleId.organization}:${moduleId.name} version ${moduleId.revision} doesn't match whitelist version $unmatched")
+          case _ => None
+        }
+      })
+    }
+
+    val problems = collectProblems("Compile", compileClasspath) ++ collectProblems("Test", testClasspath)
+
+    if (problems.nonEmpty) {
+      problems.foreach(p => log.error(p._2))
+
+      log.debug {
+        // This makes it very easy to fix the problem, by outputting a formatted list of dependencies to add.
+        problems.map { problem =>
+          val mid = problem._1
+          val cross = mid.name.endsWith("_" + svb)
+          val m = if (cross) "%%" else "%"
+          val name = if (cross) mid.name.dropRight(svb.length + 1) else mid.name
+          s""""${mid.organization}" $m "$name" % "${mid.revision}""""
+        }.sorted.mkString(
+          "The following dependencies need to be added to the whitelist:\n",
+          ",\n",
+          ""
+        )
+      }
+      throw new DependencyWhitelistValidationFailed
+    }
+  }
+
+  val validateDependenciesSetting = validateDependencies := validateDependenciesTask.value
+  val dependencyWhitelistSetting = dependencyWhitelist := DependencyWhitelist.value
+
+  private class DependencyWhitelistValidationFailed extends RuntimeException with FeedbackProvidedException {
+    override def toString = "Dependency whitelist validation failed!"
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,17 +16,18 @@ object Dependencies {
   val NettyVersion = "4.0.42.Final"
   val KafkaVersion = "0.10.0.1"
   val AkkaStreamKafkaVersion = "0.13"
-  val Log4j = "1.2.17"
+  val Log4jVersion = "1.2.17"
   val ScalaJava8CompatVersion = "0.7.0"
   val ScalaXmlVersion = "1.0.5"
 
   // Specific libraries that get reused
   private val scalaTest = "org.scalatest" %% "scalatest" % ScalaTestVersion
   private val guava = "com.google.guava" % "guava" % GuavaVersion
-  private val log4J = "log4j" % "log4j" % Log4j
+  private val log4J = "log4j" % "log4j" % Log4jVersion
   private val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % ScalaJava8CompatVersion
   private val scalaXml = "org.scala-lang.modules" %% "scala-xml" % ScalaXmlVersion
   private val jbossLogging = "org.jboss.logging" % "jboss-logging" % "3.3.0.Final"
+  private val typesafeConfig = "com.typesafe" % "config" % "1.3.1"
 
   private val akkaActor = "com.typesafe.akka" %% "akka-actor" % AkkaVersion
   private val akkaCluster = "com.typesafe.akka" %% "akka-cluster" % AkkaVersion
@@ -92,7 +93,7 @@ object Dependencies {
       "com.ning" % "compress-lzf" % "0.8.4",
       "com.novocode" % "junit-interface" % "0.11",
       "com.thinkaurelius.thrift" % "thrift-server" % "0.3.7",
-      "com.typesafe" % "config" % "1.3.0",
+      typesafeConfig,
       "com.typesafe" %% "ssl-config-core" % "0.2.1",
       akkaStreamKafka,
       akkaPersistenceCassandra,
@@ -104,7 +105,7 @@ object Dependencies {
       "com.zaxxer" % "HikariCP" % "2.5.1",
       "commons-cli" % "commons-cli" % "1.1",
       "commons-codec" % "commons-codec" % "1.10",
-      "commons-logging" % "commons-logging" % "1.1.1",
+      "commons-logging" % "commons-logging" % "1.2",
       "io.aeron" % "aeron-client" % "1.1.0",
       "io.aeron" % "aeron-driver" % "1.1.0",
       "io.dropwizard.metrics" % "metrics-core" % "3.1.2",
@@ -131,8 +132,8 @@ object Dependencies {
       "org.apache.cassandra" % "cassandra-thrift" % CassandraAllVersion,
       "org.apache.commons" % "commons-lang3" % "3.4",
       "org.apache.commons" % "commons-math3" % "3.2",
-      "org.apache.httpcomponents" % "httpclient" % "4.2.5",
-      "org.apache.httpcomponents" % "httpcore" % "4.2.4",
+      "org.apache.httpcomponents" % "httpclient" % "4.5.2",
+      "org.apache.httpcomponents" % "httpcore" % "4.4.4",
       "org.apache.kafka" % "kafka-clients" % "0.10.0.1",
       "org.apache.thrift" % "libthrift" % "0.9.2",
       "org.apache.tomcat" % "tomcat-servlet-api" % "8.0.33",
@@ -144,7 +145,7 @@ object Dependencies {
       "org.hibernate" % "hibernate-validator" % "5.2.4.Final",
       "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final",
       "org.immutables" % "value" % "2.3.2",
-      "org.javassist" % "javassist" % "3.20.0-GA",
+      "org.javassist" % "javassist" % "3.21.0-GA",
       jbossLogging,
       "org.joda" % "joda-convert" % "1.8.1",
       "org.hamcrest" % "hamcrest-core" % "1.3",
@@ -197,8 +198,8 @@ object Dependencies {
     ) ++ libraryFamily("org.apache.logging.log4j", "2.7")(
       "log4j-api", "log4j-core", "log4j-slf4j-impl"
 
-    ) ++ libraryFamily("org.asynchttpclient", "2.0.11")(
-      "async-http-client", "netty-codec-dns", "netty-resolver", "netty-resolver-dns"
+    ) ++ libraryFamily("org.asynchttpclient", "2.0.24")(
+      "async-http-client", "async-http-client-netty-utils", "netty-codec-dns", "netty-resolver", "netty-resolver-dns"
 
     ) ++ libraryFamily("org.ow2.asm", "5.0.3")(
       "asm", "asm-analysis", "asm-commons", "asm-tree", "asm-util"
@@ -265,7 +266,7 @@ object Dependencies {
     playJava,
     "org.pcollections" % "pcollections" % "2.1.2",
     // Needed to upgrade from 3.18 to ensure everything is on 3.20
-    "org.javassist" % "javassist" % "3.20.0-GA",
+    "org.javassist" % "javassist" % "3.21.0-GA",
     "com.fasterxml" % "classmate" % "1.3.0",
     jbossLogging,
     scalaTest % Test,
@@ -320,11 +321,7 @@ object Dependencies {
     // Needed to match whitelist versions
     "io.netty" % "netty-codec-http" % NettyVersion,
     "io.netty" % "netty-transport-native-epoll" % NettyVersion,
-    "com.typesafe.netty" % "netty-reactive-streams" % "1.0.8",
-    // These are required by signpost, which are required by play-ws. Can be removed when
-    // https://github.com/playframework/playframework/issues/5905 is fixed.
-    "org.apache.httpcomponents" % "httpclient" % "4.2.5",
-    "org.apache.httpcomponents" % "httpcore" % "4.2.4"
+    "com.typesafe.netty" % "netty-reactive-streams" % "1.0.8"
   )
 
   val `client-javadsl` = libraryDependencies ++= Nil
@@ -353,7 +350,8 @@ object Dependencies {
 
   val `testkit-core` = libraryDependencies ++= Seq(
     akkaActor,
-    akkaStream
+    akkaStream,
+    typesafeConfig
   )
 
   val `testkit-javadsl` = libraryDependencies ++= Seq(
@@ -410,6 +408,7 @@ object Dependencies {
 
   val `cluster-core` = libraryDependencies ++= Seq(
     akkaCluster,
+    typesafeConfig,
     akkaTestkit % Test,
     scalaTest % Test,
     "com.novocode" % "junit-interface" % "0.11" % Test
@@ -493,7 +492,8 @@ object Dependencies {
 
     "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion % Test exclude("io.netty", "netty-all"),
     "io.netty" % "netty-codec-http" % NettyVersion % Test,
-    "io.netty" % "netty-transport-native-epoll" % NettyVersion % Test classifier "linux-x86_64"
+    "io.netty" % "netty-transport-native-epoll" % NettyVersion % Test classifier "linux-x86_64",
+    "org.apache.httpcomponents" % "httpclient" % "4.5.2" % Test
   )
 
   val `persistence-cassandra-javadsl` = libraryDependencies ++= Nil


### PR DESCRIPTION
This change ensures the following:

* Every Lagom library depends on the same version of every dependency, so there's now no chance that using two different Lagom libraries together will cause a problem in one of them due to a different version of a transitive dependency being used.
* The libraries on our classpath when we run tests match the classpath that users will see when they depend on our libraries (assuming they don't make any other changes to it).
* If we do an upgrade that upgrades a transitive dependency, we will know, and can verify that the upgrade won't cause any problems.

While the list of libraries does look very large, it's important to realise that this is a list of dependencies used by all Lagom libraries, both at compile/runtime and in test.