### PR TITLE
Kafka service name override

### DIFF
--- a/service/core/kafka/client/src/main/resources/reference.conf
+++ b/service/core/kafka/client/src/main/resources/reference.conf
@@ -10,6 +10,7 @@ lagom.broker.kafka {
   # If this is an empty string, then a service locator lookup will not be done,
   # and the brokers configuration will be used instead.
   service-name = "kafka_native"
+  service-name = ${?KAFKA_SERVICE_NAME}
 
   # The URLs of the Kafka brokers. Separate each URL with a comma.
   # This will be ignored if the service-name configuration is non empty.


### PR DESCRIPTION
Add the possibility to override the Kafka service name with the environment variable `KAFKA_SERVICE_NAME`. This is a common scenario in the context of ConductR on DC/OS on which the service name needs to be overwritten to `_node-0._tcp.kafka.mesos`.

As described at https://tech-hub.lightbend.com/guides/dcos-microservices, the default approach within ConductR is to provide a custom bundle configuration in which the environment variable `KAFKA_SERVICE_NAME` is set and therefore the Kafka service name is overwritten.

This makes it also consistent with Cassandra, in which the default service name can be overwritten with the env `CASSANDRA_SERVICE_NAME`: https://github.com/lagom/lagom/blob/master/persistence-cassandra/core/src/main/resources/play/reference-overrides.conf#L41