### PR TITLE
Update Akka Persistence Cassandra to 0.26

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -478,7 +478,7 @@ lazy val `integration-tests-scaladsl` = (project in file("service/scaladsl/integ
   )
   .dependsOn(`server-scaladsl`, logback, `testkit-scaladsl`)
 
-// for forked tests, necessary for Cassandra
+// for forked tests
 def forkedTests: Seq[Setting[_]] = Seq(
   fork in Test := true,
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
@@ -594,7 +594,6 @@ lazy val `persistence-cassandra-core` = (project in file("persistence-cassandra/
   .dependsOn(`persistence-core` % "compile;test->test")
   .settings(runtimeLibCommon: _*)
   .enablePlugins(RuntimeLibPlugins)
-  .settings(forkedTests: _*)
   .settings(
     name := "lagom-persistence-cassandra-core",
     Dependencies.`persistence-cassandra-core`
@@ -615,7 +614,6 @@ lazy val `persistence-cassandra-javadsl` = (project in file("persistence-cassand
   .settings(mimaSettings(since12): _*)
   .settings(multiJvmTestSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
-  .settings(forkedTests: _*)
   .settings() configs (MultiJvm)
 
 lazy val `persistence-cassandra-scaladsl` = (project in file("persistence-cassandra/scaladsl"))
@@ -628,7 +626,6 @@ lazy val `persistence-cassandra-scaladsl` = (project in file("persistence-cassan
   .settings(runtimeLibCommon: _*)
   .settings(multiJvmTestSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
-  .settings(forkedTests: _*)
   .settings() configs (MultiJvm)
 
 

--- a/persistence-cassandra/core/src/main/resources/test-embedded-cassandra.yaml
+++ b/persistence-cassandra/core/src/main/resources/test-embedded-cassandra.yaml
@@ -1,0 +1,64 @@
+# This overrides the default configuration from akka-persistence-cassandra 0.26+,
+# which now requires Cassandra 3.8+ after adding the cdc_raw_directory setting
+#
+# Cassandra storage config YAML
+# Reference: http://docs.datastax.com/en/cassandra/3.x/cassandra/configuration/configCassandra_yaml.html
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# directories where Cassandra should store data on disk.
+data_file_directories:
+    - $DIR/data
+
+# commit log
+commitlog_directory: $DIR/commitlog
+
+# saved caches
+saved_caches_directory: $DIR/saved_caches
+
+hints_directory: $DIR/hints
+
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+endpoint_snitch: SimpleSnitch
+
+listen_address: 127.0.0.1
+
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+native_transport_port: $PORT
+
+# TCP port, for commands and data
+storage_port: $STORAGE_PORT
+
+# Whether to start the thrift rpc server.
+start_rpc: false
+
+
+seed_provider:
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1"
+
+
+# The following settings were inspired by
+# http://opensourceconnections.com/blog/2013/08/31/building-the-perfect-cassandra-test-environment/
+rpc_server_type: hsha
+concurrent_reads: 2
+concurrent_writes: 2
+rpc_min_threads: 1
+rpc_max_threads: 1
+concurrent_compactors: 1
+compaction_throughput_mb_per_sec: 0
+key_cache_size_in_mb: 0
+hinted_handoff_enabled: false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val PlayVersion = "2.5.13"
   val AkkaVersion = "2.4.17"
   val ScalaVersion = "2.11.8"
-  val AkkaPersistenceCassandraVersion = "0.25.1"
+  val AkkaPersistenceCassandraVersion = "0.26"
   val ScalaTestVersion = "3.0.1"
   val JacksonVersion = "2.7.8"
   val CassandraAllVersion = "3.0.9"
@@ -70,7 +70,7 @@ object Dependencies {
       "com.addthis.metrics" % "reporter-config3" % "3.0.0",
       "com.boundary" % "high-scale-lib" % "1.0.6",
       "com.clearspring.analytics" % "stream" % "2.5.2",
-      "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.0",
+      "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.4",
       "com.fasterxml" % "classmate" % "1.3.0",
       "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
       "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.4.17.1",


### PR DESCRIPTION
Fixes #664 and #435.

Also includes a fix for non-standard ports in a Cassandra cluster (akka/akka-persistence-cassandra#187).