### PR TITLE
Add support for HTTPS on seed-based project creation

### DIFF
--- a/docs/manual/java/gettingstarted/GettingStartedSbt.md
+++ b/docs/manual/java/gettingstarted/GettingStartedSbt.md
@@ -21,7 +21,7 @@ To create your project, follow these steps:
 
 1. Enter the following command to invoke `sbt new` using the Lagom Giter8 template:
    ```
-   sbt new -Dsbt.version=0.13.13 lagom/lagom-java.g8
+   sbt -Dsbt.version=0.13.15 new https://github.com/lagom/lagom-java.g8
    ```
 1. The sbt Lagom template prompts for the following parameters. Press `Enter` to accept the defaults or specify your own values:
 

--- a/docs/manual/scala/gettingstarted/IntroGetStarted.md
+++ b/docs/manual/scala/gettingstarted/IntroGetStarted.md
@@ -18,7 +18,7 @@ To create your project, follow these steps:
 
 1. Enter the following command:
    ```
-   sbt new -Dsbt.version=0.13.13 lagom/lagom-scala.g8
+   sbt -Dsbt.version=0.13.15 new https://github.com/lagom/lagom-scala.g8
    ```
 
 1. The template prompts for the following parameters. Press `Enter` to accept the defaults or specify your own values:


### PR DESCRIPTION
Changing the transport when using `sbt new` requires 0.13.15 which has a 
more strict syntax when parsing arguments requiring reordering.

Fixes #683

Needs backporting to `1.3.x`