### PR TITLE
Configure the Cassandra keyspace in the archetype

### DIFF
--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/resources/application.conf
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/resources/application.conf
@@ -3,4 +3,21 @@
 #
 play.modules.enabled += ${package}.${service1Name}.impl.${service1ClassName}Module
 
-lagom.persistence.ask-timeout=10s
+lagom.persistence.ask-timeout = 10s
+
+${service1Name}.cassandra.keyspace = ${service1Name}
+
+## The unusual syntax below is because this file is proccessed by Velocity.
+## We are using Velocity properties to construct a config key name,
+## which is then used in a HOCON substitution.
+##
+## The results, if service1Name = hello, should look like this:
+##
+## cassandra-journal.keyspace = ${hello.cassandra.keyspace}
+## cassandra-snapshot-store.keyspace = ${hello.cassandra.keyspace}
+## lagom.persistence.read-side.cassandra.keyspace = ${hello.cassandra.keyspace}
+##
+## Also note that this comment is a Velocity comment and is not included in the output.
+cassandra-journal.keyspace = ${${service1Name}.cassandra.keyspace}
+cassandra-snapshot-store.keyspace = ${${service1Name}.cassandra.keyspace}
+lagom.persistence.read-side.cassandra.keyspace = ${${service1Name}.cassandra.keyspace}


### PR DESCRIPTION
This will help to ensure that projects won't be affected by changes to
the default keyspace configuration.

See #578

Should be backported to 1.3.x.