### PR TITLE
Avoid relying on default contact-point settings

### DIFF
--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/testkit/TestUtil.scala
@@ -20,16 +20,19 @@ object TestUtil extends AbstractTestUtil {
     cassandra-journal {
       port = $cassandraPort
       keyspace = $testName
+      contact-points = ["127.0.0.1"]
     }
     cassandra-snapshot-store {
       port = $cassandraPort
       keyspace = $testName
+      contact-points = ["127.0.0.1"]
     }
     cassandra-query-journal.eventual-consistency-delay = 2s
 
     lagom.persistence.read-side.cassandra {
       port = $cassandraPort
       keyspace = ${testName}_read
+      contact-points = ["127.0.0.1"]
     }
 
     akka.test.single-expect-default = 5s

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/testkit/TestUtil.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/testkit/TestUtil.scala
@@ -27,16 +27,19 @@ object TestUtil extends AbstractTestUtil {
     cassandra-journal {
       port = $cassandraPort
       keyspace = $testName
+      contact-points = ["127.0.0.1"]
     }
     cassandra-snapshot-store {
       port = $cassandraPort
       keyspace = $testName
+      contact-points = ["127.0.0.1"]
     }
     cassandra-query-journal.eventual-consistency-delay = 2s
 
     lagom.persistence.read-side.cassandra {
       port = $cassandraPort
       keyspace = ${testName}_read
+      contact-points = ["127.0.0.1"]
     }
 
     akka.test.single-expect-default = 5s

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -261,7 +261,7 @@ object ServiceTest {
         val cassandraDirectory = Files.createTempDirectory(testName).toFile
         FileUtils.deleteRecursiveOnExit(cassandraDirectory)
         val t0 = System.nanoTime()
-        CassandraLauncher.start(cassandraDirectory, LagomTestConfigResource, clean = false, port = 0)
+        CassandraLauncher.start(cassandraDirectory, LagomTestConfigResource, clean = false, port = cassandraPort)
         log.debug(s"Cassandra started in ${TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0)} ms")
         val b2 = b1.configure(new Configuration(TestUtil.persistenceConfig(testName, cassandraPort, useServiceLocator = false)))
           .configure("lagom.cluster.join-self", "on")

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
@@ -191,7 +191,7 @@ object ServiceTest {
         val cassandraDirectory = Files.createTempDirectory(testName).toFile
         FileUtils.deleteRecursiveOnExit(cassandraDirectory)
         val t0 = System.nanoTime()
-        CassandraLauncher.start(cassandraDirectory, LagomTestConfigResource, clean = false, port = 0)
+        CassandraLauncher.start(cassandraDirectory, LagomTestConfigResource, clean = false, port = cassandraPort)
         log.debug(s"Cassandra started in ${TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0)} ms")
         Configuration(TestUtil.persistenceConfig(testName, cassandraPort, useServiceLocator = false)) ++
           Configuration("lagom.cluster.join-self" -> "on")


### PR DESCRIPTION
Fixes #756

Edits `TestUtils` in both scaladsl and javadsl to ensure `contact-points` for all keyspaces are `127.0.0.1`.

I noticed in both API the `ServiceTest` was invoking `CassandraLauncher` without specifying the port. The code was correct (because `CassandraLauncher` is an `object`) but confusing and replaced to make it explicit.