### PR TITLE
[WIP] Enable Metrics delivery by default in scaladsl

### DIFF
--- a/api-tools/src/test/scala/com/lightbend/lagom/api/tools/tests/scaladsl/ServiceLoaders.scala
+++ b/api-tools/src/test/scala/com/lightbend/lagom/api/tools/tests/scaladsl/ServiceLoaders.scala
@@ -5,7 +5,7 @@ package com.lightbend.lagom.api.tools.tests.scaladsl
 
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
-import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationContext, LagomApplicationLoader, LagomServer }
+import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationContext, LagomApplicationLoader }
 import play.api.libs.ws.ahc.AhcWSComponents
 
 class AclServiceLoader extends LagomApplicationLoader {

--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -4,18 +4,19 @@
 package play.core.server
 
 import java.io.File
+
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.lightbend.lagom.sbt.server.ReloadableServer
 import play.api._
-import play.api.libs.concurrent.ActorSystemProvider
 import play.core.{ ApplicationProvider, BuildLink, SourceMapper }
 import play.utils.Threads
-import scala.concurrent.{ Await, Future }
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
-import scala.collection.JavaConverters._
 
 /**
  * Used to start servers in 'dev' mode, a mode where the application

--- a/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/devmode/LagomDevModeComponents.scala
+++ b/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/devmode/LagomDevModeComponents.scala
@@ -7,16 +7,15 @@ import java.net.URI
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import com.lightbend.lagom.internal.client.{ CircuitBreakerConfig, CircuitBreakerMetricsProviderImpl, CircuitBreakers }
 import com.lightbend.lagom.internal.scaladsl.client.{ ScaladslServiceClient, ScaladslServiceResolver, ScaladslWebSocketClient }
 import com.lightbend.lagom.internal.scaladsl.registry.{ ServiceRegistration, ServiceRegistry, ServiceRegistryServiceLocator }
-import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.api.Descriptor.Call
-import com.lightbend.lagom.scaladsl.api.{ ServiceInfo, ServiceLocator }
 import com.lightbend.lagom.scaladsl.api.deser.DefaultExceptionSerializer
-import play.api.{ Configuration, Environment }
+import com.lightbend.lagom.scaladsl.api.{ ServiceInfo, ServiceLocator }
+import com.lightbend.lagom.scaladsl.client.CircuitBreakerComponents
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.WSClient
+import play.api.{ Configuration, Environment }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -52,7 +51,7 @@ trait LagomDevModeComponents extends LagomDevModeServiceLocatorComponents {
  * It expects the service locator URL to be provided using the `lagom.service-locator.url` property, which by default
  * will be automatically provided to the service by Lagom's dev mode build plugins.
  */
-trait LagomDevModeServiceLocatorComponents {
+trait LagomDevModeServiceLocatorComponents extends CircuitBreakerComponents {
   /**
    * If being used in a Lagom service, this will be implemented by
    * [[com.lightbend.lagom.scaladsl.server.LagomServerComponents]], however if it's being
@@ -66,10 +65,6 @@ trait LagomDevModeServiceLocatorComponents {
   def executionContext: ExecutionContext
   def materializer: Materializer
   def actorSystem: ActorSystem
-
-  lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider = new CircuitBreakerMetricsProviderImpl(actorSystem)
-  lazy val circuitBreakerConfig: CircuitBreakerConfig = new CircuitBreakerConfig(configuration)
-  lazy val circuitBreakers: CircuitBreakers = new CircuitBreakers(actorSystem, circuitBreakerConfig, circuitBreakerMetricsProvider)
 
   lazy val devModeServiceLocatorUrl: URI = URI.create(configuration.underlying.getString("lagom.service-locator.url"))
   lazy val serviceRegistry: ServiceRegistry = {

--- a/docs/manual/scala/guide/services/ServiceClients.md
+++ b/docs/manual/scala/guide/services/ServiceClients.md
@@ -76,7 +76,12 @@ With the above "hello" example we could adjust the configuration by defining pro
 
 ### Circuit breaker metrics
 
-Lagom allows you to publish metrics for circuit breakers via a metrics service. A `MetricsService` is bound under the covers in every Lagom server. Then, for each instance of your service you can request the following endpoints:
+
+Lagom allows you to publish metrics for circuit breakers via a metrics service. To enable this service, mix in the [`MetricsServiceComponents`](api/com/lightbend/lagom/scaladsl/server/status/MetricsServiceComponents.html) trait into your application, and add the provided `metricsServiceBinding` to your service bindings in your `lagomServer` declaration, like so:
+
+@[metrics-service](code/ServiceClients.scala)
+
+The service provides the following endpoints:
 
 * `/_status/circuit-breaker/current` - Snapshot of current circuit breaker status
 * `/_status/circuit-breaker/stream` - Stream of circuit breaker status

--- a/docs/manual/scala/guide/services/ServiceClients.md
+++ b/docs/manual/scala/guide/services/ServiceClients.md
@@ -76,14 +76,9 @@ With the above "hello" example we could adjust the configuration by defining pro
 
 ### Circuit breaker metrics
 
-Lagom allows you to publish metrics for circuit breakers via a metrics service. To enable this service, mix in the [`MetricsServiceComponents`](api/com/lightbend/lagom/scaladsl/server/status/MetricsServiceComponents.html) trait into your application, and add the provided `metricsServiceBinding` to your service bindings in your `lagomServer` declaration, like so:
-
-@[metrics-service](code/ServiceClients.scala)
-
-The service provides the following endpoints:
+Lagom allows you to publish metrics for circuit breakers via a metrics service. A `MetricsService` is bound under the covers in every Lagom server. Then, for each instance of your service you can request the following endpoints:
 
 * `/_status/circuit-breaker/current` - Snapshot of current circuit breaker status
 * `/_status/circuit-breaker/stream` - Stream of circuit breaker status
 
 [Lightbend Monitoring](https://www.lightbend.com/products/monitoring) will provide metrics for Lagom circuit breakers, including aggregated views of the information for all nodes in the cluster.
-

--- a/docs/manual/scala/guide/services/code/ServiceClients.scala
+++ b/docs/manual/scala/guide/services/code/ServiceClients.scala
@@ -79,3 +79,27 @@ package circuitbreakers {
   }
 
 }
+
+
+package metricsservice {
+
+  import helloservice._
+  import com.lightbend.lagom.scaladsl.server.{LagomApplication, LagomApplicationContext, LagomServer}
+  import play.api.libs.ws.ahc.AhcWSComponents
+  import com.softwaremill.macwire._
+
+  //#metrics-service
+  import com.lightbend.lagom.scaladsl.server.status.MetricsServiceComponents
+
+  abstract class MyApplication(context: LagomApplicationContext)
+    extends LagomApplication(context)
+      with AhcWSComponents {
+
+    lazy val lagomServer = LagomServer.forServices(
+      bindService[HelloService].to(wire[HelloServiceImpl]),
+      metricsServiceBinding
+    )
+  }
+  //#metrics-service
+
+}

--- a/docs/manual/scala/guide/services/code/ServiceClients.scala
+++ b/docs/manual/scala/guide/services/code/ServiceClients.scala
@@ -79,27 +79,3 @@ package circuitbreakers {
   }
 
 }
-
-package metricsservice {
-
-  import helloservice._
-  import com.lightbend.lagom.scaladsl.server.{LagomApplication, LagomApplicationContext, LagomServer}
-  import play.api.libs.ws.ahc.AhcWSComponents
-  import com.softwaremill.macwire._
-
-  //#metrics-service
-  import com.lightbend.lagom.scaladsl.server.status.MetricsServiceComponents
-
-  abstract class MyApplication(context: LagomApplicationContext)
-    extends LagomApplication(context)
-      with AhcWSComponents
-      with MetricsServiceComponents {
-
-    lazy val lagomServer = LagomServer.forServices(
-      bindService[HelloService].to(wire[HelloServiceImpl]),
-      metricsServiceBinding
-    )
-  }
-  //#metrics-service
-
-}

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/ServiceLocator.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/ServiceLocator.scala
@@ -3,11 +3,9 @@
  */
 package com.lightbend.lagom.scaladsl.api
 
-import java.net.{ URI, URISyntaxException }
+import java.net.URI
 
 import com.lightbend.lagom.scaladsl.api.Descriptor.Call
-import com.typesafe.config.ConfigException
-import play.api.Configuration
 
 import scala.concurrent.{ ExecutionContext, Future }
 

--- a/service/scaladsl/client/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
+++ b/service/scaladsl/client/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceClient.scala
@@ -7,15 +7,16 @@ import java.io.File
 
 import akka.actor.ActorSystem
 import akka.stream.{ ActorMaterializer, Materializer }
+import com.lightbend.lagom.internal.client.CircuitBreakerMetricsProviderImpl
 import com.lightbend.lagom.internal.scaladsl.api.broker.TopicFactoryProvider
-import com.lightbend.lagom.scaladsl.api._
 import com.lightbend.lagom.internal.scaladsl.client.{ ScaladslClientMacroImpl, ScaladslServiceClient, ScaladslServiceResolver, ScaladslWebSocketClient }
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
+import com.lightbend.lagom.scaladsl.api._
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.api.deser.{ DefaultExceptionSerializer, ExceptionSerializer }
-import play.api.{ Configuration, Environment, Mode }
 import play.api.inject.{ ApplicationLifecycle, DefaultApplicationLifecycle }
 import play.api.libs.ws.WSClient
-import play.api.libs.ws.ahc.AhcWSComponents
+import play.api.{ Configuration, Environment, Mode }
 
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
@@ -112,9 +113,12 @@ trait LagomServiceClientComponents extends TopicFactoryProvider {
   def serviceInfo: ServiceInfo
   def serviceLocator: ServiceLocator
   def materializer: Materializer
+  def actorSystem: ActorSystem
   def executionContext: ExecutionContext
   def environment: Environment
   def applicationLifecycle: ApplicationLifecycle
+
+  lazy val circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider = new CircuitBreakerMetricsProviderImpl(actorSystem)
 
   lazy val serviceResolver: ServiceResolver = new ScaladslServiceResolver(defaultExceptionSerializer)
   lazy val defaultExceptionSerializer: ExceptionSerializer = new DefaultExceptionSerializer(environment)
@@ -127,7 +131,7 @@ trait LagomServiceClientComponents extends TopicFactoryProvider {
 }
 
 /**
- * Convienence for constructing service clients in a non Lagom server application.
+ * Convenience for constructing service clients in a non Lagom server application.
  *
  * It is important to invoke [[#stop]] when the application is no longer needed, as this will trigger the shutdown
  * of all thread and connection pools.

--- a/service/scaladsl/client/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceLocators.scala
+++ b/service/scaladsl/client/src/main/scala/com/lightbend/lagom/scaladsl/client/ServiceLocators.scala
@@ -7,7 +7,8 @@ import java.net.{ URI, URISyntaxException }
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.ActorSystem
-import com.lightbend.lagom.internal.client.{ CircuitBreakerConfig, CircuitBreakerMetricsProviderImpl, CircuitBreakers }
+import com.lightbend.lagom.internal.client.{ CircuitBreakerConfig, CircuitBreakers }
+import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
 import com.lightbend.lagom.scaladsl.api.Descriptor.Call
 import com.lightbend.lagom.scaladsl.api.{ CircuitBreaker, Descriptor, ServiceLocator }
 import com.typesafe.config.ConfigException
@@ -69,9 +70,10 @@ trait CircuitBreakerComponents {
   def actorSystem: ActorSystem
   def configuration: Configuration
   def executionContext: ExecutionContext
+  def circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider
 
   lazy val circuitBreakerConfig: CircuitBreakerConfig = new CircuitBreakerConfig(configuration)
-  lazy val circuitBreakers = new CircuitBreakers(actorSystem, circuitBreakerConfig, new CircuitBreakerMetricsProviderImpl(actorSystem))
+  lazy val circuitBreakers = new CircuitBreakers(actorSystem, circuitBreakerConfig, circuitBreakerMetricsProvider)
 }
 
 /**

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -18,6 +18,7 @@ import com.lightbend.lagom.scaladsl.api.deser.DefaultExceptionSerializer
 import com.lightbend.lagom.scaladsl.api._
 import com.lightbend.lagom.scaladsl.client.{ CircuitBreakingServiceLocator, LagomServiceClientComponents }
 import com.lightbend.lagom.scaladsl.playjson.{ EmptyJsonSerializerRegistry, JsonSerializerRegistry, ProvidesJsonSerializerRegistry }
+import com.lightbend.lagom.scaladsl.server.status.MetricsServiceComponents
 import com.typesafe.config.Config
 import play.api._
 import play.api.ApplicationLoader.Context
@@ -187,7 +188,8 @@ abstract class LagomApplication(context: LagomApplicationContext)
   with ProvidesAdditionalConfiguration
   with ProvidesJsonSerializerRegistry
   with LagomServerComponents
-  with LagomServiceClientComponents {
+  with LagomServiceClientComponents
+  with MetricsServiceComponents {
 
   override implicit lazy val executionContext: ExecutionContext = actorSystem.dispatcher
   override lazy val configuration: Configuration = Configuration.load(environment) ++

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomServer.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomServer.scala
@@ -48,7 +48,7 @@ object LagomServer {
   }
 }
 
-trait LagomServerComponents {
+trait LagomServerComponents extends MetricsServiceComponents {
   def httpConfiguration: HttpConfiguration
   def materializer: Materializer
   def executionContext: ExecutionContext

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomServer.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomServer.scala
@@ -7,6 +7,7 @@ import akka.stream.Materializer
 import com.lightbend.lagom.internal.scaladsl.server.{ ScaladslServerMacroImpl, ScaladslServiceRouter }
 import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceInfo }
 import com.lightbend.lagom.scaladsl.client.ServiceResolver
+import com.lightbend.lagom.scaladsl.server.status.MetricsServiceComponents
 import play.api.http.HttpConfiguration
 import play.api.mvc.{ Handler, RequestHeader }
 import play.api.routing.Router.Routes
@@ -28,8 +29,7 @@ sealed trait LagomServer {
 }
 
 object LagomServer {
-
-  @deprecated("Binding multiple locatable ServiceDescriptors per Lagom service is unsupported. Use LagomServer.forService() instead", "1.3.2")
+  @deprecated("Binding multiple locatable ServiceDescriptors per Lagom service is unsupported. Use LagomServer.forService() instead", "1.3.1")
   def forServices(bindings: LagomServiceBinding[_]*): LagomServer = {
     new LagomServer {
       override val serviceBindings: immutable.Seq[LagomServiceBinding[_]] = bindings.to[immutable.Seq]

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/status/MetricsService.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/status/MetricsService.scala
@@ -6,6 +6,7 @@ package com.lightbend.lagom.scaladsl.server.status
 import java.time.Instant
 
 import akka.NotUsed
+import akka.actor.ActorSystem
 import akka.stream.scaladsl.Source
 import com.lightbend.lagom.internal.client.{ CircuitBreakerMetricsImpl, CircuitBreakerMetricsProviderImpl }
 import com.lightbend.lagom.internal.spi.CircuitBreakerMetricsProvider
@@ -44,7 +45,8 @@ trait MetricsService extends Service {
  * Provides an in-built metrics service.
  */
 trait MetricsServiceComponents extends LagomServerComponents {
-  def circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider
+  def actorSystem: ActorSystem
+  def circuitBreakerMetricsProvider: CircuitBreakerMetricsProvider = new CircuitBreakerMetricsProviderImpl(actorSystem)
 
   lazy val metricsServiceBinding: LagomServiceBinding[MetricsService] = {
     // Can't use the bindService macro here, since it's in the same compilation unit. The code below is exactly what


### PR DESCRIPTION
This is related to #635 and #580. 

This PR is just some ideas to try and make MetricsProvider enabled and setup to use the default impl in scaladsl so it's easier for users. This is not meant to be merged yet.

If merged, this should be backported to `1.3.x`.