### PR TITLE
Use new Slick 3.2 DB profile classes in configuration defaults and examples

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
@@ -45,7 +45,7 @@ db.default {
   url = "jdbc:postgresql://database.example.com/playdb"
 }
 
-jdbc-defaults.slick.driver = "slick.driver.PostgresDriver$"
+jdbc-defaults.slick.driver = "slick.jdbc.PostgresProfile$"
 ```
 
 ## Table creation

--- a/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
@@ -45,7 +45,7 @@ db.default {
   url = "jdbc:postgresql://database.example.com/playdb"
 }
 
-jdbc-defaults.slick.driver = "slick.driver.PostgresDriver$"
+jdbc-defaults.slick.driver = "slick.jdbc.PostgresProfile$"
 ```
 
 ## Table creation

--- a/persistence-jdbc/core/src/main/resources/reference.conf
+++ b/persistence-jdbc/core/src/main/resources/reference.conf
@@ -3,7 +3,7 @@
 jdbc-defaults.slick {
 
   # The driver to use
-  driver = "slick.driver.H2Driver$"
+  driver = "slick.jdbc.H2Profile$"
 
   # The JNDI name
   jndiName = "DefaultDS"


### PR DESCRIPTION
This was accidentally left out of #642 