### PR TITLE
remove an extra 'the' in persistententity-doc

### DIFF
--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -123,7 +123,7 @@ You can send a negative acknowledgment with `ctx.commandFailed`, which will fail
 
 If persisting the events fails a negative acknowledgment is automatically sent, which will fail the `Future` on the sender side with `PersistentEntity.PersistException`.
 
-If the `PersistentEntity` receives a command for which there is no registered command handler a negative acknowledgment is automatically sent, which will fail the the `Future` on the sender side with `PersistentEntity.UnhandledCommandException`.
+If the `PersistentEntity` receives a command for which there is no registered command handler a negative acknowledgment is automatically sent, which will fail the `Future` on the sender side with `PersistentEntity.UnhandledCommandException`.
 
 If you don't reply to a command the `Future` on the sender side will be completed with a `akka.pattern.AskTimeoutException` after a timeout.
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

This PR fixes a typo in the documentation for PersistentEntity.
