### PR TITLE
Remove version from manifest to get serialiser from the registry

### DIFF
--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
@@ -74,6 +74,9 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
     val migratedManifest = migration match {
       case Some(migration) if (migration.currentVersion > fromVersion) =>
         migration.transformClassName(fromVersion, manifestClassName)
+      case Some(migration) if (migration.currentVersion < fromVersion) =>
+        throw new IllegalStateException(s"Migration version ${migration.currentVersion} is " +
+          s"behind version $fromVersion of deserialized type [$manifestClassName]")
       case _ => manifestClassName
     }
 

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -138,6 +138,21 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
+    "throw runtime exception when deserialization target type has version greater than defined migration"  in withActorSystem(TestRegistry3) { system =>
+
+      val migratedEvent = MigratedEvent(addedField = 2, newName = "some value")
+
+      val serializeExt = SerializationExtension(system)
+      val serializer = serializeExt.findSerializerFor(migratedEvent).asInstanceOf[SerializerWithStringManifest]
+
+      val illegalManifest = classOf[MigratedEvent].getName + "#6"
+
+      assertThrows[IllegalStateException] {
+        serializer.fromBinary(Array[Byte](), illegalManifest)
+      }
+
+    }
+
     "apply sequential migrations using json-transformations" in withActorSystem(TestRegistry2) { system =>
 
       val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -118,6 +118,23 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       }
     }
 
+    "pick up serializers for registry with migration" in withActorSystem(TestRegistry3) { system =>
+
+      val migratedEvent = MigratedEvent(addedField = 2, newName = "some value")
+
+      val serializeExt = SerializationExtension(system)
+      val serializer = serializeExt.findSerializerFor(migratedEvent).asInstanceOf[SerializerWithStringManifest]
+
+      val bytes = serializer.toBinary(migratedEvent)
+      val manifest = serializer.manifest(migratedEvent)
+
+      bytes.isEmpty should be(false)
+
+      val deserialized = serializer.fromBinary(bytes, manifest)
+      deserialized should be(migratedEvent)
+
+    }
+
     "apply sequential migrations using json-transformations" in withActorSystem(TestRegistry2) { system =>
 
       val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -67,9 +67,11 @@ object TestRegistry3 extends JsonSerializerRegistry {
     JsonSerializer(Json.format[MigratedEvent])
   )
 
+  def currentMigrationVersion: Int = 5
+
   // manual way to do the same transformations (compared to json transformations above)
   override def migrations: Map[String, JsonMigration] = Map(
-    classOf[MigratedEvent].getName -> new JsonMigration(5) {
+    classOf[MigratedEvent].getName -> new JsonMigration(currentMigrationVersion) {
       override def transform(fromVersion: Int, json: JsObject): JsObject = {
         var toUpdate = json
         if (fromVersion < 2) {
@@ -128,9 +130,6 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val bytes = serializer.toBinary(migratedEvent)
       val manifest = serializer.manifest(migratedEvent)
 
-
-      manifest shouldEqual classOf[MigratedEvent].getName + "#5"
-
       bytes.isEmpty should be(false)
 
       val deserialized = serializer.fromBinary(bytes, manifest)
@@ -138,14 +137,28 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "throw runtime exception when deserialization target type has version greater than defined migration"  in withActorSystem(TestRegistry3) { system =>
+    "format manifest of migrated type to include the version defined in migration registry" in withActorSystem(TestRegistry3) { system =>
 
       val migratedEvent = MigratedEvent(addedField = 2, newName = "some value")
 
       val serializeExt = SerializationExtension(system)
       val serializer = serializeExt.findSerializerFor(migratedEvent).asInstanceOf[SerializerWithStringManifest]
 
-      val illegalManifest = classOf[MigratedEvent].getName + "#6"
+      val manifest = serializer.manifest(migratedEvent)
+
+      manifest shouldEqual expectedVersionedManifest(classOf[MigratedEvent], TestRegistry3.currentMigrationVersion)
+
+    }
+
+    "throw runtime exception when deserialization target type version is ahead of that defined in migration registry" in withActorSystem(TestRegistry3) { system =>
+
+      val migratedEvent = MigratedEvent(addedField = 2, newName = "some value")
+
+      val serializeExt = SerializationExtension(system)
+      val serializer = serializeExt.findSerializerFor(migratedEvent).asInstanceOf[SerializerWithStringManifest]
+
+      val illegalVersion = TestRegistry3.currentMigrationVersion + 1
+      val illegalManifest = expectedVersionedManifest(classOf[MigratedEvent], illegalVersion)
 
       assertThrows[IllegalStateException] {
         serializer.fromBinary(Array[Byte](), illegalManifest)
@@ -164,7 +177,9 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val serializeExt = SerializationExtension(system)
       val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
 
-      val deserialized = serializer.fromBinary(oldJsonBytes, classOf[MigratedEvent].getName + "#1")
+      val oldVersionBeforeThanCurrentMigration = 1
+      val manifest = expectedVersionedManifest(classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration)
+      val deserialized = serializer.fromBinary(oldJsonBytes, manifest)
       deserialized should be(expectedEvent)
 
     }
@@ -180,7 +195,9 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val serializeExt = SerializationExtension(system)
       val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
 
-      val deserialized = serializer.fromBinary(oldJsonBytes, classOf[MigratedEvent].getName + "#1")
+      val oldVersionBeforeThanCurrentMigration = 1
+      val manifest = expectedVersionedManifest(classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration)
+      val deserialized = serializer.fromBinary(oldJsonBytes, manifest)
       deserialized should be(expectedEvent)
 
     }
@@ -197,6 +214,10 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
       deserialized should be(event)
 
+    }
+
+    def expectedVersionedManifest[T](clazz: Class[T], migrationVersion: Int) = {
+      s"${clazz.getName}#$migrationVersion"
     }
 
   }

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -128,6 +128,9 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val bytes = serializer.toBinary(migratedEvent)
       val manifest = serializer.manifest(migratedEvent)
 
+
+      manifest shouldEqual classOf[MigratedEvent].getName + "#5"
+
       bytes.isEmpty should be(false)
 
       val deserialized = serializer.fromBinary(bytes, manifest)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes
This fixes runtime exception of missing play-json serializer for versioned event with suffix `#<version number>`

## Purpose

- Removes versioning from manifest name to contain the same key as configured registry
- Handle missing pattern matching when migration current version is not greater than the event's version

## References
https://groups.google.com/forum/#!topic/lagom-framework/SQnLtf-nVz8
