### PR TITLE
Allow Kafka consumers to batch messages

### DIFF
--- a/service/core/kafka/client/src/main/resources/reference.conf
+++ b/service/core/kafka/client/src/main/resources/reference.conf
@@ -40,6 +40,13 @@ lagom.broker.kafka {
     consumer {
       failure-exponential-backoff = ${lagom.broker.kafka.client.default.failure-exponential-backoff}
 
+      # The number of offsets that will be buffered to allow the consumer flow to
+      # do its own buffering. This should be set to a number that is at least as
+      # large as the maximum amount of buffering that the consumer flow will do,
+      # if the consumer buffer buffers more than this, the offset buffer will
+      # backpressure and cause the stream to stop.
+      offset-buffer = 100
+
       # Number of messages batched together by the consumer before the related messages'
       # offsets are committed to Kafka.
       # By increasing the batching-size you are trading speed with the risk of having

--- a/service/core/kafka/client/src/main/scala/com/lightbend/lagom/internal/broker/kafka/KafkaConfig.scala
+++ b/service/core/kafka/client/src/main/scala/com/lightbend/lagom/internal/broker/kafka/KafkaConfig.scala
@@ -59,6 +59,7 @@ object ProducerConfig {
 }
 
 sealed trait ConsumerConfig extends ClientConfig {
+  def offsetBuffer: Int
   def batchingSize: Int
   def batchingInterval: FiniteDuration
 }
@@ -71,6 +72,7 @@ object ConsumerConfig {
     extends ClientConfig.ClientConfigImpl(conf)
     with ConsumerConfig {
 
+    override val offsetBuffer: Int = conf.getInt("offset-buffer")
     override val batchingSize: Int = conf.getInt("batching-size")
     override val batchingInterval: FiniteDuration = {
       val interval = conf.getDuration("batching-interval")


### PR DESCRIPTION
This allows at least once Kakfa consumers to batch messages, by ensuring that the zip stage of zipping the user flow with the offset doesn't backpressure on the unzip stage through the offset side of the flow when the user buffer is batching or otherwise processing messages in parallel.