### PR TITLE
Add a PathParamSerializer for Double

### DIFF
--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/deser/PathParamSerializers.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/deser/PathParamSerializers.java
@@ -78,6 +78,11 @@ public final class PathParamSerializers {
     public static final PathParamSerializer<Integer> INTEGER = required("Integer", Integer::parseInt, i -> i.toString());
 
     /**
+     * An Double path param serializer.
+     */
+    public static final PathParamSerializer<Double> DOUBLE = required("Double", Double::parseDouble, d -> d.toString());
+
+    /**
      * A Boolean path param serializer.
      */
     public static final PathParamSerializer<Boolean> BOOLEAN = required("Boolean", Boolean::parseBoolean,

--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
@@ -55,6 +55,7 @@ object ServiceReader {
       classOf[String] -> PathParamSerializers.STRING,
       classOf[java.lang.Long] -> PathParamSerializers.LONG,
       classOf[java.lang.Integer] -> PathParamSerializers.INTEGER,
+      classOf[java.lang.Double] -> PathParamSerializers.DOUBLE,
       classOf[java.lang.Boolean] -> PathParamSerializers.BOOLEAN,
       classOf[java.util.Optional[_]] -> PathParamSerializers.OPTIONAL
     )

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/deser/PathParamSerializer.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/deser/PathParamSerializer.scala
@@ -64,6 +64,11 @@ object PathParamSerializer {
   implicit val IntPathParamSerializer: PathParamSerializer[Int] = required("Int")(_.toInt)(_.toString)
 
   /**
+   * An Double path parameter serializer
+   */
+  implicit val DoublePathParamSerializer: PathParamSerializer[Double] = required("Double")(_.toDouble)(_.toString)
+
+  /**
    * A Boolean path parameter serializer
    */
   implicit val BooleanPathParamSerializer: PathParamSerializer[Boolean] = required("Boolean")(_.toBoolean)(_.toString)

--- a/service/scaladsl/api/src/test/scala/com/lightbend/lagom/scaladsl/api/ServiceSupportSpec.scala
+++ b/service/scaladsl/api/src/test/scala/com/lightbend/lagom/scaladsl/api/ServiceSupportSpec.scala
@@ -26,6 +26,19 @@ class ServiceSupportSpec extends WordSpec with Matchers with OptionValues {
       holder.value.pathParamSerializers should have size 1
       holder.value.pathParamSerializers.head should ===(PathParamSerializer.StringPathParamSerializer)
     }
+
+    "Double path params support" should {
+      val holder = new DoubleMockService {
+        override def foo(bar: Double): ServiceCall[String, String] = null
+      }.descriptor.calls.collect {
+        case CallImpl(PathCallIdImpl("/foo/:bar"), holder: ServiceSupport.ScalaMethodServiceCall[_, _], _, _, _, _) => holder
+      }.headOption
+
+      "pass the path param serializers " in {
+        holder.value.pathParamSerializers should have size 1
+        holder.value.pathParamSerializers.head should ===(PathParamSerializer.DoublePathParamSerializer)
+      }
+    }
   }
 }
 
@@ -37,4 +50,13 @@ trait MockService extends Service {
     pathCall("/foo/:bar", foo _)
   )
 
+}
+
+trait DoubleMockService extends Service {
+
+  def foo(bar: Double): ServiceCall[String, String]
+
+  override def descriptor = named("mock").withCalls(
+    pathCall("/foo/:bar", foo _)
+  )
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Add a default PathParamSerializer for Double.

## Purpose

It add a default PathParamSerializer for Double.

## Background Context

Double is a common used type in JSON.

## References

None