### PR TITLE
Update jackson reference.conf to use concatenation

### DIFF
--- a/jackson/src/main/resources/reference.conf
+++ b/jackson/src/main/resources/reference.conf
@@ -6,12 +6,11 @@ lagom.serialization.json {
   # The Jackson JSON serializer will register these modules.
   # It is also possible to use jackson-modules = ["*"] to dynamically
   # find and register all modules in the classpath.  
-  jackson-modules = [
-    "com.fasterxml.jackson.module.paramnames.ParameterNamesModule",
-    "com.fasterxml.jackson.datatype.jdk8.Jdk8Module",
-    "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule",
-    "com.fasterxml.jackson.datatype.pcollections.PCollectionsModule",
-    "com.fasterxml.jackson.datatype.guava.GuavaModule"]
+  jackson-modules += "com.fasterxml.jackson.module.paramnames.ParameterNamesModule"
+  jackson-modules += "com.fasterxml.jackson.datatype.jdk8.Jdk8Module"
+  jackson-modules += "com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"
+  jackson-modules += "com.fasterxml.jackson.datatype.pcollections.PCollectionsModule"
+  jackson-modules += "com.fasterxml.jackson.datatype.guava.GuavaModule"
   #//#jackson-modules  
   
   # The serializer will compress the payload if the message class


### PR DESCRIPTION
This fixes issue #748 and uses concatenation so that classloader order won't matter if another reference.conf is appending to the jackson-modules

## Fixes

Fixes #748

## Purpose

This allows other dependencies to be loaded that have a reference.conf that append to `lagom.serialization.json.jackson-modules`. Without this change some reference.conf files will be ignored depending the class loader order.

## References

This was discussed in the lagom Gitter channel
