### PR TITLE
[WIP] Improves Cassandra persistence consistency defaults

### DIFF
--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidator.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidator.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import play.api.{ Configuration, Environment }
+
+object CassandraConsistencyValidator {
+
+  def validate(configuration: Configuration, environment: Environment): Boolean = {
+    val journalConfig: Option[Configuration] = configuration.getConfig("cassandra-journal")
+
+    CassandraConsistencyConfig.load(journalConfig.get).exists {
+      case CassandraConsistencyConfig("QUORUM", "QUORUM", Some(rf)) if rf >= 3 => true
+      case _ => false
+    }
+  }
+
+}
+
+case class CassandraConsistencyConfig(
+  readConsistency:   String,
+  writeConsistency:  String,
+  replicationFactor: Option[Int]
+)
+
+object CassandraConsistencyConfig {
+  def load(configuration: Configuration): Option[CassandraConsistencyConfig] = {
+    for {
+      rc <- configuration.getString("read-consistency")
+      wc <- configuration.getString("write-consistency")
+    } yield {
+      val rf = configuration.getInt("replication-factor")
+      CassandraConsistencyConfig(rc, wc, rf)
+    }
+  }
+}

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidatorSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidatorSpec.scala
@@ -1,0 +1,30 @@
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import org.scalatest.{ FlatSpec, Matchers }
+import play.api.{ Configuration, Environment, Mode }
+
+
+class CassandraConsistencyValidatorSpec extends FlatSpec with Matchers {
+
+  behavior of "CassandraConsistencyValidator"
+
+  it should "(for APC-journal in Prod) accept a read/write QUORUM with replication-factor >= 3" in {
+    val config = Configuration.from(Map(
+      "cassandra-journal.write-consistency" -> "QUORUM",
+      "cassandra-journal.read-consistency" -> "QUORUM",
+      "cassandra-journal.replication-factor" -> 3
+    ))
+
+    CassandraConsistencyValidator.validate(config, Environment.simple(mode = Mode.Prod)) should be (true)
+
+  }
+  it should "(for APC-journal in Prod) deny a read/write QUORUM with replication-factor under 3" in {
+    val config = Configuration.from(Map(
+      "cassandra-journal.write-consistency" -> "QUORUM",
+      "cassandra-journal.read-consistency" -> "QUORUM",
+      "cassandra-journal.replication-factor" -> 2
+    ))
+    CassandraConsistencyValidator.validate(config, Environment.simple(mode = Mode.Prod)) should be (false)
+  }
+
+}

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -3,17 +3,16 @@
  */
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
-import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorHolder
-import com.lightbend.lagom.internal.persistence.cassandra.ServiceLocatorAdapter
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraConsistencyValidator, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder }
 
 import scala.concurrent.Future
 import java.net.URI
 
-import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry, ReadSidePersistenceComponents, WriteSidePersistenceComponents }
 import com.lightbend.lagom.spi.persistence.OffsetStore
+import play.api.{ Configuration, Environment }
 
 /**
  * Persistence Cassandra components (for compile-time injection).
@@ -31,6 +30,10 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
 
   def serviceLocator: ServiceLocator
 
+  def configuration: Configuration
+  def environment: Environment
+  require(CassandraConsistencyValidator.validate(configuration, environment))
+
   // eager initialization
   private[lagom] val serviceLocatorHolder: ServiceLocatorHolder = {
     val holder = ServiceLocatorHolder(actorSystem)
@@ -46,6 +49,11 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
  * Read-side persistence Cassandra components (for compile-time injection).
  */
 trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponents {
+
+  def configuration: Configuration
+  def environment: Environment
+  require(CassandraConsistencyValidator.validate(configuration, environment))
+
   lazy val cassandraSession: CassandraSession = new CassandraSession(actorSystem)
 
   private[lagom] lazy val cassandraOffsetStore: CassandraOffsetStore =


### PR DESCRIPTION
Related to #730

 - [ ] prevent service start in Production Mode when QUORUM / 3 (at least) is setup
 - [ ] relax consistency levels in Dev and Test Mode
 - [ ] default consistency levels to those described in #730
 - [ ] allow users to disable the check (see https://github.com/lagom/lagom/pull/743#issuecomment-301357826)
 - [ ] make checks pass if setup is more strict that those described in #730 (higher `replication-factor` or more restrictive `consistency-level`)
 - [ ] list all offending settings separately
 - [ ] run validations for read and write side in separate classes to ease using different read and write implementations.