### PR TITLE
Update Akka Persistence Cassandra to 0.24

### DIFF
--- a/persistence-cassandra/core/src/main/resources/reference.conf
+++ b/persistence-cassandra/core/src/main/resources/reference.conf
@@ -29,56 +29,34 @@ lagom.persistence.read-side {
     cluster-id = "cas_native"
     cluster-id = ${?CASSANDRA_SERVICE_NAME}
 
-    # Write consistency level
-    write-consistency = "QUORUM"
-
-    # Read consistency level
-    read-consistency = "QUORUM"
-
-    # The name of the Cassandra keyspace
+    # Name of the keyspace to be created/used by the read-side session
     keyspace = ${lagom.defaults.persistence.read-side.cassandra.keyspace}
 
-    # Parameter indicating whether the journal keyspace should be auto created
+    # Parameter indicating whether the read-side keyspace should be auto created
     keyspace-autocreate = true
 
-    # replication strategy to use when creating keyspace.
-    # SimpleStrategy or NetworkTopologyStrategy
-    replication-strategy = "SimpleStrategy"
+    # Parameter indicating whether the read-side tables should be auto created
+    # TODO: currently unused, see https://github.com/lagom/lagom/issues/605
+    tables-autocreate = true
 
-    # Replication factor to use when creating keyspace.
-    # Is only used when replication-strategy is SimpleStrategy.
-    replication-factor = 1
+    # The number of retries when a write request returns a TimeoutException or an UnavailableException.
+    write-retries = 3
 
-    # Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"].
-    # Is only used when replication-strategy is NetworkTopologyStrategy.
-    data-center-replication-factors = []
+    # Deletes are achieved using a metadata entry and then the actual messages are deleted asynchronously
+    # Number of retries before giving up
+    delete-retries = 3
 
-    # To limit the Cassandra hosts that it connects to a specific datacenter.
-    # (DCAwareRoundRobinPolicy withLocalDc)
-    # The id for the local datacenter of the Cassandra hosts it should connect to.
-    # By default, this property is not set resulting in Datastax's standard round robin policy being used.
-    local-datacenter = ""
+    # The number of retries when a read query fails.
+    read-retries = 3
 
-    # To connect to the Cassandra hosts with credentials.
-    # Authentication is disabled if username is not configured.
-    authentication.username = ""
-    authentication.password = ""
+    # Set this to a positive integer to enable speculative executions.
+    # The value defines the number of speculative executions that will be
+    # performed with the delay defined by 'speculative-executions-delay'.
+    # See http://docs.datastax.com/en/developer/java-driver/3.1/manual/speculative_execution/
+    speculative-executions = 0
 
-    # SSL can be configured with the following properties.
-    # SSL is disabled if the truststore is not configured.
-    # For detailed instructions, please refer to the DataStax Cassandra chapter about
-    # SSL Encryption: http://docs.datastax.com/en/cassandra/2.0/cassandra/security/secureSslEncryptionTOC.html
-    # Path to the JKS Truststore file
-    ssl.truststore.path = ""
-    # Password to unlock the JKS Truststore
-    ssl.truststore.password = ""
-    # Path to the JKS Keystore file (optional config, only needed for client authentication)
-    ssl.keystore.path = ""
-    # Password to unlock JKS Truststore and access the private key (both must use the same password)
-    ssl.keystore.password = ""
-
-    # Maximum size of result set
-    max-result-size = 50001
+    # See 'speculative-executions'
+    speculative-executions-delay = 1s
 
     # Number of retries before giving up connecting for the initial connection to the Cassandra cluster
     connect-retries = 3
@@ -90,8 +68,12 @@ lagom.persistence.read-side {
     # to the Cassandra cluster
     reconnect-max-delay = 30s
 
+    # Enable debug logging of queries as described in
+    # https://docs.datastax.com/en/developer/java-driver/3.1/manual/logging/#logging-query-latencies
+    log-queries = off
+
     # Cassandra driver connection pool settings
-    # Documented at https://datastax.github.io/java-driver/features/pooling/
+    # Documented at http://docs.datastax.com/en/developer/java-driver/latest/manual/pooling/
     connection-pool {
 
       # Create new connection threshold local
@@ -122,12 +104,58 @@ lagom.persistence.read-side {
       pool-timeout-millis = 0
     }
 
+    # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
+    replication-strategy = "SimpleStrategy"
+
+    # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
+    replication-factor = 1
+
+    # Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
+    data-center-replication-factors = []
+
+    # To limit the Cassandra hosts this plugin connects with to a specific datacenter.
+    # (DCAwareRoundRobinPolicy withLocalDc)
+    # The id for the local datacenter of the Cassandra hosts it should connect to.
+    # By default, this property is not set resulting in Datastax's standard round robin policy being used.
+    local-datacenter = ""
+
+    # Number of hosts from non-local datacenter to use as a fall-back policy.
+    # Works only when local-datacenter is set
+    used-hosts-per-remote-dc = 0
+
+    # To connect to the Cassandra hosts with credentials.
+    # Authentication is disabled if username is not configured.
+    authentication.username = ""
+    authentication.password = ""
+
+    # SSL can be configured with the following properties.
+    # SSL is disabled if the truststore is not configured.
+    # For detailed instructions, please refer to the DataStax Cassandra chapter about
+    # SSL Encryption: http://docs.datastax.com/en/cassandra/2.0/cassandra/security/secureSslEncryptionTOC.html
+    # Path to the JKS Truststore file
+    ssl.truststore.path = ""
+    # Password to unlock the JKS Truststore
+    ssl.truststore.password = ""
+    # Path to the JKS Keystore file (optional config, only needed for client authentication)
+    ssl.keystore.path = ""
+    # Password to unlock JKS Truststore and access the private key (both must use the same password)
+    ssl.keystore.password = ""
+
+    # Write consistency level
+    write-consistency = "QUORUM"
+
+    # Read consistency level
+    read-consistency = "QUORUM"
+
+    # Maximum size of result set
+    max-result-size = 50001
+
     # Set the protocol version explicitly, should only be used for compatibility testing.
     # Supported values: 3, 4
     protocol-version = ""
-    
+
     # Options to configure low-level socket options for the connections to Cassandra hosts
-    # See: https://datastax.github.io/java-driver/manual/socket_options
+    # See: http://docs.datastax.com/en/developer/java-driver/latest/manual/socket_options
     socket {
 
       # how long the driver waits to establish a new connection to a Cassandra node before giving up
@@ -150,9 +178,9 @@ lagom.persistence.read-side {
 }
 
 lagom.defaults.persistence.read-side.cassandra {
-	# Port of contact points in the Cassandra cluster
-	port = 9042
-	keyspace = "lagom_read"
+  # Port of contact points in the Cassandra cluster
+  port = 9042
+  keyspace = "lagom_read"
 }
 #//#persistence-read-side
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val PlayVersion = "2.5.13"
   val AkkaVersion = "2.4.17"
   val ScalaVersion = "2.11.8"
-  val AkkaPersistenceCassandraVersion = "0.22"
+  val AkkaPersistenceCassandraVersion = "0.24"
   val ScalaTestVersion = "3.0.1"
   val JacksonVersion = "2.7.8"
   val CassandraAllVersion = "3.0.9"


### PR DESCRIPTION
This also required introducing new session configuration settings to the read-side reference.conf. To make this easier, other settings were also reordered to match their position in the cassandra-journal configuration. Comments were also updated.