### PR TITLE
[WIP] Registers one PlayJsonSerializer per entity->jsonFormats mapping

### DIFF
--- a/play-json/src/main/resources/reference.conf
+++ b/play-json/src/main/resources/reference.conf
@@ -2,4 +2,11 @@ akka.actor {
   serialization-identifiers {
     "com.lightbend.lagom.scaladsl.playjson.PlayJsonSerializer" = 1000004
   }
+
+  // Require play-json serializer for all events.
+  // This allows for generic trait/class serializers to be registered without having to extend Serializable
+  // in order to guarantee play-json serializer priority.
+  serialization-bindings {
+    "java.io.Serializable" = none
+  }
 }

--- a/play-json/src/main/resources/reference.conf
+++ b/play-json/src/main/resources/reference.conf
@@ -2,11 +2,4 @@ akka.actor {
   serialization-identifiers {
     "com.lightbend.lagom.scaladsl.playjson.PlayJsonSerializer" = 1000004
   }
-
-  // Require play-json serializer for all events.
-  // This allows for generic trait/class serializers to be registered without having to extend Serializable
-  // in order to guarantee play-json serializer priority.
-  serialization-bindings {
-    "java.io.Serializable" = none
-  }
 }

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
@@ -22,14 +22,14 @@ object JsonSerializer {
    * Create a serializer for the PlayJsonSerializationRegistry, describes how a specific class can be read and written
    * as json using separate play-json [[Reads]] and [[Writes]]
    */
-  def apply[T: ClassTag: Format]: JsonSerializer[T] =
+  def apply[T <: Jsonable: ClassTag: Format]: JsonSerializer[T] =
     JsonSerializerImpl(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], implicitly[Format[T]])
 
   /**
    * Create a serializer for the PlayJsonSerializationRegistry, describes how a specific class can be read and written
    * as json using separate play-json [[Reads]] and [[Writes]]
    */
-  def apply[T: ClassTag](format: Format[T]): JsonSerializer[T] =
+  def apply[T <: Jsonable: ClassTag](format: Format[T]): JsonSerializer[T] =
     JsonSerializerImpl(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], format)
 
   private case class JsonSerializerImpl[T](entityClass: Class[T], format: Format[T]) extends JsonSerializer[T]

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializerRegistry.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializerRegistry.scala
@@ -33,11 +33,13 @@ abstract class JsonSerializerRegistry {
     .getOrElse(throw new RuntimeException(s"Missing play-json serializer for [${clazz.getName}], " +
       s"defined are [${registry.keys.mkString(", ")}]"))
 
-  def readsFor(manifest: String): Reads[AnyRef] = registry.getOrElse(
-    manifest,
-    throw new RuntimeException(s"Missing play-json serializer for [$manifest], " +
-      s"defined are [${registry.keys.mkString(", ")}]")
-  )
+  def readsFor(manifest: String): Reads[AnyRef] = {
+    registry.getOrElse(
+      manifest,
+      throw new RuntimeException(s"Missing play-json serializer for [$manifest], " +
+        s"defined are [${registry.keys.mkString(", ")}]")
+    )
+  }
 
   /**
    * Concatenate the serializers and migrations of this registry with another registry to form a new registry.

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializerRegistry.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializerRegistry.scala
@@ -38,12 +38,14 @@ object JsonSerializerRegistry {
   /**
    * Create the serializer details for the given serializer registry.
    */
-  def serializerDetailsFor(system: ExtendedActorSystem, registry: JsonSerializerRegistry): SerializerDetails = {
-    SerializerDetails(
-      "lagom-play-json",
-      new PlayJsonSerializer(system, registry),
-      registry.serializers.map(_.entityClass)
-    )
+  def serializerDetailsFor(system: ExtendedActorSystem, registry: JsonSerializerRegistry): immutable.Seq[SerializerDetails] = {
+    registry.serializers.map { serializer =>
+      SerializerDetails(
+        s"lagom-play-json.serialization.bindings.${serializer.entityClass.getName}",
+        new PlayJsonSerializer(system, serializer, registry.migrations),
+        Vector(serializer.entityClass)
+      )
+    }
   }
 
   /**
@@ -54,7 +56,7 @@ object JsonSerializerRegistry {
    */
   def serializationSetupFor(registry: JsonSerializerRegistry): SerializationSetup = {
     SerializationSetup { system =>
-      Vector(serializerDetailsFor(system, registry))
+      serializerDetailsFor(system, registry)
     }
   }
 

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializerRegistry.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializerRegistry.scala
@@ -17,18 +17,21 @@ import scala.collection.immutable
 abstract class JsonSerializerRegistry {
 
   private lazy val registry: Map[String, Format[AnyRef]] = {
-    serializers.map(entry =>
-      (entry.entityClass.getName, entry.format.asInstanceOf[Format[AnyRef]])).toMap
+    upcastSerializers.map { entry =>
+      (entry.entityClass.getName, entry.format.asInstanceOf[Format[AnyRef]])
+    }.toMap
   }
 
-  protected def serializers: immutable.Seq[JsonSerializer[_]]
+  protected def serializers[T <: Jsonable]: immutable.Seq[JsonSerializer[T]]
+
+  private[playjson] def upcastSerializers: immutable.Seq[JsonSerializer[_]] = serializers
 
   /**
    * A set of migrations keyed by the fully classified class name that the migration should be triggered for
    */
   def migrations: Map[String, JsonMigration] = Map.empty
 
-  def writesFor(clazz: Class[_]): Writes[AnyRef] = serializers
+  def writesFor(clazz: Class[_]): Writes[AnyRef] = upcastSerializers
     .collectFirst { case serializer if clazz.isAssignableFrom(serializer.entityClass) => serializer.format.asInstanceOf[Writes[AnyRef]] }
     .getOrElse(throw new RuntimeException(s"Missing play-json serializer for [${clazz.getName}], " +
       s"defined are [${registry.keys.mkString(", ")}]"))
@@ -58,7 +61,7 @@ object JsonSerializerRegistry {
    * Create the serializer details for the given serializer registry.
    */
   def serializerDetailsFor(system: ExtendedActorSystem, registry: JsonSerializerRegistry): immutable.Seq[SerializerDetails] = {
-    registry.serializers.map { serializer =>
+    registry.upcastSerializers.map { serializer =>
       SerializerDetails(
         s"lagom-play-json.serialization.bindings.${serializer.entityClass.getName}",
         new PlayJsonSerializer(system, writerFor = serializer.entityClass, registry),

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/Jsonable.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/Jsonable.scala
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.playjson
+
+trait Jsonable extends Serializable

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
@@ -25,6 +25,7 @@ private[lagom] final class PlayJsonSerializer(
   extends SerializerWithStringManifest
   with BaseSerializer {
 
+  private val format: Format[AnyRef] = serializer.format.asInstanceOf[Format[AnyRef]]
   private val charset = StandardCharsets.UTF_8
   private val log = Logging.getLogger(system, getClass)
   private val isDebugEnabled = log.isDebugEnabled
@@ -39,8 +40,6 @@ private[lagom] final class PlayJsonSerializer(
 
   override def toBinary(o: AnyRef): Array[Byte] = {
     val startTime = if (isDebugEnabled) System.nanoTime else 0L
-
-    val format = serializer.format.asInstanceOf[Format[AnyRef]]
 
     val json = format.writes(o)
     val result = Json.stringify(json).getBytes(charset)
@@ -71,9 +70,7 @@ private[lagom] final class PlayJsonSerializer(
           s"behind version $fromVersion of deserialized type [$manifestClassName]")
       case _ => manifestClassName
     }
-
-    val format = serializer.format.asInstanceOf[Format[AnyRef]]
-
+    
     val json = Json.parse(bytes) match {
       case jsObject: JsObject => jsObject
       case other =>

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -16,30 +16,31 @@ import scala.collection.immutable.{ Seq, SortedMap }
 sealed trait GenericEvent
 case class SpecificEvent1(x: Int) extends GenericEvent
 case class SpecificEvent2(s: String) extends GenericEvent
-case class MigratedSpecificEventOld() extends GenericEvent
 case class MigratedSpecificEvent(addedField: Int, newName: String) extends GenericEvent
 case class UnrelatedEvent(y: Boolean)
 
 object GenericEvent {
+
+  // In practice all of this could be generated via derived codecs: https://github.com/julienrf/play-json-derived-codecs
   private val specificEvent1Format = Json.format[SpecificEvent1]
   private val specificEvent2Format = Json.format[SpecificEvent2]
   private val migratedSpecificEventFormat = Json.format[MigratedSpecificEvent]
 
   implicit val format: Format[GenericEvent] = new Format[GenericEvent] {
     override def reads(json: JsValue): JsResult[GenericEvent] = (json \ "$type").asOpt[String] match {
-      case Some("SPECIFIC_EVENT_1")        => specificEvent1Format.reads(json)
-      case Some("SPECIFIC_EVENT_2")        => specificEvent2Format.reads(json)
-      case Some("MIGRATED_SPECIFIC_EVENT") => specificEvent2Format.reads(json)
-      case _                               => JsError()
+      case Some(typeName) if typeName == SpecificEvent1.getClass.getName => specificEvent1Format.reads(json)
+      case Some(typeName) if typeName == SpecificEvent2.getClass.getName => specificEvent2Format.reads(json)
+      case Some(typeName) if typeName == MigratedSpecificEvent.getClass.getName => migratedSpecificEventFormat.reads(json)
+      case _ => JsError()
     }
 
     override def writes(o: GenericEvent): JsValue = o match {
       case evt: SpecificEvent1 =>
-        specificEvent1Format.writes(evt) ++ Json.obj("$type" -> "SPECIFIC_EVENT_1")
+        specificEvent1Format.writes(evt) ++ Json.obj("$type" -> SpecificEvent1.getClass.getName)
       case evt: SpecificEvent2 =>
-        specificEvent2Format.writes(evt) ++ Json.obj("$type" -> "SPECIFIC_EVENT_2")
+        specificEvent2Format.writes(evt) ++ Json.obj("$type" -> SpecificEvent2.getClass.getName)
       case evt: MigratedSpecificEvent =>
-        migratedSpecificEventFormat.writes(evt) ++ Json.obj("$type" -> "MIGRATED_SPECIFIC_EVENT")
+        migratedSpecificEventFormat.writes(evt) ++ Json.obj("$type" -> MigratedSpecificEvent.getClass.getName)
     }
   }
 }
@@ -145,7 +146,8 @@ object TestRegistry4 extends JsonSerializerRegistry {
         // remove field (not really needed, here for completeness)
         1 -> (__ \ "removedField").json.prune,
         // add a field with some default value
-        2 -> __.json.update((__ \ "addedField").json.put(JsString("2"))),
+        // update the "$type" to match the new type name
+        2 -> __.json.update((__ \ "addedField").json.put(JsString("2"))).andThen(__.json.update((__ \ "$type").json.put(JsString(MigratedSpecificEvent.getClass.getName)))),
         // a field was renamed, this one is tricky -
         // copy value first, using "update", then remove the old key using "prune"
         3 -> __.json.update((__ \ "newName").json.copyFrom((__ \ "oldName").json.pick))
@@ -155,7 +157,7 @@ object TestRegistry4 extends JsonSerializerRegistry {
           (__ \ "addedField").json.update(Format.of[JsString].map { case JsString(value) => JsNumber(value.toInt) })
       )
     ),
-    JsonMigrations.renamed(MigratedSpecificEventOld.getClass.getName, inVersion = 2, toClass = classOf[MigratedSpecificEvent]),
+    JsonMigrations.renamed("MigratedSpecificEvent.old.ClassName", inVersion = 2, toClass = classOf[MigratedSpecificEvent]),
     JsonMigrations.renamed("GenericEvent.old.ClassName", inVersion = 3, toClass = classOf[GenericEvent])
   )
 }
@@ -166,7 +168,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
   "The PlayJsonSerializer" should {
 
-    "pick up serializers from configured registry" ignore withActorSystem(TestRegistry1) { system =>
+    "pick up serializers from configured registry" in withActorSystem(TestRegistry1) { system =>
 
       val serializeExt = SerializationExtension(system)
       List(Event1("test", 1), Event2("test2", Inner(on = true))).foreach { event =>
@@ -182,7 +184,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       }
     }
 
-    "pick up serializers for registry with migration" ignore withActorSystem(TestRegistry3) { system =>
+    "pick up serializers for registry with migration" in withActorSystem(TestRegistry3) { system =>
 
       val migratedEvent = MigratedEvent(addedField = 2, newName = "some value")
 
@@ -199,7 +201,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "format manifest of migrated type to include the version defined in migration registry" ignore withActorSystem(TestRegistry3) { system =>
+    "format manifest of migrated type to include the version defined in migration registry" in withActorSystem(TestRegistry3) { system =>
 
       val migratedEvent = MigratedEvent(addedField = 2, newName = "some value")
 
@@ -212,7 +214,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "perform migration given previous manifest-with-version format" ignore withActorSystem(TestRegistry3) { system =>
+    "perform migration given previous manifest-with-version format" in withActorSystem(TestRegistry3) { system =>
 
       val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
       val oldJsonBytes = Json.stringify(JsObject(Seq(
@@ -231,7 +233,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       deserialized should equal(expectedEvent)
     }
 
-    "perform migration given previous manifest-without-version format" ignore withActorSystem(TestRegistry1) { system =>
+    "perform migration given previous manifest-without-version format" in withActorSystem(TestRegistry1) { system =>
 
       val expectedEvent = Event1("test", 1)
       val oldJsonBytes = Json.stringify(JsObject(Seq(
@@ -249,7 +251,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       deserialized should equal(expectedEvent)
     }
 
-    "throw runtime exception when deserialization target type version is ahead of that defined in migration registry" ignore withActorSystem(TestRegistry3) { system =>
+    "throw runtime exception when deserialization target type version is ahead of that defined in migration registry" in withActorSystem(TestRegistry3) { system =>
 
       val migratedEvent = MigratedEvent(addedField = 2, newName = "some value")
 
@@ -265,7 +267,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "apply sequential migrations using json-transformations" ignore withActorSystem(TestRegistry2) { system =>
+    "apply sequential migrations using json-transformations" in withActorSystem(TestRegistry2) { system =>
 
       val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
       val oldJsonBytes = Json.stringify(JsObject(Seq(
@@ -283,7 +285,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "apply migrations written imperatively" ignore withActorSystem(TestRegistry3) { system =>
+    "apply migrations written imperatively" in withActorSystem(TestRegistry3) { system =>
 
       val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
       val oldJsonBytes = Json.stringify(JsObject(Seq(
@@ -301,7 +303,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "apply rename migration" ignore withActorSystem(TestRegistry2) { system =>
+    "apply rename migration" in withActorSystem(TestRegistry2) { system =>
 
       val event = Event1("something", 25)
 
@@ -315,7 +317,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "serialize covariant types with generic serializer" ignore withActorSystem(TestRegistry4) { system =>
+    "serialize covariant types with generic serializer" in withActorSystem(TestRegistry4) { system =>
       val serializeExt = SerializationExtension(system)
 
       List(SpecificEvent1(1), SpecificEvent2("test")).foreach { event =>
@@ -332,16 +334,17 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val expectedEvent = MigratedSpecificEvent(addedField = 2, newName = "some value")
       val oldJsonBytes = Json.stringify(JsObject(Seq(
         "removedField" -> JsString("doesn't matter"),
-        "oldName" -> JsString("some value")
+        "oldName" -> JsString("some value"),
+        "$type" -> JsString("MigratedSpecificEvent.old.ClassNam")
       ))).getBytes(StandardCharsets.UTF_8)
       val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
       val oldVersion = 1
-      val manifestV2 = s"GenericEvent.old.ClassName#${MigratedSpecificEventOld.getClass.getName}#$oldVersion"
+      val manifestV2 = s"GenericEvent.old.ClassName#MigratedSpecificEvent.old.ClassName#$oldVersion"
       val deserialized = serializer.fromBinary(oldJsonBytes, manifestV2)
       deserialized should be(expectedEvent)
     }
 
-    "serialize with specific serializer and deserialize with any serializer" ignore withActorSystem(TestRegistry4) { system =>
+    "serialize with specific serializer and deserialize with any serializer" in withActorSystem(TestRegistry4) { system =>
       val serializeExt = SerializationExtension(system)
       val specificEvent = SpecificEvent1(x = 1)
       val unrelatedEvent = UnrelatedEvent(y = true)
@@ -349,7 +352,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val unrelatedEventSerializer = serializeExt.findSerializerFor(unrelatedEvent).asInstanceOf[SerializerWithStringManifest]
 
       val specificEventBytes = genericEventSerializer.toBinary(specificEvent)
-      val unrelatedEventBytes = genericEventSerializer.toBinary(unrelatedEvent)
+      val unrelatedEventBytes = unrelatedEventSerializer.toBinary(unrelatedEvent)
 
       val specificEventManifest = genericEventSerializer.manifest(specificEvent)
       val unrelatedEventManifest = unrelatedEventSerializer.manifest(unrelatedEvent)

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -17,7 +17,7 @@ sealed trait GenericEvent extends Jsonable
 case class SpecificEvent1(x: Int) extends GenericEvent
 case class SpecificEvent2(s: String) extends GenericEvent
 case class MigratedSpecificEvent(addedField: Int, newName: String) extends GenericEvent
-case class UnrelatedEvent(y: Boolean)
+case class UnrelatedEvent(y: Boolean) extends Jsonable
 
 object GenericEvent {
 

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -13,7 +13,7 @@ import play.api.libs.json._
 
 import scala.collection.immutable.{ Seq, SortedMap }
 
-sealed trait GenericEvent
+sealed trait GenericEvent extends Jsonable
 case class SpecificEvent1(x: Int) extends GenericEvent
 case class SpecificEvent2(s: String) extends GenericEvent
 case class MigratedSpecificEvent(addedField: Int, newName: String) extends GenericEvent
@@ -49,13 +49,13 @@ object UnrelatedEvent {
   implicit val format: Format[UnrelatedEvent] = Json.format[UnrelatedEvent]
 }
 
-case class Event1(name: String, increment: Int)
+case class Event1(name: String, increment: Int) extends Jsonable
 object Event1 {
   implicit val format: Format[Event1] = Json.format[Event1]
 }
-case class Event2(name: String, inner: Inner)
-case class Inner(on: Boolean)
-case class MigratedEvent(addedField: Int, newName: String)
+case class Event2(name: String, inner: Inner) extends Jsonable
+case class Inner(on: Boolean) extends Jsonable
+case class MigratedEvent(addedField: Int, newName: String) extends Jsonable
 
 object TestRegistry1 extends JsonSerializerRegistry {
 

--- a/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslClientMacroImpl.scala
+++ b/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslClientMacroImpl.scala
@@ -121,3 +121,4 @@ private[lagom] object ScaladslClientMacroImpl {
   }
 
 }
+


### PR DESCRIPTION
Related to #786
Also addresses #789 in the context of this fix for #789. 

Summary of fix approach: 
- 1 serializer per entity mapping
- each serializer writes one registered type
- each serializer can deserialize any registered type
- new format for serialization manifest (`writerForClassName#manifestClassName#migrationVersion`)
- parsing the manifest is made backwards compatible
- migrations are still based on the concrete class name of the object being serialized
- Reintroduce `Jsonable` in order to guarantee PlayJsonSerializers take precedence over JavaSerializer when dealing with case classes (which extend Serializable by default). 

Detail: 
- Modifies the Serialization setup such that one PlayJsonSerializer is created per entity mapping. 
- Each of these serializers can only write (`toBinary`) one of the registered entity types (and its covariant types). 
    - This fixes the issue outlined in #787 
- Each of these serializers can read (`fromBinary`) all of the types in the JsonSerializationRegistry.
    - Because all of these separate serializers share the same serialization identifier (per the lagom play-json's reference.conf) akka will end up choosing any one of these serializers for deserializing all registered entity types. 
   - In order to maintain ease of use (i.e. not having to manage serializer ids in the user's project) each of these serializers has a reference to the full JsonRegistry.
   - in order to look up the correct `formats` for deserialization we must find it by the name of the class registered to the "specialized" PlayJsonSerializer instance which serialized the object in the first place. This is achieved by changing the format of the manifest produced by the serializer to include both the class of the object and writer's `writerFor` class (which might be a base trait or base class of the actual object being serialized).
   -  parsing the manifest is made backwards compatible so that existing event source tables can still be read and migrations applied. 
- Reintroduce `Jsonable` in order to guarantee PlayJsonSerializers take precedence over JavaSerializer when dealing with case classes (which extend Serializable by default). 
   - as noted in #786 akka will find serializers for `traits/base classes` when selecting a serializer to use for writing an an event object. However because case classes extend `Serializable` by default akka will often find a JavaSerializer for the event object. And because the `trait/base class` typically don't extend Serializable their corresponding serializers are not guaranteed to have priority over the JavaSerializer. In the past this was addressed via `Jsonable` which extended Serializable.




