### PR TITLE
[Proposal] public Actions.empty

### DIFF
--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
@@ -62,7 +62,7 @@ class PersistentEntityRefSpec extends WordSpecLike with Matchers with BeforeAndA
     override type State = String
 
     def initialState: String = ""
-    override def behavior = Actions()
+    override def behavior = Actions.empty
   }
 
   val components = new CassandraPersistenceComponents {

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
@@ -138,7 +138,7 @@ abstract class PersistentEntity {
   def recoveryCompleted(state: State): State = state
 
   object Actions {
-    private val empty = new Actions(PartialFunction.empty, Map.empty)
+    val empty = new Actions(PartialFunction.empty, Map.empty)
     def apply(): Actions = empty
   }
 

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/NamedEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/NamedEntity.scala
@@ -13,5 +13,5 @@ class NamedEntity() extends PersistentEntity {
 
   override def initialState: State = ""
 
-  override def behavior: Behavior = Actions()
+  override def behavior: Behavior = Actions.empty
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Nothing

## Purpose

IMHO, `Actions.empty` function should be public because when we want to create an empty actions set, `Actions()` doesn't look like "scala like" and is not explicit enough.

When we want to create a empty List in Scala we do `List.empty`, so why not for `Actions` ?

## Background Context

Explained above

## References

None
