### PR TITLE
Doc Fix: Adds missing trait mixin in Circuit Breaker Metrics code example

### DIFF
--- a/docs/manual/scala/guide/services/code/ServiceClients.scala
+++ b/docs/manual/scala/guide/services/code/ServiceClients.scala
@@ -93,7 +93,8 @@ package metricsservice {
 
   abstract class MyApplication(context: LagomApplicationContext)
     extends LagomApplication(context)
-      with AhcWSComponents {
+      with AhcWSComponents
+      with MetricsServiceComponents {
 
     lazy val lagomServer = LagomServer.forServices(
       bindService[HelloService].to(wire[HelloServiceImpl]),


### PR DESCRIPTION
Documentation fix: 
Adds missing trait mixin in Circuit Breaker Metrics code example.

The scala code example for Circuit Breaker Metrics imports the `MetricsServiceComponents` but does not actually mix it into the application before using`metricsServiceBinding`:  https://www.lagomframework.com/documentation/1.3.x/scala/ServiceClients.html#Circuit-breaker-metrics

