### PR TITLE
Remove reference to Cassandra in the JdbcReadside

### DIFF
--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSide.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSide.scala
@@ -21,7 +21,7 @@ import scala.reflect.ClassTag
  */
 trait JdbcReadSide {
   /**
-   * Create a builder for a Cassandra read side event handler.
+   * Create a builder for a JDBC read side event handler.
    *
    * @param readSideId An identifier for this read side. This will be used to store offsets in the offset store.
    * @return The builder.


### PR DESCRIPTION
Update Scala doc in JdbcReadside.scala to remove references to the Cassandra Readside builder, which can be misleading