### PR TITLE
bugfix/605-allow-to-disable-offset-store-auto-creation

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -68,8 +68,6 @@ lagom.persistence.read-side.cassandra {
 
 With these properties set to `false`, if the keyspaces or tables are missing at startup your service will log an error and fail to start.
 
-It is not possible to disable automatic creation of the offset store table at this time.
-
 Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugin's [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).
 
 ## Cassandra Location

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -68,8 +68,6 @@ lagom.persistence.read-side.cassandra {
 
 With these properties set to `false`, if the keyspaces or tables are missing at startup your service will log an error and fail to start.
 
-It is not possible to disable automatic creation of the offset store table at this time.
-
 Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://github.com/akka/akka-persistence-cassandra) plugin. A full configuration reference can be in the plugin's [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.20/src/main/resources/reference.conf).
 
 ## Cassandra Location

--- a/persistence-cassandra/core/src/main/resources/reference.conf
+++ b/persistence-cassandra/core/src/main/resources/reference.conf
@@ -36,7 +36,6 @@ lagom.persistence.read-side {
     keyspace-autocreate = true
 
     # Parameter indicating whether the read-side tables should be auto created
-    # TODO: currently unused, see https://github.com/lagom/lagom/issues/605
     tables-autocreate = true
 
     # The number of retries when a write request returns a TimeoutException or an UnavailableException.

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -19,10 +19,10 @@ import scala.concurrent.Future
  * Internal API
  */
 private[lagom] abstract class CassandraOffsetStore(
-  system: ActorSystem,
-  session: CassandraSession,
+  system:                    ActorSystem,
+  session:                   CassandraSession,
   cassandraReadSideSettings: CassandraReadSideSettings,
-  config: ReadSideConfig
+  config:                    ReadSideConfig
 ) extends OffsetStore {
 
   import system.dispatcher

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -19,10 +19,10 @@ import scala.concurrent.Future
  * Internal API
  */
 private[lagom] abstract class CassandraOffsetStore(
-  system:            ActorSystem,
-  session:           CassandraSession,
-  cassandraProvider: CassandraProvider,
-  config:            ReadSideConfig
+  system: ActorSystem,
+  session: CassandraSession,
+  cassandraReadSideSettings: CassandraReadSideSettings,
+  config: ReadSideConfig
 ) extends OffsetStore {
 
   import system.dispatcher
@@ -35,7 +35,7 @@ private[lagom] abstract class CassandraOffsetStore(
     }
   }
 
-  val startupTask = if (cassandraProvider.autoCreateTables) {
+  val startupTask = if (cassandraReadSideSettings.autoCreateTables) {
     implicit val timeout = Timeout(config.globalPrepareTimeout)
 
     ClusterStartupTask(

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -60,9 +60,8 @@ private[lagom] abstract class CassandraOffsetStore(
 
   protected def doPrepare(eventProcessorId: String, tag: String): Future[(Offset, PreparedStatement)] = {
     implicit val timeout = Timeout(config.globalPrepareTimeout)
-    startupTask.foreach(_.askExecute)
-
     for {
+      _ <- startupTask.fold(Future.successful[Done](Done))(task => task.askExecute)
       offset <- readOffset(eventProcessorId, tag)
       statement <- prepareWriteOffset
     } yield {

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraProvider.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraProvider.scala
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import akka.actor.ActorSystem
+
+/**
+ * Internal API
+ */
+private[lagom] class CassandraProvider(system: ActorSystem) {
+  private val cassandraConfig = system.settings.config.getConfig("lagom.persistence.read-side.cassandra")
+
+  val autoCreateTables: Boolean = cassandraConfig.getBoolean("tables-autocreate")
+}

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
@@ -3,12 +3,13 @@
  */
 package com.lightbend.lagom.internal.persistence.cassandra
 
+import javax.inject.Inject
 import akka.actor.ActorSystem
 
 /**
  * Internal API
  */
-private[lagom] class CassandraReadSideSettings(system: ActorSystem) {
+private[lagom] class CassandraReadSideSettings @Inject() (system: ActorSystem) {
   private val cassandraConfig = system.settings.config.getConfig("lagom.persistence.read-side.cassandra")
 
   val autoCreateTables: Boolean = cassandraConfig.getBoolean("tables-autocreate")

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
@@ -8,7 +8,7 @@ import akka.actor.ActorSystem
 /**
  * Internal API
  */
-private[lagom] class CassandraProvider(system: ActorSystem) {
+private[lagom] class CassandraReadSideSettings(system: ActorSystem) {
   private val cassandraConfig = system.settings.config.getConfig("lagom.persistence.read-side.cassandra")
 
   val autoCreateTables: Boolean = cassandraConfig.getBoolean("tables-autocreate")

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
@@ -7,7 +7,7 @@ import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraOffsetStore, CassandraProvider }
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraOffsetStore, CassandraReadSideSettings }
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraSession
 
 import scala.concurrent.ExecutionContext
@@ -17,6 +17,6 @@ import scala.concurrent.ExecutionContext
  */
 @Singleton
 private[lagom] final class JavadslCassandraOffsetStore @Inject() (system: ActorSystem, session: CassandraSession,
-                                                                  cassandraConfigProvider: CassandraProvider,
-                                                                  config:                  ReadSideConfig)(implicit ec: ExecutionContext)
-  extends CassandraOffsetStore(system, session.scalaDelegate, cassandraConfigProvider, config)
+                                                                  cassandraReadSideSettings: CassandraReadSideSettings,
+                                                                  config: ReadSideConfig)(implicit ec: ExecutionContext)
+  extends CassandraOffsetStore(system, session.scalaDelegate, cassandraReadSideSettings, config)

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
@@ -7,7 +7,7 @@ import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraOffsetStore, CassandraProvider }
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraSession
 
 import scala.concurrent.ExecutionContext
@@ -17,5 +17,6 @@ import scala.concurrent.ExecutionContext
  */
 @Singleton
 private[lagom] final class JavadslCassandraOffsetStore @Inject() (system: ActorSystem, session: CassandraSession,
-                                                                  config: ReadSideConfig)(implicit ec: ExecutionContext)
-  extends CassandraOffsetStore(system, session.scalaDelegate, config)
+                                                                  cassandraConfigProvider: CassandraProvider,
+                                                                  config:                  ReadSideConfig)(implicit ec: ExecutionContext)
+  extends CassandraOffsetStore(system, session.scalaDelegate, cassandraConfigProvider, config)

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/JavadslCassandraOffsetStore.scala
@@ -18,5 +18,5 @@ import scala.concurrent.ExecutionContext
 @Singleton
 private[lagom] final class JavadslCassandraOffsetStore @Inject() (system: ActorSystem, session: CassandraSession,
                                                                   cassandraReadSideSettings: CassandraReadSideSettings,
-                                                                  config: ReadSideConfig)(implicit ec: ExecutionContext)
+                                                                  config:                    ReadSideConfig)(implicit ec: ExecutionContext)
   extends CassandraOffsetStore(system, session.scalaDelegate, cassandraReadSideSettings, config)

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -54,7 +54,7 @@ class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(Cassandra
 
   "A Cassandra Read-Side" must {
     "not send ClusterStartupTask message, so startupTask must return None" +
-      "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+    "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
       offsetStore.startupTask shouldBe None
     }
   }

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletionStage
 import com.google.inject.Guice
 import com.lightbend.lagom.internal.javadsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, JavadslCassandraOffsetStore }
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraProvider
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.javadsl.persistence._
 import com.typesafe.config.ConfigFactory
 
@@ -27,8 +27,8 @@ class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSp
   override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system, injector)
 
   private lazy val testSession: CassandraSession = new CassandraSession(system)
-  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
-  private lazy val offsetStore = new JavadslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
+  private lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(system)
+  private lazy val offsetStore = new JavadslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
   private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore, null, injector)
 
   override def processorFactory(): ReadSideProcessor[TestEntity.Evt] =
@@ -49,11 +49,12 @@ class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(Cassandra
   import system.dispatcher
 
   private lazy val testSession: CassandraSession = new CassandraSession(system)
-  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
-  private lazy val offsetStore = new JavadslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
+  private lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(system)
+  private lazy val offsetStore = new JavadslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
 
-  "ReadSide" must {
-    "not auto create offset store table when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+  "A Cassandra Read-Side" must {
+    "not send ClusterStartupTask message and future should be returned with Done result " +
+      "immediately if 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
       offsetStore.startupTask.isCompleted shouldBe true
     }
   }

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.javadsl.persistence.cassandra
 import java.util.concurrent.CompletionStage
 
 import com.google.inject.Guice
-import com.lightbend.lagom.internal.javadsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, JavadslCassandraOffsetStore }
+import com.lightbend.lagom.internal.javadsl.persistence.cassandra.{CassandraPersistentEntityRegistry, CassandraReadSideImpl, JavadslCassandraOffsetStore}
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.javadsl.persistence._

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.javadsl.persistence.cassandra
 import java.util.concurrent.CompletionStage
 
 import com.google.inject.Guice
-import com.lightbend.lagom.internal.javadsl.persistence.cassandra.{CassandraPersistentEntityRegistry, CassandraReadSideImpl, JavadslCassandraOffsetStore}
+import com.lightbend.lagom.internal.javadsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, JavadslCassandraOffsetStore }
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.javadsl.persistence._
@@ -54,8 +54,8 @@ class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(Cassandra
 
   "A Cassandra Read-Side" must {
     "not send ClusterStartupTask message, so startupTask must return None" +
-    "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
-      offsetStore.startupTask shouldBe None
-    }
+      "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+        offsetStore.startupTask shouldBe None
+      }
   }
 }

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -53,9 +53,9 @@ class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(Cassandra
   private lazy val offsetStore = new JavadslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
 
   "A Cassandra Read-Side" must {
-    "not send ClusterStartupTask message and future should be returned with Done result " +
-      "immediately if 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
-      offsetStore.startupTask.isCompleted shouldBe true
+    "not send ClusterStartupTask message, so startupTask must return None" +
+      "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+      offsetStore.startupTask shouldBe None
     }
   }
 }

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
@@ -5,7 +5,7 @@ package com.lightbend.lagom.internal.scaladsl.persistence.cassandra
 
 import akka.actor.ActorSystem
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraProvider, CassandraOffsetStore }
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraReadSideSettings, CassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
 
 import scala.concurrent.ExecutionContext
@@ -14,6 +14,6 @@ import scala.concurrent.ExecutionContext
  * Internal API
  */
 private[lagom] final class ScaladslCassandraOffsetStore(system: ActorSystem, session: CassandraSession,
-                                                        cassandraConfigProvider: CassandraProvider,
-                                                        config:                  ReadSideConfig)(implicit ec: ExecutionContext)
-  extends CassandraOffsetStore(system, session.delegate, cassandraConfigProvider, config)
+                                                        cassandraReadSideSettings: CassandraReadSideSettings,
+                                                        config: ReadSideConfig)(implicit ec: ExecutionContext)
+  extends CassandraOffsetStore(system, session.delegate, cassandraReadSideSettings, config)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
@@ -5,7 +5,7 @@ package com.lightbend.lagom.internal.scaladsl.persistence.cassandra
 
 import akka.actor.ActorSystem
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraProvider, CassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraSession
 
 import scala.concurrent.ExecutionContext
@@ -14,5 +14,6 @@ import scala.concurrent.ExecutionContext
  * Internal API
  */
 private[lagom] final class ScaladslCassandraOffsetStore(system: ActorSystem, session: CassandraSession,
-                                                        config: ReadSideConfig)(implicit ec: ExecutionContext)
-  extends CassandraOffsetStore(system, session.delegate, config)
+                                                        cassandraConfigProvider: CassandraProvider,
+                                                        config:                  ReadSideConfig)(implicit ec: ExecutionContext)
+  extends CassandraOffsetStore(system, session.delegate, cassandraConfigProvider, config)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/ScaladslCassandraOffsetStore.scala
@@ -15,5 +15,5 @@ import scala.concurrent.ExecutionContext
  */
 private[lagom] final class ScaladslCassandraOffsetStore(system: ActorSystem, session: CassandraSession,
                                                         cassandraReadSideSettings: CassandraReadSideSettings,
-                                                        config: ReadSideConfig)(implicit ec: ExecutionContext)
+                                                        config:                    ReadSideConfig)(implicit ec: ExecutionContext)
   extends CassandraOffsetStore(system, session.delegate, cassandraReadSideSettings, config)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -3,16 +3,13 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
-import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorHolder
-import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorAdapter
-
 import scala.concurrent.Future
 import java.net.URI
 
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry, ReadSidePersistenceComponents, WriteSidePersistenceComponents }
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraProvider, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder }
 import com.lightbend.lagom.spi.persistence.OffsetStore
 
 /**
@@ -47,9 +44,10 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
  */
 trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponents {
   lazy val cassandraSession: CassandraSession = new CassandraSession(actorSystem)
+  lazy val cassandraConfigProvider: CassandraProvider = new CassandraProvider(actorSystem)
 
   private[lagom] lazy val cassandraOffsetStore: CassandraOffsetStore =
-    new ScaladslCassandraOffsetStore(actorSystem, cassandraSession, readSideConfig)(executionContext)
+    new ScaladslCassandraOffsetStore(actorSystem, cassandraSession, cassandraConfigProvider, readSideConfig)(executionContext)
   lazy val offsetStore: OffsetStore = cassandraOffsetStore
 
   lazy val cassandraReadSide: CassandraReadSide = new CassandraReadSideImpl(actorSystem, cassandraSession, cassandraOffsetStore)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -9,7 +9,7 @@ import java.net.URI
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry, ReadSidePersistenceComponents, WriteSidePersistenceComponents }
-import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraProvider, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder }
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraReadSideSettings, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder }
 import com.lightbend.lagom.spi.persistence.OffsetStore
 
 /**
@@ -44,10 +44,10 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
  */
 trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponents {
   lazy val cassandraSession: CassandraSession = new CassandraSession(actorSystem)
-  lazy val cassandraConfigProvider: CassandraProvider = new CassandraProvider(actorSystem)
+  lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(actorSystem)
 
   private[lagom] lazy val cassandraOffsetStore: CassandraOffsetStore =
-    new ScaladslCassandraOffsetStore(actorSystem, cassandraSession, cassandraConfigProvider, readSideConfig)(executionContext)
+    new ScaladslCassandraOffsetStore(actorSystem, cassandraSession, testCasReadSideSettings, readSideConfig)(executionContext)
   lazy val offsetStore: OffsetStore = cassandraOffsetStore
 
   lazy val cassandraReadSide: CassandraReadSide = new CassandraReadSideImpl(actorSystem, cassandraSession, cassandraOffsetStore)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 object TestUtil extends AbstractTestUtil {
 
-  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean) = ConfigFactory.parseString(s"""
+  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean, offsetStoreAutoCreate: Boolean = true) = ConfigFactory.parseString(s"""
     cassandra-journal.session-provider = akka.persistence.cassandra.ConfigSessionProvider
     cassandra-snapshot-store.session-provider = akka.persistence.cassandra.ConfigSessionProvider
     lagom.persistence.read-side.cassandra.session-provider = akka.persistence.cassandra.ConfigSessionProvider
@@ -30,6 +30,7 @@ object TestUtil extends AbstractTestUtil {
     lagom.persistence.read-side.cassandra {
       port = $cassandraPort
       keyspace = ${testName}_read
+      tables-autocreate = $offsetStoreAutoCreate
     }
 
     akka.test.single-expect-default = 5s
@@ -53,6 +54,10 @@ object TestUtil extends AbstractTestUtil {
 
   def persistenceConfig(testName: String, cassandraPort: Int): Config = {
     persistenceConfig(testName, cassandraPort, useServiceLocator = false)
+  }
+
+  def persistenceConfig(testName: String, cassandraPort: Int, offsetStoreAutoCreate: Boolean): Config = {
+    persistenceConfig(testName, cassandraPort, useServiceLocator = false, offsetStoreAutoCreate)
   }
 
 }

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
@@ -9,7 +9,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 object TestUtil extends AbstractTestUtil {
 
-  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean, offsetStoreAutoCreate: Boolean = true) = ConfigFactory.parseString(s"""
+  def persistenceConfig(testName: String, cassandraPort: Int, useServiceLocator: Boolean) = ConfigFactory.parseString(s"""
     cassandra-journal.session-provider = akka.persistence.cassandra.ConfigSessionProvider
     cassandra-snapshot-store.session-provider = akka.persistence.cassandra.ConfigSessionProvider
     lagom.persistence.read-side.cassandra.session-provider = akka.persistence.cassandra.ConfigSessionProvider
@@ -30,7 +30,6 @@ object TestUtil extends AbstractTestUtil {
     lagom.persistence.read-side.cassandra {
       port = $cassandraPort
       keyspace = ${testName}_read
-      tables-autocreate = $offsetStoreAutoCreate
     }
 
     akka.test.single-expect-default = 5s
@@ -55,9 +54,4 @@ object TestUtil extends AbstractTestUtil {
   def persistenceConfig(testName: String, cassandraPort: Int): Config = {
     persistenceConfig(testName, cassandraPort, useServiceLocator = false)
   }
-
-  def persistenceConfig(testName: String, cassandraPort: Int, offsetStoreAutoCreate: Boolean): Config = {
-    persistenceConfig(testName, cassandraPort, useServiceLocator = false, offsetStoreAutoCreate)
-  }
-
 }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -20,7 +20,8 @@ class CassandraPersistenceSpec private (system: ActorSystem) extends ActorSystem
     this(ActorSystem(testName, ActorSystemSetup(
       BootstrapSetup(TestUtil.persistenceConfig(
         testName,
-        CassandraLauncher.randomPort
+        CassandraLauncher.randomPort,
+        offsetStoreAutoCreate = false
       )),
       JsonSerializerRegistry.serializationSetupFor(jsonSerializerRegistry)
     )))

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.{ ActorSystem, BootstrapSetup }
 import akka.actor.setup.ActorSystemSetup
 import akka.cluster.Cluster
 import akka.persistence.cassandra.testkit.CassandraLauncher
+
 import com.lightbend.lagom.persistence.{ ActorSystemSpec, PersistenceSpec }
 import com.lightbend.lagom.scaladsl.persistence.cassandra.testkit.TestUtil
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
@@ -16,13 +17,12 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 class CassandraPersistenceSpec private (system: ActorSystem) extends ActorSystemSpec(system) {
 
-  def this(testName: String, config: Config, jsonSerializerRegistry: JsonSerializerRegistry) =
+  def this(testName: String, config: Config, jsonSerializerRegistry: JsonSerializerRegistry, offsetStoreAutoCreate: Boolean = true) =
     this(ActorSystem(testName, ActorSystemSetup(
-      BootstrapSetup(TestUtil.persistenceConfig(
+      BootstrapSetup(config.withFallback(TestUtil.persistenceConfig(
         testName,
-        CassandraLauncher.randomPort,
-        offsetStoreAutoCreate = false
-      )),
+        CassandraLauncher.randomPort
+      ))),
       JsonSerializerRegistry.serializationSetupFor(jsonSerializerRegistry)
     )))
 

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -9,7 +9,6 @@ import akka.actor.{ ActorSystem, BootstrapSetup }
 import akka.actor.setup.ActorSystemSetup
 import akka.cluster.Cluster
 import akka.persistence.cassandra.testkit.CassandraLauncher
-
 import com.lightbend.lagom.persistence.{ ActorSystemSpec, PersistenceSpec }
 import com.lightbend.lagom.scaladsl.persistence.cassandra.testkit.TestUtil
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -17,7 +17,7 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 class CassandraPersistenceSpec private (system: ActorSystem) extends ActorSystemSpec(system) {
 
-  def this(testName: String, config: Config, jsonSerializerRegistry: JsonSerializerRegistry, offsetStoreAutoCreate: Boolean = true) =
+  def this(testName: String, config: Config, jsonSerializerRegistry: JsonSerializerRegistry) =
     this(ActorSystem(testName, ActorSystemSetup(
       BootstrapSetup(config.withFallback(TestUtil.persistenceConfig(
         testName,

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -3,30 +3,29 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
+import scala.concurrent.Future
+import scala.concurrent.duration._
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraProvider
+import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore}
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
 import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.Future
-import scala.concurrent.duration._
-
 object CassandraReadSideSpec {
 
-  val config = ConfigFactory.parseString(s"""
-    akka.loglevel = INFO
-    """)
-
+  val defaultConfig = ConfigFactory.parseString("akka.loglevel = INFO")
+  val noAutoCreateConfig = ConfigFactory.parseString("lagom.persistence.read-side.cassandra.tables-autocreate = false")
 }
 
-class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.config, TestEntitySerializerRegistry) with AbstractReadSideSpec {
+class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.defaultConfig, TestEntitySerializerRegistry) with AbstractReadSideSpec {
   import system.dispatcher
 
   override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system)
 
+  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
   private lazy val testSession: CassandraSession = new CassandraSession(system)
-  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, ReadSideConfig())
+  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
   private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
@@ -39,5 +38,19 @@ class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSp
   override def afterAll(): Unit = {
     persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
+  }
+}
+
+class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.noAutoCreateConfig, TestEntitySerializerRegistry) {
+  import system.dispatcher
+
+  private lazy val testSession: CassandraSession = new CassandraSession(system)
+  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
+  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
+
+  "ReadSide" must {
+    "not auto create offset store table when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+      offsetStore.startupTask.isCompleted shouldBe true
+    }
   }
 }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -52,7 +52,7 @@ class CassandraReadSideAutoCreateSpec
 
   "A Cassandra Read-Side" must {
     "not send ClusterStartupTask message, so startupTask must return None" +
-      "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+    "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
       offsetStore.startupTask shouldBe None
     }
   }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.scaladsl.persistence.cassandra
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraProvider
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore}
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
@@ -23,9 +23,9 @@ class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSp
 
   override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system)
 
-  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
+  private lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(system)
   private lazy val testSession: CassandraSession = new CassandraSession(system)
-  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
+  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
   private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
@@ -45,11 +45,12 @@ class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(Cassandra
   import system.dispatcher
 
   private lazy val testSession: CassandraSession = new CassandraSession(system)
-  private lazy val testCasConfigProvider: CassandraProvider = new CassandraProvider(system)
-  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasConfigProvider, ReadSideConfig())
+  private lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(system)
+  private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
 
-  "ReadSide" must {
-    "not auto create offset store table when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+  "A Cassandra Read-Side" must {
+    "not send ClusterStartupTask message and future should be returned with Done result " +
+      "immediately if 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
       offsetStore.startupTask.isCompleted shouldBe true
     }
   }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -49,9 +49,9 @@ class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(Cassandra
   private lazy val offsetStore = new ScaladslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
 
   "A Cassandra Read-Side" must {
-    "not send ClusterStartupTask message and future should be returned with Done result " +
-      "immediately if 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
-      offsetStore.startupTask.isCompleted shouldBe true
+    "not send ClusterStartupTask message, so startupTask must return None" +
+      "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+      offsetStore.startupTask shouldBe None
     }
   }
 }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -5,12 +5,13 @@ package com.lightbend.lagom.scaladsl.persistence.cassandra
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+
+import com.typesafe.config.ConfigFactory
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore}
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
-import com.typesafe.config.ConfigFactory
 
 object CassandraReadSideSpec {
 
@@ -41,7 +42,8 @@ class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSp
   }
 }
 
-class CassandraReadSideAutoCreateSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.noAutoCreateConfig, TestEntitySerializerRegistry) {
+class CassandraReadSideAutoCreateSpec
+  extends CassandraPersistenceSpec(CassandraReadSideSpec.noAutoCreateConfig, TestEntitySerializerRegistry) {
   import system.dispatcher
 
   private lazy val testSession: CassandraSession = new CassandraSession(system)

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -9,7 +9,7 @@ import scala.concurrent.duration._
 import com.typesafe.config.ConfigFactory
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
-import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore}
+import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
 
@@ -52,8 +52,8 @@ class CassandraReadSideAutoCreateSpec
 
   "A Cassandra Read-Side" must {
     "not send ClusterStartupTask message, so startupTask must return None" +
-    "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
-      offsetStore.startupTask shouldBe None
-    }
+      "when 'lagom.persistence.read-side.cassandra.tables-autocreate' flag is 'false'" in {
+        offsetStore.startupTask shouldBe None
+      }
   }
 }


### PR DESCRIPTION
- Add CassandraProvider class to separate read-side cassandra from global read-side settings
- Add possibility to disable "offset store" table auto creation
- Remove obsolete logic
- Update documentation
- Warning fixes

# Pull Request Checklist

* [y] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [y] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [y] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [y] Have you added copyright headers to new files?
* [y] Have you updated the documentation?
* [y] Have you added tests for any changed functionality?

## Fixes

Fix bug with offset store auto creation

## Purpose

There should be a way to disable offset store table auto creation

## Background Context

Some clients may want not to auto create offset store table as they don't have "CREATE" permission
in production environment

## References

https://github.com/lagom/lagom/issues/605