### PR TITLE
Added the ability add custom infrastructure services

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
@@ -32,22 +32,11 @@
 # ---------------
 
 > set lagomServiceLocatorEnabled := false
-
 # Part 1
-> validateRequest http://localhost:8000 should-be-down
-> lagomServiceLocatorStart
-$ sleep 1000
-> validateRequest http://localhost:8000 should-be-down
-
-# Part 2
 > runAll
 $ sleep 1000
 > validateRequest http://localhost:8000 should-be-down
 > validateFile retry-until-success target/reload.log line-count 1
-
-# Part 3
-> lagomServiceLocatorStop
-> validateFile target/reload.log line-count 1
 
 # Cleanup
 > stop

--- a/docs/manual/common/guide/devmode/DevEnvironment.md
+++ b/docs/manual/common/guide/devmode/DevEnvironment.md
@@ -52,6 +52,20 @@ Once the "Services started" message has appeared, if you make a change to your s
 --- (RELOAD) ---
 ```
 
+## Managing custom services
+
+By default, Lagom will, in addition to running your services, also start a service locator, a Cassandra server and a Kafka server. If using sbt, you can customise what Lagom starts, including adding other databases and infrastructure services.
+
+> **Note:** Managing custom services is not currently supported in Maven, due to Maven's inability to arbitrarily add behaviour, such as the logic necessary to start and stop an external process, to a build. This is typically not a big problem, it simply means developers have to manually install, start and stop these services themselves.
+
+To add a custom service, first you need to define a task to start the service in your `build.sbt`. The task should produce a result of `Closeable`, which can be used to stop the service. Here's an example for Elastic Search:
+
+@[start-elastic-search](code/dev-environment.sbt)
+
+Now we're able to start Elastic Search, we need to add this task to Lagom's list of infrastructure services, so that Lagom will start it when `runAll` is executed. This can be done by modifying the `lagomInfrastructureServices` setting:
+
+@[infrastructure-services](code/dev-environment.sbt)
+
 ## Behind the scenes
 
 <!-- copied this section to concepts, perhaps it can be removed later -->

--- a/docs/manual/common/guide/devmode/code/dev-environment.sbt
+++ b/docs/manual/common/guide/devmode/code/dev-environment.sbt
@@ -1,0 +1,35 @@
+
+//#start-elastic-search
+import java.io.Closeable
+
+val startElasticSearch = taskKey[Closeable]("Starts elastic search")
+
+startElasticSearch in ThisBuild := {
+  val esVersion = "5.4.0"
+  val log = streams.value.log
+  val elasticsearch = target.value / s"elasticsearch-$esVersion"
+
+  if (!elasticsearch.exists()) {
+    log.info(s"Downloading Elastic Search $esVersion...")
+    IO.unzipURL(url(s"https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$esVersion.zip"), target.value)
+    IO.append(elasticsearch / "config" / "log4j2.properties", "\nrootLogger.level = warn\n")
+  }
+
+  val binFile = if (sys.props("os.name") == "Windows") {
+    elasticsearch / "bin" / "elasticsearch.bat"
+  } else {
+    elasticsearch / "bin" / "elasticsearch"
+  }
+
+  val process = Process(binFile.getAbsolutePath, elasticsearch).run(log)
+  log.info("Elastic search started on port 9200")
+
+  new Closeable {
+    override def close(): Unit = process.destroy()
+  }
+}
+//#start-elastic-search
+
+//#infrastructure-services
+lagomInfrastructureServices in ThisBuild += (startElasticSearch in ThisBuild).taskValue
+//#infrastructure-services


### PR DESCRIPTION
Fixes #762

Note that this only includes support for sbt. Support for Maven is much more difficult, because in Maven, you can't just arbitrarily add code to your build file to download, configure and run some process. We can probably come up with a solution, possibly by allowing some scripts to be specified to be run as part of runAll startup/shutdown, but I think it requires a lot more thinking than the sbt solution, which is why I haven't attempted it here.