### PR TITLE
Ensure maven plugin adds right dependency for Play integration

### DIFF
--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceManager.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServiceManager.scala
@@ -47,7 +47,7 @@ class ServiceManager @Inject() (logger: MavenLoggerProxy, session: MavenSession,
   private def calculateDevModeDependencies(scalaBinaryVersion: String, playService: Boolean,
                                            serviceLocatorUrl: Option[String], cassandraPort: Option[Int]): Seq[Dependency] = {
     if (playService) {
-      devModeDependencies(scalaBinaryVersion, Seq("lagom-play-integration", "lagom-reloadable-server"))
+      devModeDependencies(scalaBinaryVersion, Seq("lagom-javadsl-play-integration", "lagom-reloadable-server"))
     } else {
       devModeDependencies(
         scalaBinaryVersion,


### PR DESCRIPTION
The name of this artifact changed when the scaladsl was introduced, but the Maven plugin was never fixed to support it.