### PR TITLE
Fixes to getting started procedures. 

### DIFF
--- a/docs/manual/java/gettingstarted/GettingStartedMaven.md
+++ b/docs/manual/java/gettingstarted/GettingStartedMaven.md
@@ -9,7 +9,7 @@ Follow these instructions to create and run your first project:
 
 ## Generate a project with the Lagom archetype
 
-Choose a location on your file system for your Lagom projects. Maven will prompt you for a project name and will create a directory with that name that contains the build structure and Lagom example services. 
+Choose a location on your file system for your Lagom projects. Maven will prompt you for a project name and will create a directory with that name that contains the build structure and Lagom example services. Note that it can take from a few seconds to a few minutes for Maven to download dependencies.
 
 To create your project, follow these steps:
 
@@ -23,7 +23,8 @@ To create your project, follow these steps:
     Choose archetype:
     1: remote -> com.lightbend.lagom:maven-archetype-lagom-java (maven-archetype-lagom-java)
     Choose a number or apply filter (format: [groupId:]artifactId, case sensitive contains): :
-    ```
+    ``` 
+    
 1. Enter the number that corresponds with `com.lightbend.lagom:maven-archetype-lagom-java` (at time of writing, the number `1`, and the only one available).
     Maven prompts you for the version.
 1. Enter the number corresponding with the version of Lagom you want to use. We recommend using the [current stable release](https://www.lagomframework.com/documentation/)).
@@ -35,7 +36,7 @@ To create your project, follow these steps:
     * `package` - Press `Enter` to accept the default, which is the same as the `groupId`.  
     Maven prompts you to confirm POM values.    
 1. Enter `Y` to accept the values.
-   Maven creates the project, and completes with a message similar to the following:
+   When finished, Maven creates the project, and completes with a message similar to the following:
    
 ```
    [INFO] ------------------------------------------------------------------------
@@ -72,11 +73,17 @@ Note that the `hello` and `stream` services each have:
 
 ## Run Hello World
 
-Lagom provides a `runAll` command to start the Lagom `hello` and `stream` services and runtime components, which include: Cassandra, Akka, and Kafka. From the top-level group directory, such as `my-first-system`, execute `lagom:runAll` (some console output omitted for brevity):
+Lagom provides a `runAll` command to start the Lagom `hello` and `stream` services and runtime components, which include: Cassandra, Akka, and Kafka. From the top-level group directory, such as `my-first-system`, execute `lagom:runAll`.
+
+For example:
 
 ```console
 cd my-first-system
 mvn lagom:runAll
+```
+It will take a bit of time for the services to start. The `Services started` message indicates the system is running:
+
+```
 ...
 [info] Starting embedded Cassandra server
 ..........

--- a/docs/manual/java/gettingstarted/GettingStartedSbt.md
+++ b/docs/manual/java/gettingstarted/GettingStartedSbt.md
@@ -12,7 +12,7 @@ Follow these steps to create your first Lagom build:
 
 ## Create a new Lagom build
 
-Choose a location on your file system for your Lagom projects. The template will prompt you for a project name and will create a directory with that name that contains the build structure and Lagom example services. 
+Choose a location on your file system for your Lagom projects. The template will prompt you for a project name and will create a directory with that name that contains the build structure and Lagom example services. Note that it can take from a few seconds to a few minutes for sbt to download dependencies.
 
 To create your project, follow these steps:
 
@@ -61,7 +61,7 @@ sbt
 ... (booting up)
 > runAll
 ```
-Among other messages, you should see the following:
+It will take a bit of time to build the project and start the services. Among other messages, you should see the following:
 ```
 [info] Starting embedded Cassandra server
 ..........
@@ -73,12 +73,13 @@ Among other messages, you should see the following:
 (Services started, press enter to stop and go back to the console...)
 ```
 
-You can verify that the services are indeed up and running by invoking a service endpoint from any HTTP client, such as a browser. The following request returns the message `Hello, World!`:
+You can verify that the services are indeed up and running by invoking a service endpoint from any HTTP client, such as a browser:
 
 ```
 http://localhost:9000/api/hello/World
 ```
-Congratulations! You've created and run your first Lagom system. 
+
+The service returns the message, `Hello, World!`. Congratulations! You've created and run your first Lagom system. 
 
 
 

--- a/docs/manual/java/guide/build/IntellijSbtJava.md
+++ b/docs/manual/java/guide/build/IntellijSbtJava.md
@@ -48,7 +48,7 @@ After you have an sbt build -- one you created yourself or from a template -- fo
     1. From the **Run** menu, select **Run**.
     1. Click **Edit Configurations...**.
     1. Click **+** (Add New Configuration).
-    1. Select **SBT**.
+    1. Select **SBT Task**.
     1. Name your configuration. 
     1. In the **Tasks** field, enter `runAll`.
     1. Click **Run**.

--- a/docs/manual/scala/gettingstarted/IntroGetStarted.md
+++ b/docs/manual/scala/gettingstarted/IntroGetStarted.md
@@ -10,7 +10,7 @@ Follow these steps to create and run Hello World:
 
 ## Create the build
 
-Choose a location on your file system for your Lagom projects. The template will prompt you for a project name and will create a directory with that name that contains the build structure and Lagom example services. 
+Choose a location on your file system for your Lagom projects. The template will prompt you for a project name and will create a directory with that name that contains the build structure and Lagom example services. Note that it can take from a few seconds to a few minutes for sbt to download dependencies.
 
 To create your project, follow these steps:
 
@@ -59,7 +59,7 @@ sbt
 ... (booting up)
 > runAll
 ```
-Among other messages, you should see the following:
+It will take a bit of time to build the project and start the services. Among other messages, you should see the following:
 ```
 [info] Starting embedded Cassandra server
 ..........
@@ -71,11 +71,12 @@ Among other messages, you should see the following:
 (Services started, press enter to stop and go back to the console...)
 ```
 
-Verify that the services are indeed up and running by invoking one of its endpoints from any HTTP client, such as a browser. The following request returns the message `Hello, World!`:
+Verify that the services are indeed up and running by invoking one of its endpoints from any HTTP client, such as a browser:
 
 ```
 http://localhost:9000/api/hello/World
 ```
 
+The service returns the message, `Hello, World!`. Congratulations, you've built your first Lagom project!
 
 

--- a/docs/manual/scala/guide/build/IntellijSbt.md
+++ b/docs/manual/scala/guide/build/IntellijSbt.md
@@ -52,7 +52,7 @@ After you have an sbt build -- one you created yourself or from a template -- fo
     1. From the **Run** menu, select **Run**.
     1. Click **Edit Configurations...**.
     1. Click **+** (Add New Configuration).
-    1. Select **SBT**.
+    1. Select **SBT Task**.
     1. Name your configuration. 
     1. In the **Tasks** field, enter `runAll`.
     1. Click **Run**.


### PR DESCRIPTION
It instills confidence if the user knows it will take a bit of time for both the initial project setup and runAll. Also, in the IntelliJ instructions, when creating a Run configuration, the step should say to select "SBT Task". Fixes #653