### PR TITLE
Refactor the service locator holder to expose a future to avoid polling

### DIFF
--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProvider.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProvider.scala
@@ -25,50 +25,17 @@ private[lagom] final class ServiceLocatorSessionProvider(system: ActorSystem, co
   private val log = Logger(getClass)
 
   override def lookupContactPoints(clusterId: String)(implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] = {
-    val result = ServiceLocatorHolder(system).serviceLocator match {
-      case Some(serviceLocator) =>
-        serviceLocator.locate(clusterId).map {
-          case Some(uri) =>
-            log.debug(s"Found Cassandra contact points: $uri")
-            require(uri.getHost != null, s"missing host in $uri for Cassandra contact points $clusterId")
-            require(uri.getPort != -1, s"missing port in $uri for Cassandra contact points $clusterId")
-            List(new InetSocketAddress(uri.getHost, uri.getPort))
-          case None =>
-            // fail the future
-            throw new NoContactPointsException(s"No contact points for [$clusterId]")
-        }
-
-      case None =>
-        val promise = Promise[immutable.Seq[InetSocketAddress]]()
-
-        // retry a few times to best effort to avoid failure due to startup race condition between Akka Persistence
-        // and the binding of the ServiceLocator in the  Guice module
-        def tryAgain(count: Int): Unit = {
-          if (count == 0)
-            promise.failure(new IllegalStateException("ServiceLocator is not bound"))
-          else {
-            system.scheduler.scheduleOnce(200.millis) {
-              if (ServiceLocatorHolder(system).serviceLocator.isDefined)
-                promise.completeWith(lookupContactPoints(clusterId))
-              else
-                tryAgain(count - 1)
-            }
-          }
-        }
-
-        tryAgain(10)
-
-        promise.future
+    ServiceLocatorHolder(system).serviceLocatorEventually flatMap { serviceLocator =>
+      serviceLocator.locate(clusterId).map {
+        case Some(uri) =>
+          log.debug(s"Found Cassandra contact points: $uri")
+          require(uri.getHost != null, s"missing host in $uri for Cassandra contact points $clusterId")
+          require(uri.getPort != -1, s"missing port in $uri for Cassandra contact points $clusterId")
+          List(new InetSocketAddress(uri.getHost, uri.getPort))
+        case _ => throw new NoContactPointsException(s"No contact points for [$clusterId]")
+      }
     }
-
-    result.onFailure {
-      case e =>
-        log.warn(s"Could not find Cassandra contact points, due to: ${e.getMessage}")
-    }
-
-    result
   }
-
 }
 
 private[lagom] final class NoContactPointsException(msg: String) extends RuntimeException(msg) with NoStackTrace

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorHolderSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorHolderSpec.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import akka.actor.ActorSystem
+import org.scalatest.{ MustMatchers, WordSpec }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class ServiceLocatorHolderSpec extends WordSpec with MustMatchers {
+  val system = ActorSystem("test")
+
+  "ServiceLocatorHolder" should {
+    "timeout when no service locator is found" in {
+      val eventually = ServiceLocatorHolder(system).serviceLocatorEventually
+      assertThrows[NoServiceLocatorException](
+        Await.result(eventually, 15.seconds)
+      )
+    }
+  }
+}

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorHolderSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorHolderSpec.scala
@@ -16,7 +16,7 @@ class ServiceLocatorHolderSpec extends WordSpec with MustMatchers {
     "timeout when no service locator is found" in {
       val eventually = ServiceLocatorHolder(system).serviceLocatorEventually
       assertThrows[NoServiceLocatorException](
-        Await.result(eventually, ServiceLocatorHolder.TIMEOUT + 2.seconds )
+        Await.result(eventually, ServiceLocatorHolder.TIMEOUT + 2.seconds)
       )
     }
   }

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorHolderSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorHolderSpec.scala
@@ -16,7 +16,7 @@ class ServiceLocatorHolderSpec extends WordSpec with MustMatchers {
     "timeout when no service locator is found" in {
       val eventually = ServiceLocatorHolder(system).serviceLocatorEventually
       assertThrows[NoServiceLocatorException](
-        Await.result(eventually, 15.seconds)
+        Await.result(eventually, ServiceLocatorHolder.TIMEOUT + 2.seconds )
       )
     }
   }

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProviderSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProviderSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import java.net.{ InetSocketAddress, URI }
+
+import akka.actor.ActorSystem
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.{ MustMatchers, WordSpec }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+
+class ServiceLocatorSessionProviderSpec extends WordSpec with MustMatchers {
+  val system = ActorSystem("test")
+  val config: Config = ConfigFactory.load()
+  val uri = new URI("http://localhost:8080")
+
+  val locator = new ServiceLocatorAdapter {
+    override def locate(name: String): Future[Option[URI]] = {
+      name match {
+        case "existing" => Future.successful(Some(uri))
+        case "absent"   => Future.successful(None)
+      }
+    }
+
+  }
+
+  val providerConfig: Config = config.getConfig("lagom.persistence.read-side.cassandra")
+  val provider = new ServiceLocatorSessionProvider(system, providerConfig)
+  ServiceLocatorHolder(system).setServiceLocator(locator)
+
+  "ServiceLocatorSessionProvider" should {
+
+    "Get the address when the contact points exist" in {
+      val future = provider.lookupContactPoints("existing")
+
+      Await.result(future, 3 seconds) mustBe Seq(new InetSocketAddress(uri.getHost, uri.getPort))
+    }
+
+    "Fail the future when the contact points do not exist" in {
+      val future = provider.lookupContactPoints("absent")
+
+      intercept[NoContactPointsException] {
+        Await.result(future, 3 seconds)
+      }
+    }
+  }
+}

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProviderSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/ServiceLocatorSessionProviderSpec.scala
@@ -37,14 +37,14 @@ class ServiceLocatorSessionProviderSpec extends WordSpec with MustMatchers {
     "Get the address when the contact points exist" in {
       val future = provider.lookupContactPoints("existing")
 
-      Await.result(future, 3 seconds) mustBe Seq(new InetSocketAddress(uri.getHost, uri.getPort))
+      Await.result(future, 3.seconds) mustBe Seq(new InetSocketAddress(uri.getHost, uri.getPort))
     }
 
     "Fail the future when the contact points do not exist" in {
       val future = provider.lookupContactPoints("absent")
 
       intercept[NoContactPointsException] {
-        Await.result(future, 3 seconds)
+        Await.result(future, 3.seconds)
       }
     }
   }

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraConfigProvider.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraConfigProvider.scala
@@ -29,15 +29,16 @@ final class CassandraConfigProvider @Inject() (system: ActorSystem) extends Prov
   override lazy val get: CassandraConfig = CassandraConfigProvider.CassandraConfigImpl(cassandraUrisFromConfig)
 
   private def cassandraUrisFromConfig: PSet[CassandraContactPoint] = {
-    val contactPoints = List("cassandra-journal", "cassandra-snapshot-store", "lagom.persistence.read-side.cassandra").flatMap { path =>
-      val c = config.getConfig(path)
-      if (c.getString("session-provider") == classOf[ServiceLocatorSessionProvider].getName) {
-        val name = c.getString("cluster-id")
-        val port = c.getInt("port")
-        val uri = new URI(s"tcp://127.0.0.1:$port/$name")
-        Some(CassandraContactPoint.of(name, uri))
-      } else None
-    }.toSet
+    val contactPoints: Set[CassandraContactPoint] =
+      List("cassandra-journal", "cassandra-snapshot-store", "lagom.persistence.read-side.cassandra").flatMap { path =>
+        val c = config.getConfig(path)
+        if (c.getString("session-provider") == classOf[ServiceLocatorSessionProvider].getName) {
+          val name = c.getString("cluster-id")
+          val port = c.getInt("port")
+          val uri = new URI(s"tcp://127.0.0.1:$port/$name")
+          Some(CassandraContactPoint.of(name, uri))
+        } else None
+      }.toSet
     HashTreePSet.from(contactPoints.asJava)
   }
 }
@@ -46,5 +47,7 @@ final class CassandraConfigProvider @Inject() (system: ActorSystem) extends Prov
  * Internal API
  */
 private object CassandraConfigProvider {
+
   final case class CassandraConfigImpl(uris: PSet[CassandraContactPoint]) extends CassandraConfig
+
 }

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceModule.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceModule.scala
@@ -41,14 +41,14 @@ class CassandraPersistenceModule extends AbstractModule {
       override def hear[I](typeLiteral: TypeLiteral[I], typeEncounter: TypeEncounter[I]): Unit = {
         typeEncounter.register(new InjectionListener[I] {
           override def afterInjection(i: I): Unit = {
-            i.asInstanceOf[CassandraPersistenceModule.InitServiceLocatorHolder].init();
+            i.asInstanceOf[CassandraPersistenceModule.InitServiceLocatorHolder].init()
           }
         })
       }
     }
     val matcher = new AbstractMatcher[TypeLiteral[_]] {
       override def matches(typeLiteral: TypeLiteral[_]): Boolean = {
-        return classOf[CassandraPersistenceModule.InitServiceLocatorHolder] == typeLiteral.getRawType;
+        classOf[CassandraPersistenceModule.InitServiceLocatorHolder] == typeLiteral.getRawType
       }
     }
     binder.bindListener(matcher, listener)
@@ -83,4 +83,5 @@ private object CassandraPersistenceModule {
       }
     }
   }
+
 }


### PR DESCRIPTION
This is a rewrite of #410. Thanks @tommpy

Please note #410 also introduced a change on logger timeout I didn't port since 
it was deemed unnecessary and the implemented solution needed reviewing anyway.

This PR needs backporting to `1.3.x`