### PR TITLE
Document Cassandra keyspace configuration changes

### DIFF
--- a/docs/manual/common/guide/devmode/CassandraServer.md
+++ b/docs/manual/common/guide/devmode/CassandraServer.md
@@ -1,6 +1,6 @@
 # Cassandra Server
 
-By default, Lagom services needing to persist data use Cassandra as database. Therefore, for conveniency, we have embedded a Cassandra server in the development environment, so that you don't have to worry about installing it. There are a number of settings and tasks available to tune the Cassandra server to your liking, let's explore them:
+By default, Lagom services needing to persist data use Cassandra as database. For convenience, we have embedded a Cassandra server in the development environment, so that you don't have to worry about installing it. There are a number of settings and tasks available to tune the Cassandra server to your liking, let's explore them:
 
 ## Default port
 
@@ -44,11 +44,11 @@ In sbt:
 
 @[cassandra-clean-on-start](code/build-cassandra-opts.sbt)
 
-# Keyspace
+## Keyspace _(deprecated)_
 
-A keyspace in Cassandra is a namespace that defines data replication on nodes. Each service should use a unique keyspace name so that the tables of different services are not conflicting with each other. But don't worry, we have already taken care of that and, by default, the keyspace is automatically set to be the project's name (after possibly having replaced a few characters that aren't allowed). If the generated keyspace doesn't suit you, you are free to provide a custom one.
+A keyspace in Cassandra is a namespace that defines data replication on nodes. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other. In the development environment, the keyspace is automatically set to be the project's name by default (after possibly having replaced a few characters that aren't allowed). If the generated keyspace doesn't suit you, you are free to provide a custom one.
 
-In Maven, you can do this by modifying the service implementations pom configuration:
+In Maven, you can do this by modifying the service implementation's pom configuration:
 
 ```xml
 <plugin>
@@ -61,11 +61,7 @@ In Maven, you can do this by modifying the service implementations pom configura
 </plugin>
 ```
 
-In sbt, let's assume you have the following Lagom project in your build:
-
-@[cassandra-users-project](code/build-cassandra-opts-lang.sbt)
-
-Because the project's name is `users-impl`, the generated Cassandra keyspace will be `users_impl` (note that dashes are replaced with underscores). If you'd prefer the keyspace to be named simply `users`, you could either change the project's `name` to be `users`, or alternatively add the following setting:
+In sbt, add the `lagomCassandraKeyspace` setting to the service implementation project:
 
 @[cassandra-users-project-with-keyspace](code/build-cassandra-opts-lang.sbt)
 
@@ -79,7 +75,9 @@ cassandra-snapshot-store.keyspace=users
 lagom.persistence.read-side.cassandra.keyspace=users
 ```
 
-Note that the keyspace values provided via the `application.conf` will always win over any keyspace name that may be set in the build.
+Note that the keyspace values provided via the `application.conf` will always win over any keyspace name that may be set in the build. For that reason, overriding the keyspace in the build is deprecated, and will be removed in a future version of Lagom.
+
+There is more information about configuring keyspaces in the documentation for [[Cassandra persistent entity configuration|PersistentEntityCassandra#Configuration]].
 
 ## JVM options
 

--- a/docs/manual/common/guide/devmode/CassandraServer.md
+++ b/docs/manual/common/guide/devmode/CassandraServer.md
@@ -75,9 +75,9 @@ cassandra-snapshot-store.keyspace=users
 lagom.persistence.read-side.cassandra.keyspace=users
 ```
 
-Note that the keyspace values provided via the `application.conf` will always win over any keyspace name that may be set in the build. For that reason, overriding the keyspace in the build is deprecated, and will be removed in a future version of Lagom.
+Note that Cassandra uses keyspace values from the `application.conf` file instead of any you might define in the build. For that reason, overriding the keyspace in the build is deprecated, and will be removed in a future version of Lagom.
 
-There is more information about configuring keyspaces in the documentation for [[Cassandra persistent entity configuration|PersistentEntityCassandra#Configuration]].
+See [[Cassandra persistent entity configuration|PersistentEntityCassandra#Configuration]] for more information about configuring keyspaces.
 
 ## JVM options
 

--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -22,9 +22,7 @@ In sbt:
 
 ## Configuration
 
-Lagom uses several internal Cassandra tables to persist entity data. You need to configure the keyspaces that are used for these tables. By default, Lagom automatically creates these keyspaces and tables at startup if they're missing.
-
-A keyspace in Cassandra is a namespace that defines data replication on nodes and acts as a container for tables. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other.
+Lagom's persistence needs a few tables to store its data. These tables are stored in Cassandra keyspaces. A keyspace in Cassandra is a namespace that defines data replication on Cassandra nodes. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other. You need to configure the keyspaces that are used for these tables in each of your service implementation projects.
 
 Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
 

--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -22,4 +22,46 @@ In sbt:
 
 ## Configuration
 
+Lagom uses several internal Cassandra tables to persist entity data. These are known as the journal, which stores events, and the snapshot store, which stores snapshots of the state as an optimization for faster recovery (see [[Snapshots|PersistentEntity#Snapshots]] for details). [[Cassandra Read-Side support|ReadSideCassandra]] also uses a table to store the event offsets last processed by each read-side processor (detailed in [[Read-side design|ReadSide#Read-side-design]]). You will need to configure the keyspaces that contain the tables for each of these components.
+
+A keyspace in Cassandra is a namespace that defines data replication on nodes. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other.
+
+You can configure these keyspaces in each service implementation project's `application.conf` file:
+
+```conf
+cassandra-journal.keyspace = users_journal
+cassandra-snapshot-store.keyspace = users_snapshot
+lagom.persistence.read-side.cassandra.keyspace = users_read_side
+```
+
+Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
+
+While different services should be isolated by using different keyspaces, it is perfectly fine to use the same keyspace for all of these components within one service. In that case, it can be convenient to define a custom keyspace configuration property and use [property substitution](https://github.com/typesafehub/config#factor-out-common-values) to avoid repeating it.
+
+```conf
+users.cassandra.keyspace = users
+
+cassandra-journal.keyspace = ${users.cassandra.keyspace}
+cassandra-snapshot-store.keyspace = ${users.cassandra.keyspace}
+lagom.persistence.read-side.cassandra.keyspace = ${users.cassandra.keyspace}
+```
+
+By default, Lagom automatically creates the configured keyspaces and its internal tables if they are missing. If you prefer to manage the schema explicitly, you can disable automatic creation with these properties:
+
+```conf
+cassandra-journal {
+  keyspace-autocreate = true
+  tables-autocreate = true
+}
+cassandra-snapshot-store {
+  keyspace-autocreate = true
+  tables-autocreate = true
+}
+lagom.persistence.read-side.cassandra {
+  keyspace-autocreate = true
+}
+```
+
+It is not possible to disable automatic creation of the offset store table at this time.
+
 Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugins [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).

--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -26,6 +26,8 @@ Lagom uses several internal Cassandra tables to persist entity data. These are k
 
 A keyspace in Cassandra is a namespace that defines data replication on nodes. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other.
 
+Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
+
 You can configure these keyspaces in each service implementation project's `application.conf` file:
 
 ```conf
@@ -33,8 +35,6 @@ cassandra-journal.keyspace = users_journal
 cassandra-snapshot-store.keyspace = users_snapshot
 lagom.persistence.read-side.cassandra.keyspace = users_read_side
 ```
-
-Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
 
 While different services should be isolated by using different keyspaces, it is perfectly fine to use the same keyspace for all of these components within one service. In that case, it can be convenient to define a custom keyspace configuration property and use [property substitution](https://github.com/typesafehub/config#factor-out-common-values) to avoid repeating it.
 

--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -50,15 +50,15 @@ By default, Lagom automatically creates the configured keyspaces and its interna
 
 ```conf
 cassandra-journal {
-  keyspace-autocreate = true
-  tables-autocreate = true
+  keyspace-autocreate = false
+  tables-autocreate = false
 }
 cassandra-snapshot-store {
-  keyspace-autocreate = true
-  tables-autocreate = true
+  keyspace-autocreate = false
+  tables-autocreate = false
 }
 lagom.persistence.read-side.cassandra {
-  keyspace-autocreate = true
+  keyspace-autocreate = false
 }
 ```
 

--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -64,4 +64,4 @@ lagom.persistence.read-side.cassandra {
 
 It is not possible to disable automatic creation of the offset store table at this time.
 
-Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugins [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).
+Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugin's [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).

--- a/docs/manual/java/guide/devmode/code/build-cassandra-opts-lang.sbt
+++ b/docs/manual/java/guide/devmode/code/build-cassandra-opts-lang.sbt
@@ -1,10 +1,3 @@
-
-
-//#cassandra-users-project
-lazy val usersImpl = (project in file("usersImpl")).enablePlugins(LagomJava)
-  .settings(name := "users-impl")
-//#cassandra-users-project
-
 //#cassandra-users-project-with-keyspace
 lazy val usersImplKeyspaced = (project in file("usersImpl")).enablePlugins(LagomJava)
   .settings(

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -22,9 +22,7 @@ In sbt:
 
 ## Configuration
 
-Lagom uses several internal Cassandra tables to persist entity data. You need to configure the keyspaces that are used for these tables. By default, Lagom automatically creates these keyspaces and tables at startup if they're missing.
-
-A keyspace in Cassandra is a namespace that defines data replication on nodes and acts as a container for tables. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other.
+Lagom's persistence needs a few tables to store its data. These tables are stored in Cassandra keyspaces. A keyspace in Cassandra is a namespace that defines data replication on Cassandra nodes. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other. You need to configure the keyspaces that are used for these tables in each of your service implementation projects.
 
 Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
 

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -22,4 +22,46 @@ In sbt:
 
 ## Configuration
 
+Lagom uses several internal Cassandra tables to persist entity data. These are known as the journal, which stores events, and the snapshot store, which stores snapshots of the state as an optimization for faster recovery (see [[Snapshots|PersistentEntity#Snapshots]] for details). [[Cassandra Read-Side support|ReadSideCassandra]] also uses a table to store the event offsets last processed by each read-side processor (detailed in [[Read-side design|ReadSide#Read-side-design]]). You will need to configure the keyspaces that contain the tables for each of these components.
+
+A keyspace in Cassandra is a namespace that defines data replication on nodes. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other.
+
+You can configure these keyspaces in each service implementation project's `application.conf` file:
+
+```conf
+cassandra-journal.keyspace = users_journal
+cassandra-snapshot-store.keyspace = users_snapshot
+lagom.persistence.read-side.cassandra.keyspace = users_read_side
+```
+
+Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
+
+While different services should be isolated by using different keyspaces, it is perfectly fine to use the same keyspace for all of these components within one service. In that case, it can be convenient to define a custom keyspace configuration property and use [property substitution](https://github.com/typesafehub/config#factor-out-common-values) to avoid repeating it.
+
+```conf
+users.cassandra.keyspace = users
+
+cassandra-journal.keyspace = ${users.cassandra.keyspace}
+cassandra-snapshot-store.keyspace = ${users.cassandra.keyspace}
+lagom.persistence.read-side.cassandra.keyspace = ${users.cassandra.keyspace}
+```
+
+By default, Lagom automatically creates the configured keyspaces and its internal tables if they are missing. If you prefer to manage the schema explicitly, you can disable automatic creation with these properties:
+
+```conf
+cassandra-journal {
+  keyspace-autocreate = true
+  tables-autocreate = true
+}
+cassandra-snapshot-store {
+  keyspace-autocreate = true
+  tables-autocreate = true
+}
+lagom.persistence.read-side.cassandra {
+  keyspace-autocreate = true
+}
+```
+
+It is not possible to disable automatic creation of the offset store table at this time.
+
 Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugins [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -26,6 +26,8 @@ Lagom uses several internal Cassandra tables to persist entity data. These are k
 
 A keyspace in Cassandra is a namespace that defines data replication on nodes. Each service should use a unique keyspace name so that the tables of different services do not conflict with each other.
 
+Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
+
 You can configure these keyspaces in each service implementation project's `application.conf` file:
 
 ```conf
@@ -33,8 +35,6 @@ cassandra-journal.keyspace = users_journal
 cassandra-snapshot-store.keyspace = users_snapshot
 lagom.persistence.read-side.cassandra.keyspace = users_read_side
 ```
-
-Cassandra keyspace names must start with an alphanumeric character and contain only alphanumeric and underscore characters. They are case-insensitive and stored in lowercase.
 
 While different services should be isolated by using different keyspaces, it is perfectly fine to use the same keyspace for all of these components within one service. In that case, it can be convenient to define a custom keyspace configuration property and use [property substitution](https://github.com/typesafehub/config#factor-out-common-values) to avoid repeating it.
 

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -50,15 +50,15 @@ By default, Lagom automatically creates the configured keyspaces and its interna
 
 ```conf
 cassandra-journal {
-  keyspace-autocreate = true
-  tables-autocreate = true
+  keyspace-autocreate = false
+  tables-autocreate = false
 }
 cassandra-snapshot-store {
-  keyspace-autocreate = true
-  tables-autocreate = true
+  keyspace-autocreate = false
+  tables-autocreate = false
 }
 lagom.persistence.read-side.cassandra {
-  keyspace-autocreate = true
+  keyspace-autocreate = false
 }
 ```
 

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -64,4 +64,4 @@ lagom.persistence.read-side.cassandra {
 
 It is not possible to disable automatic creation of the offset store table at this time.
 
-Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugins [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).
+Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugin's [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).

--- a/docs/manual/scala/guide/devmode/code/build-cassandra-opts-lang.sbt
+++ b/docs/manual/scala/guide/devmode/code/build-cassandra-opts-lang.sbt
@@ -1,10 +1,3 @@
-
-
-//#cassandra-users-project
-lazy val usersImpl = (project in file("usersImpl")).enablePlugins(LagomScala)
-  .settings(name := "users-impl")
-//#cassandra-users-project
-
 //#cassandra-users-project-with-keyspace
 lazy val usersImplKeyspaced = (project in file("usersImpl")).enablePlugins(LagomScala)
   .settings(


### PR DESCRIPTION
- Describe keyspace configuration in the Cassandra persistent entity documentation
- Deprecate keyspace configuration in the build

## References

See #578

## Backport

Should be backported to 1.3.x