### PR TITLE
Warn on implicit keyspace config

### DIFF
--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
@@ -17,13 +17,13 @@ private[lagom] object CassandraKeyspaceConfig {
       log.error("Configuration for [{}] must be set in application.conf", path)
     } else if (log.isWarningEnabled) {
       val keyspace = config.getString(path)
-      val defaultKeyspace = config.getString(s"$defaultNamespace.keyspace")
-      if (keyspace == defaultKeyspace) {
+      val defaultPath = s"$defaultNamespace.keyspace"
+      if (config.hasPath(defaultPath) && keyspace == config.getString(defaultPath)) {
         log.warning(
           "Configuration for [{}] is using deprecated default value [{}]. " +
             "Please set an explicit keyspace value in application.conf",
           path,
-          defaultKeyspace
+          keyspace
         )
       }
     }

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import akka.event.LoggingAdapter
+import com.typesafe.config.Config
+
+private[lagom] object CassandraKeyspaceConfig {
+
+  def validateKeyspace(namespace: String)(implicit config: Config, log: LoggingAdapter): Unit =
+    validateKeyspace(namespace, s"$namespace.defaults")
+
+  def validateKeyspace(namespace: String, defaultNamespace: String)(implicit config: Config, log: LoggingAdapter): Unit = {
+    val path = s"$namespace.keyspace"
+    if (!config.hasPath(path)) {
+      log.error("Configuration for [{}] must be set in application.conf", path)
+    } else if (log.isWarningEnabled) {
+      val keyspace = config.getString(path)
+      val defaultKeyspace = config.getString(s"$defaultNamespace.keyspace")
+      if (keyspace == defaultKeyspace) {
+        log.warning(
+          "Configuration for [{}] is using deprecated default value [{}]. " +
+            "Please set an explicit keyspace value in application.conf",
+          path,
+          defaultKeyspace
+        )
+      }
+    }
+  }
+
+}

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
@@ -14,8 +14,9 @@ private[lagom] object CassandraKeyspaceConfig {
       val defaultPath = s"$defaultNamespace.keyspace"
       if (config.hasPath(defaultPath) && keyspace == config.getString(defaultPath)) {
         log.warning(
-          "Configuration for [{}] is using deprecated default value [{}]. " +
-            "Please set an explicit keyspace value in application.conf",
+          "Configuration for [{}] uses deprecated default value [{}]. " +
+            "Please set an explicit keyspace value in application.conf if you haven't already. " +
+            "The default will be removed in a future version of Lagom.",
           s"$namespace.keyspace",
           keyspace
         )

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraKeyspaceConfig.scala
@@ -8,21 +8,15 @@ import com.typesafe.config.Config
 
 private[lagom] object CassandraKeyspaceConfig {
 
-  def validateKeyspace(namespace: String)(implicit config: Config, log: LoggingAdapter): Unit =
-    validateKeyspace(namespace, s"$namespace.defaults")
-
-  def validateKeyspace(namespace: String, defaultNamespace: String)(implicit config: Config, log: LoggingAdapter): Unit = {
-    val path = s"$namespace.keyspace"
-    if (!config.hasPath(path)) {
-      log.error("Configuration for [{}] must be set in application.conf", path)
-    } else if (log.isWarningEnabled) {
-      val keyspace = config.getString(path)
+  def validateKeyspace(namespace: String, defaultNamespace: String, config: Config, log: LoggingAdapter): Unit = {
+    if (log.isWarningEnabled) {
+      val keyspace = config.getString(s"$namespace.keyspace")
       val defaultPath = s"$defaultNamespace.keyspace"
       if (config.hasPath(defaultPath) && keyspace == config.getString(defaultPath)) {
         log.warning(
           "Configuration for [{}] is using deprecated default value [{}]. " +
             "Please set an explicit keyspace value in application.conf",
-          path,
+          s"$namespace.keyspace",
           keyspace
         )
       }

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -21,11 +21,20 @@ import com.lightbend.lagom.internal.persistence.cassandra.CassandraKeyspaceConfi
 private[lagom] final class CassandraPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector)
   extends AbstractPersistentEntityRegistry(system, injector) {
 
-  implicit private val config = system.settings.config
-  implicit private val log = Logging.getLogger(system, getClass)
+  private val log = Logging.getLogger(system, getClass)
 
-  for (namespace <- Seq("cassandra-journal", "cassandra-snapshot-store"))
-    CassandraKeyspaceConfig.validateKeyspace(namespace)
+  CassandraKeyspaceConfig.validateKeyspace(
+    namespace = "cassandra-journal",
+    defaultNamespace = "cassandra-journal.defaults",
+    system.settings.config,
+    log
+  )
+  CassandraKeyspaceConfig.validateKeyspace(
+    namespace = "cassandra-snapshot-store",
+    defaultNamespace = "cassandra-snapshot-store.defaults",
+    system.settings.config,
+    log
+  )
 
   override protected val journalId = CassandraReadJournal.Identifier
 

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -6,11 +6,13 @@ package com.lightbend.lagom.internal.javadsl.persistence.cassandra
 import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery2
 import com.google.inject.Injector
 import com.lightbend.lagom.internal.javadsl.persistence.AbstractPersistentEntityRegistry
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraKeyspaceConfig
 
 /**
  * Internal API
@@ -18,6 +20,12 @@ import com.lightbend.lagom.internal.javadsl.persistence.AbstractPersistentEntity
 @Singleton
 private[lagom] final class CassandraPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector)
   extends AbstractPersistentEntityRegistry(system, injector) {
+
+  implicit private val config = system.settings.config
+  implicit private val log = Logging.getLogger(system, getClass)
+
+  for (namespace <- Seq("cassandra-journal", "cassandra-snapshot-store"))
+    CassandraKeyspaceConfig.validateKeyspace(namespace)
 
   override protected val journalId = CassandraReadJournal.Identifier
 

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraSession.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraSession.scala
@@ -8,13 +8,14 @@ import java.util.{ Optional, List => JList }
 import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.persistence.cassandra.session.CassandraSessionSettings
 import akka.persistence.cassandra.session.scaladsl.{ CassandraSession => AkkaScalaCassandraSession }
 import akka.persistence.cassandra.session.javadsl.{ CassandraSession => AkkaJavaCassandraSession }
 import akka.stream.javadsl
 import akka.{ Done, NotUsed }
 import com.datastax.driver.core._
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSessionProvider
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraKeyspaceConfig, CassandraReadSideSessionProvider }
 
 import scala.annotation.varargs
 import scala.concurrent.ExecutionContext
@@ -43,6 +44,14 @@ final class CassandraSession(system: ActorSystem, settings: CassandraSessionSett
         "lagom.persistence.read-side.use-dispatcher"
       ))
     )
+
+  implicit private val config = system.settings.config
+  implicit private val log = Logging.getLogger(system, getClass)
+
+  CassandraKeyspaceConfig.validateKeyspace(
+    namespace = "lagom.persistence.read-side.cassandra",
+    defaultNamespace = "lagom.defaults.persistence.read-side.cassandra"
+  )
 
   /**
    * Internal API

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraSession.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraSession.scala
@@ -45,12 +45,13 @@ final class CassandraSession(system: ActorSystem, settings: CassandraSessionSett
       ))
     )
 
-  implicit private val config = system.settings.config
-  implicit private val log = Logging.getLogger(system, getClass)
+  private val log = Logging.getLogger(system, getClass)
 
   CassandraKeyspaceConfig.validateKeyspace(
     namespace = "lagom.persistence.read-side.cassandra",
-    defaultNamespace = "lagom.defaults.persistence.read-side.cassandra"
+    defaultNamespace = "lagom.defaults.persistence.read-side.cassandra",
+    system.settings.config,
+    log
   )
 
   /**

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -17,11 +17,20 @@ import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntit
 private[lagom] final class CassandraPersistentEntityRegistry(system: ActorSystem)
   extends AbstractPersistentEntityRegistry(system) {
 
-  implicit private val config = system.settings.config
-  implicit private val log = Logging.getLogger(system, getClass)
+  private val log = Logging.getLogger(system, getClass)
 
-  for (namespace <- Seq("cassandra-journal", "cassandra-snapshot-store"))
-    CassandraKeyspaceConfig.validateKeyspace(namespace)
+  CassandraKeyspaceConfig.validateKeyspace(
+    namespace = "cassandra-journal",
+    defaultNamespace = "cassandra-journal.defaults",
+    system.settings.config,
+    log
+  )
+  CassandraKeyspaceConfig.validateKeyspace(
+    namespace = "cassandra-snapshot-store",
+    defaultNamespace = "cassandra-snapshot-store.defaults",
+    system.settings.config,
+    log
+  )
 
   override protected val journalId = CassandraReadJournal.Identifier
 

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -4,9 +4,11 @@
 package com.lightbend.lagom.internal.scaladsl.persistence.cassandra
 
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery2
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraKeyspaceConfig
 import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntityRegistry
 
 /**
@@ -14,6 +16,12 @@ import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntit
  */
 private[lagom] final class CassandraPersistentEntityRegistry(system: ActorSystem)
   extends AbstractPersistentEntityRegistry(system) {
+
+  implicit private val config = system.settings.config
+  implicit private val log = Logging.getLogger(system, getClass)
+
+  for (namespace <- Seq("cassandra-journal", "cassandra-snapshot-store"))
+    CassandraKeyspaceConfig.validateKeyspace(namespace)
 
   override protected val journalId = CassandraReadJournal.Identifier
 

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraSession.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraSession.scala
@@ -37,12 +37,13 @@ final class CassandraSession(system: ActorSystem, settings: CassandraSessionSett
       ))
     )
 
-  implicit private val config = system.settings.config
-  implicit private val log = Logging.getLogger(system, getClass)
+  private val log = Logging.getLogger(system, getClass)
 
   CassandraKeyspaceConfig.validateKeyspace(
     namespace = "lagom.persistence.read-side.cassandra",
-    defaultNamespace = "lagom.defaults.persistence.read-side.cassandra"
+    defaultNamespace = "lagom.defaults.persistence.read-side.cassandra",
+    system.settings.config,
+    log
   )
 
   /**

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraSession.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraSession.scala
@@ -3,14 +3,13 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
-import javax.inject.{ Inject, Singleton }
-
 import akka.actor.ActorSystem
+import akka.event.Logging
 import akka.persistence.cassandra.session.CassandraSessionSettings
 import akka.stream.scaladsl
 import akka.{ Done, NotUsed }
 import com.datastax.driver.core._
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSessionProvider
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraKeyspaceConfig, CassandraReadSideSessionProvider }
 
 import scala.annotation.varargs
 import scala.concurrent.{ ExecutionContext, Future }
@@ -37,6 +36,14 @@ final class CassandraSession(system: ActorSystem, settings: CassandraSessionSett
         "lagom.persistence.read-side.use-dispatcher"
       ))
     )
+
+  implicit private val config = system.settings.config
+  implicit private val log = Logging.getLogger(system, getClass)
+
+  CassandraKeyspaceConfig.validateKeyspace(
+    namespace = "lagom.persistence.read-side.cassandra",
+    defaultNamespace = "lagom.defaults.persistence.read-side.cassandra"
+  )
 
   /**
    * Internal API


### PR DESCRIPTION
This lets users know that relying on the default is deprecated, and that
they should configure keyspaces explicitly in application.conf.

See #578

This should be backported to 1.3.x.