### PR TITLE
Update KafkaServer.md

### DIFF
--- a/docs/manual/common/guide/devmode/KafkaServer.md
+++ b/docs/manual/common/guide/devmode/KafkaServer.md
@@ -79,7 +79,7 @@ Kafka is essentially a durable commit log. You can find all data persisted by Ka
 
 ## Start and stop
 
-The Kafka server is automatically started when executing the `runAll` task. However, there are times when you might want to manually start only a few services, and hence you won't use the `runAll` task. In this case, you can manually start the Cassandra server via the `lagom:startKafka` maven task or `lagomKafkaStart` sbt task, and stopping it with the `lagom:stopKafka` Maven task or `lagomKafkaStop` sbt task.
+The Kafka server is automatically started when executing the `runAll` task. However, there are times when you might want to manually start only a few services, and hence you won't use the `runAll` task. In this case, you can manually start the Kafka server via the `lagom:startKafka` maven task or `lagomKafkaStart` sbt task, and stopping it with the `lagom:stopKafka` Maven task or `lagomKafkaStop` sbt task.
 
 ## Disable it
 


### PR DESCRIPTION
It's written '**Cassandra**' instead of '**Kafka**'.

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

I couldn't find an open issue for this. It's a simple documentation mistake mentioning Cassandra when it should be Kafka.

## Purpose

Fix documentation mistake.

## Background Context

N/A

## References

N/A