### PR TITLE
Bugfix/605 allow disable offsetstore auto create

### DIFF
--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -68,8 +68,6 @@ lagom.persistence.read-side.cassandra {
 
 With these properties set to `false`, if the keyspaces or tables are missing at startup your service will log an error and fail to start.
 
-It is not possible to disable automatic creation of the offset store table at this time.
-
 Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugin's [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).
 
 ## Cassandra Location

--- a/persistence-cassandra/core/src/main/resources/reference.conf
+++ b/persistence-cassandra/core/src/main/resources/reference.conf
@@ -36,7 +36,6 @@ lagom.persistence.read-side {
     keyspace-autocreate = true
 
     # Parameter indicating whether the read-side tables should be auto created
-    # TODO: currently unused, see https://github.com/lagom/lagom/issues/605
     tables-autocreate = true
 
     # The number of retries when a write request returns a TimeoutException or an UnavailableException.

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -59,7 +59,6 @@ private[lagom] abstract class CassandraOffsetStore(
   }
 
   protected def doPrepare(eventProcessorId: String, tag: String): Future[(Offset, PreparedStatement)] = {
-    implicit val timeout = Timeout(config.globalPrepareTimeout)
     for {
       _ <- startupTask
       offset <- readOffset(eventProcessorId, tag)

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -19,9 +19,10 @@ import scala.concurrent.Future
  * Internal API
  */
 private[lagom] abstract class CassandraOffsetStore(
-  system:  ActorSystem,
-  session: CassandraSession,
-  config:  ReadSideConfig
+  system:            ActorSystem,
+  session:           CassandraSession,
+  cassandraProvider: CassandraProvider,
+  config:            ReadSideConfig
 ) extends OffsetStore {
 
   import system.dispatcher
@@ -34,16 +35,20 @@ private[lagom] abstract class CassandraOffsetStore(
     }
   }
 
-  private val startupTask = ClusterStartupTask(
-    system,
-    "cassandraOffsetStorePrepare",
-    createTable,
-    config.globalPrepareTimeout,
-    config.role,
-    config.minBackoff,
-    config.maxBackoff,
-    config.randomBackoffFactor
-  )
+  val startupTask = if (cassandraProvider.autoCreateTables) {
+    implicit val timeout = Timeout(config.globalPrepareTimeout)
+
+    ClusterStartupTask(
+      system,
+      "cassandraOffsetStorePrepare",
+      createTable,
+      config.globalPrepareTimeout,
+      config.role,
+      config.minBackoff,
+      config.maxBackoff,
+      config.randomBackoffFactor
+    ).askExecute()
+  } else Future.successful(Done)
 
   private def createTable(): Future[Done] = {
     session.executeCreateTable(s"""
@@ -56,7 +61,7 @@ private[lagom] abstract class CassandraOffsetStore(
   protected def doPrepare(eventProcessorId: String, tag: String): Future[(Offset, PreparedStatement)] = {
     implicit val timeout = Timeout(config.globalPrepareTimeout)
     for {
-      _ <- startupTask.askExecute()
+      _ <- startupTask
       offset <- readOffset(eventProcessorId, tag)
       statement <- prepareWriteOffset
     } yield {
@@ -81,12 +86,12 @@ private[lagom] abstract class CassandraOffsetStore(
       case Some(row) =>
         val uuid = row.getUUID("timeUuidOffset")
         if (uuid != null) {
-          new TimeBasedUUID(uuid)
+          TimeBasedUUID(uuid)
         } else {
           if (row.isNull("sequenceOffset")) {
             NoOffset
           } else {
-            new Sequence(row.getLong("sequenceOffset"))
+            Sequence(row.getLong("sequenceOffset"))
           }
         }
       case None => NoOffset

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraProvider.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraProvider.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import akka.actor.ActorSystem
+
+/**
+ * Internal API
+ */
+private[lagom] class CassandraProvider(system: ActorSystem) {
+  private val cassandraConfig = system.settings.config.getConfig("lagom.persistence.read-side.cassandra")
+
+  val autoCreateTables: Boolean = cassandraConfig.getBoolean("tables-autocreate")
+}

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
@@ -7,7 +7,7 @@ import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraOffsetStore, CassandraProvider }
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraSession
 
 import scala.concurrent.ExecutionContext
@@ -17,5 +17,6 @@ import scala.concurrent.ExecutionContext
  */
 @Singleton
 private[lagom] final class JavadslCassandraOffsetStore @Inject() (system: ActorSystem, session: CassandraSession,
-                                                                  config: ReadSideConfig)(implicit ec: ExecutionContext)
-  extends CassandraOffsetStore(system, session.scalaDelegate, config)
+                                                                  cassandraConfigProvider: CassandraProvider,
+                                                                  config:                  ReadSideConfig)(implicit ec: ExecutionContext)
+  extends CassandraOffsetStore(system, session.scalaDelegate, cassandraConfigProvider, config)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
@@ -5,7 +5,7 @@ package com.lightbend.lagom.internal.scaladsl.persistence.cassandra
 
 import akka.actor.ActorSystem
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraProvider, CassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
 
 import scala.concurrent.ExecutionContext
@@ -14,5 +14,6 @@ import scala.concurrent.ExecutionContext
  * Internal API
  */
 private[lagom] final class ScaladslCassandraOffsetStore(system: ActorSystem, session: CassandraSession,
-                                                        config: ReadSideConfig)(implicit ec: ExecutionContext)
-  extends CassandraOffsetStore(system, session.delegate, config)
+                                                        cassandraConfigProvider: CassandraProvider,
+                                                        config:                  ReadSideConfig)(implicit ec: ExecutionContext)
+  extends CassandraOffsetStore(system, session.delegate, cassandraConfigProvider, config)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -3,16 +3,13 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
-import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorHolder
-import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorAdapter
-
 import scala.concurrent.Future
 import java.net.URI
 
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry, ReadSidePersistenceComponents, WriteSidePersistenceComponents }
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraProvider, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder }
 import com.lightbend.lagom.spi.persistence.OffsetStore
 
 /**
@@ -47,9 +44,10 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
  */
 trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponents {
   lazy val cassandraSession: CassandraSession = new CassandraSession(actorSystem)
+  lazy val cassandraConfigProvider: CassandraProvider = new CassandraProvider(actorSystem)
 
   private[lagom] lazy val cassandraOffsetStore: CassandraOffsetStore =
-    new ScaladslCassandraOffsetStore(actorSystem, cassandraSession, readSideConfig)(executionContext)
+    new ScaladslCassandraOffsetStore(actorSystem, cassandraSession, cassandraConfigProvider, readSideConfig)(executionContext)
   lazy val offsetStore: OffsetStore = cassandraOffsetStore
 
   lazy val cassandraReadSide: CassandraReadSide = new CassandraReadSideImpl(actorSystem, cassandraSession, cassandraOffsetStore)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 object TestUtil extends AbstractTestUtil {
 
-  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean) = ConfigFactory.parseString(s"""
+  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean, offsetStoreAutoCreate: Boolean = true) = ConfigFactory.parseString(s"""
     cassandra-journal.session-provider = akka.persistence.cassandra.ConfigSessionProvider
     cassandra-snapshot-store.session-provider = akka.persistence.cassandra.ConfigSessionProvider
     lagom.persistence.read-side.cassandra.session-provider = akka.persistence.cassandra.ConfigSessionProvider
@@ -30,6 +30,7 @@ object TestUtil extends AbstractTestUtil {
     lagom.persistence.read-side.cassandra {
       port = $cassandraPort
       keyspace = ${testName}_read
+      tables-autocreate = $offsetStoreAutoCreate
     }
 
     akka.test.single-expect-default = 5s
@@ -53,6 +54,10 @@ object TestUtil extends AbstractTestUtil {
 
   def persistenceConfig(testName: String, cassandraPort: Int): Config = {
     persistenceConfig(testName, cassandraPort, useServiceLocator = false)
+  }
+
+  def persistenceConfig(testName: String, cassandraPort: Int, offsetStoreAutoCreate: Boolean): Config = {
+    persistenceConfig(testName, cassandraPort, useServiceLocator = false, offsetStoreAutoCreate)
   }
 
 }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -20,7 +20,8 @@ class CassandraPersistenceSpec private (system: ActorSystem) extends ActorSystem
     this(ActorSystem(testName, ActorSystemSetup(
       BootstrapSetup(TestUtil.persistenceConfig(
         testName,
-        CassandraLauncher.randomPort
+        CassandraLauncher.randomPort,
+        offsetStoreAutoCreate = false
       )),
       JsonSerializerRegistry.serializationSetupFor(jsonSerializerRegistry)
     )))

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -3,30 +3,29 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraProvider
+import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore}
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
 import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.Future
-import scala.concurrent.duration._
-
 object CassandraReadSideSpec {
 
-  val config = ConfigFactory.parseString(s"""
-    akka.loglevel = INFO
-    """)
-
+  val defaultConfig = ConfigFactory.parseString("akka.loglevel = INFO")
+  val noAutoCreateConfig = ConfigFactory.parseString("lagom.persistence.read-side.cassandra.tables-autocreate = false")
 }
 
-class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.config, TestEntitySerializerRegistry) with AbstractReadSideSpec {
+class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.defaultConfig, TestEntitySerializerRegistry) with AbstractReadSideSpec {
   import system.dispatcher
 
   override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system)
 
+  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
   private lazy val testSession: CassandraSession = new CassandraSession(system)
-  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, ReadSideConfig())
+  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
   private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
@@ -39,5 +38,19 @@ class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSp
   override def afterAll(): Unit = {
     persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
+  }
+}
+
+class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.noAutoCreateConfig, TestEntitySerializerRegistry) {
+  import system.dispatcher
+
+  private lazy val testSession: CassandraSession = new CassandraSession(system)
+  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
+  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
+
+  "ReadSide" must {
+    "not auto create offset store table when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+      offsetStore.startupTask.isCompleted shouldBe true
+    }
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [y] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [y] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [y] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [y] Have you added copyright headers to new files?
* [y] Have you updated the documentation?
* [y] Have you added tests for any changed functionality?

## Fixes

Fix bug with offset store auto creation

## Purpose

There should be a possibility to disable offset store auto creation

## Background Context

Some clients may want not auto create offset store table as don't have "CREATE" permission
in production environment

## References

https://github.com/lagom/lagom/issues/605