### PR TITLE
[WIP] Adds support for trait/base class PlayJsonSerializers. 

### DIFF
--- a/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/HelloEntity.scala
+++ b/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/HelloEntity.scala
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 import akka.Done
 import com.lightbend.lagom.scaladsl.persistence.{AggregateEvent, AggregateEventTag, AggregateEventTagger, PersistentEntity}
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
-import com.lightbend.lagom.scaladsl.playjson.{JsonSerializerRegistry, JsonSerializer}
+import com.lightbend.lagom.scaladsl.playjson.{JsonSerializer, JsonSerializerRegistry, Jsonable}
 import play.api.libs.json.{Format, Json}
 
 import scala.collection.immutable.Seq
@@ -50,7 +50,7 @@ class HelloEntity extends PersistentEntity {
   }
 }
 
-case class HelloState(message: String, timestamp: String)
+case class HelloState(message: String, timestamp: String) extends Jsonable
 
 object HelloState {
   implicit val format: Format[HelloState] = Json.format
@@ -60,7 +60,7 @@ object HelloEventTag {
   val INSTANCE: AggregateEventTag[HelloEvent] = AggregateEventTag[HelloEvent]()
 }
 
-sealed trait HelloEvent extends AggregateEvent[HelloEvent]{
+sealed trait HelloEvent extends AggregateEvent[HelloEvent] with Jsonable{
   override def aggregateTag: AggregateEventTagger[HelloEvent] = HelloEventTag.INSTANCE
 }
 
@@ -69,7 +69,7 @@ case class GreetingMessageChanged(message: String) extends HelloEvent
 object GreetingMessageChanged {
   implicit val format: Format[GreetingMessageChanged] = Json.format
 }
-sealed trait HelloCommand[R] extends ReplyType[R]
+sealed trait HelloCommand[R] extends ReplyType[R] with Jsonable
 
 case class UseGreetingMessage(message: String) extends HelloCommand[Done]
 

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogCommand.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogCommand.scala
@@ -3,9 +3,9 @@ package docs.home.scaladsl.persistence
 //#full-example
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
 import akka.Done
-import com.lightbend.lagom.scaladsl.playjson.JsonSerializer
+import com.lightbend.lagom.scaladsl.playjson.{JsonSerializer, Jsonable}
 
-sealed trait BlogCommand
+sealed trait BlogCommand extends Jsonable
 
 object BlogCommand {
   import play.api.libs.json._
@@ -25,7 +25,7 @@ object BlogCommand {
 final case class AddPost(content: PostContent) extends BlogCommand with ReplyType[AddPostDone]
 //#AddPost
 
-final case class AddPostDone(postId: String)
+final case class AddPostDone(postId: String) extends Jsonable
 
 case object GetPost extends BlogCommand with ReplyType[PostContent]
 

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogEvent.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogEvent.scala
@@ -4,7 +4,7 @@ package docs.home.scaladsl.persistence
 import com.lightbend.lagom.scaladsl.persistence.AggregateEvent
 import com.lightbend.lagom.scaladsl.persistence.AggregateEventShards
 import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
-import com.lightbend.lagom.scaladsl.playjson.JsonSerializer
+import com.lightbend.lagom.scaladsl.playjson.{JsonSerializer, Jsonable}
 
 object BlogEvent {
   val NumShards = 20
@@ -20,7 +20,7 @@ object BlogEvent {
     JsonSerializer(Json.format[PostPublished]))
 }
 
-sealed trait BlogEvent extends AggregateEvent[BlogEvent] {
+sealed trait BlogEvent extends AggregateEvent[BlogEvent] with Jsonable{
   override def aggregateTag: AggregateEventShards[BlogEvent] = BlogEvent.Tag
 }
 

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogState.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogState.scala
@@ -1,6 +1,7 @@
 package docs.home.scaladsl.persistence
 
 //#full-example
+import com.lightbend.lagom.scaladsl.playjson.Jsonable
 import play.api.libs.json._
 
 object BlogState {
@@ -11,7 +12,7 @@ object BlogState {
   implicit val format: Format[BlogState] = Json.format[BlogState]
 }
 
-final case class BlogState(content: Option[PostContent], published: Boolean) {
+final case class BlogState(content: Option[PostContent], published: Boolean) extends Jsonable{
   def withBody(body: String): BlogState = {
     content match {
       case Some(c) =>
@@ -24,7 +25,7 @@ final case class BlogState(content: Option[PostContent], published: Boolean) {
   def isEmpty: Boolean = content.isEmpty
 }
 
-final case class PostContent(title: String, body: String)
+final case class PostContent(title: String, body: String) extends Jsonable
 //#full-example
 
-final case class PostSummary(postId: String, title: String)
+final case class PostSummary(postId: String, title: String) extends Jsonable

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/serialization/AddComment.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/serialization/AddComment.scala
@@ -3,14 +3,15 @@
  */
 package docs.home.scaladsl.serialization
 
+import com.lightbend.lagom.scaladsl.playjson.Jsonable
 import play.api.libs.json.{Format, Json}
 
 //#complexMembers
-case class UserMetadata(twitterHandle: String)
+case class UserMetadata(twitterHandle: String) extends Jsonable
 object UserMetadata {
   implicit val format: Format[UserMetadata] = Json.format
 }
-case class AddComment(userId: String, comment: String, userMetadata: UserMetadata)
+case class AddComment(userId: String, comment: String, userMetadata: UserMetadata) extends Jsonable
 object AddComment {
   implicit val format: Format[AddComment] = Json.format
 }

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/serialization/AddPost.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/serialization/AddPost.scala
@@ -1,8 +1,9 @@
 package docs.home.scaladsl.serialization
 
+import com.lightbend.lagom.scaladsl.playjson.Jsonable
 import play.api.libs.json.{Format, Json}
 
-case class AddPost(text: String)
+case class AddPost(text: String) extends Jsonable
 
 object AddPost {
 

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
@@ -9,7 +9,7 @@ import akka.actor.Address
 import akka.cluster.Cluster
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
 import com.lightbend.lagom.scaladsl.persistence.testkit.SimulatedNullpointerException
-import com.lightbend.lagom.scaladsl.playjson.{ JsonSerializerRegistry, JsonSerializer }
+import com.lightbend.lagom.scaladsl.playjson.{ JsonSerializer, JsonSerializerRegistry, Jsonable }
 
 import scala.collection.immutable
 
@@ -45,13 +45,13 @@ object TestEntity {
 
   }
 
-  sealed trait Cmd
+  sealed trait Cmd extends Jsonable
 
   case object Get extends Cmd with ReplyType[State]
 
   final case class Add(element: String, times: Int = 1) extends Cmd with ReplyType[Evt]
 
-  sealed trait Mode
+  sealed trait Mode extends Jsonable
   object Mode {
     case object Prepend extends Mode
     case object Append extends Mode
@@ -81,7 +81,7 @@ object TestEntity {
     )
   }
 
-  sealed trait Evt extends AggregateEvent[Evt] {
+  sealed trait Evt extends AggregateEvent[Evt] with Jsonable {
     override def aggregateTag: AggregateEventShards[Evt] = Evt.aggregateEventShards
   }
 
@@ -104,7 +104,7 @@ object TestEntity {
     )
   }
 
-  final case class State(mode: Mode, elements: List[String]) {
+  final case class State(mode: Mode, elements: List[String]) extends Jsonable {
     def add(elem: String): State = mode match {
       case Mode.Prepend => new State(mode, elem +: elements)
       case Mode.Append  => new State(mode, elements :+ elem)

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
@@ -22,14 +22,14 @@ object JsonSerializer {
    * Create a serializer for the PlayJsonSerializationRegistry, describes how a specific class can be read and written
    * as json using separate play-json [[Reads]] and [[Writes]]
    */
-  def apply[T: ClassTag: Format]: JsonSerializer[T] =
+  def apply[T <: Jsonable: ClassTag: Format]: JsonSerializer[T] =
     JsonSerializerImpl(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], implicitly[Format[T]])
 
   /**
    * Create a serializer for the PlayJsonSerializationRegistry, describes how a specific class can be read and written
    * as json using separate play-json [[Reads]] and [[Writes]]
    */
-  def apply[T: ClassTag](format: Format[T]): JsonSerializer[T] =
+  def apply[T <: Jsonable: ClassTag](format: Format[T]): JsonSerializer[T] =
     JsonSerializerImpl(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], format)
 
   private case class JsonSerializerImpl[T](entityClass: Class[T], format: Format[T]) extends JsonSerializer[T]

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/Jsonable.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/Jsonable.scala
@@ -1,0 +1,6 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.playjson
+
+trait Jsonable extends Serializable

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
@@ -17,38 +17,32 @@ import scala.collection.immutable
  *
  * Akka serializer using the registered play-json serializers and migrations
  */
-private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, registry: JsonSerializerRegistry)
+private[lagom] final class PlayJsonSerializer(
+  val system: ExtendedActorSystem,
+  registry:   JsonSerializerRegistry
+)
   extends SerializerWithStringManifest
   with BaseSerializer {
 
+  private type Manifest = (String, Int, String, Int)
   private val charset = StandardCharsets.UTF_8
   private val log = Logging.getLogger(system, getClass)
   private val isDebugEnabled = log.isDebugEnabled
 
-  private val serializers: Map[String, Format[AnyRef]] = {
-    registry.serializers.map(entry =>
-      (entry.entityClass.getName, entry.format.asInstanceOf[Format[AnyRef]])).toMap
-  }
-
   private def migrations: Map[String, JsonMigration] = registry.migrations
 
   override def manifest(o: AnyRef): String = {
-    val className = o.getClass.getName
-    migrations.get(className) match {
-      case Some(migration) => className + "#" + migration.currentVersion
-      case None            => className
-    }
+    serializeManifest(createManifest(o))
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = {
     val startTime = if (isDebugEnabled) System.nanoTime else 0L
 
-    val (_, manifestClassName: String) = parseManifest(manifest(o))
+    val (registeredClassName, _, _, _) = createManifest(o)
 
-    val format = serializers.getOrElse(
-      manifestClassName,
-      throw new RuntimeException(s"Missing play-json serializer for [$manifestClassName]")
-    )
+    // safe because the call to manifest already confirms that this serializer exists with
+    // the returned registered class name
+    val format = registry.formatFor(registeredClassName)
 
     val json = format.writes(o)
     val result = Json.stringify(json).getBytes(charset)
@@ -65,28 +59,34 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
   }
 
   override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+
     val startTime = if (isDebugEnabled) System.nanoTime else 0L
 
-    val (fromVersion: Int, manifestClassName: String) = parseManifest(manifest)
+    val (registeredClassName, registeredClassNameFromVersion, actualClassName, actualClassNameFromVersion) = parseManifest(manifest)
 
-    val renameMigration = migrations.get(manifestClassName)
-
-    val migratedManifest = renameMigration match {
-      case Some(migration) if (migration.currentVersion > fromVersion) =>
-        migration.transformClassName(fromVersion, manifestClassName)
-      case Some(migration) if (migration.currentVersion < fromVersion) =>
-        throw new IllegalStateException(s"Migration version ${migration.currentVersion} is " +
-          s"behind version $fromVersion of deserialized type [$manifestClassName]")
-      case _ => manifestClassName
+    val migratedActualClassName = {
+      val renameMigration = migrations.get(actualClassName)
+      renameMigration match {
+        case Some(migration) if migration.currentVersion > actualClassNameFromVersion =>
+          migration.transformClassName(actualClassNameFromVersion, actualClassName)
+        case Some(migration) if migration.currentVersion < actualClassNameFromVersion =>
+          throw new IllegalStateException(s"Migration version ${migration.currentVersion} is " +
+            s"behind version $actualClassNameFromVersion of deserialized type [$actualClassName]")
+        case _ => actualClassName
+      }
     }
 
-    val transformMigration = migrations.get(migratedManifest)
-
-    val format = serializers.getOrElse(
-      migratedManifest,
-      throw new RuntimeException(s"Missing play-json serializer for [$migratedManifest], " +
-        s"defined are [${serializers.keys.mkString(", ")}]")
-    )
+    val migratedRegisteredClassName = {
+      val writerForClassNameMigration = migrations.get(registeredClassName)
+      writerForClassNameMigration match {
+        case Some(m) if m.currentVersion > registeredClassNameFromVersion =>
+          m.transformClassName(registeredClassNameFromVersion, registeredClassName)
+        case Some(m) if m.currentVersion < registeredClassNameFromVersion =>
+          throw new IllegalStateException(s"Migration version ${m.currentVersion} is " +
+            s"behind version $registeredClassNameFromVersion of deserialized type [$registeredClassNameFromVersion]")
+        case _ => registeredClassName
+      }
+    }
 
     val json = Json.parse(bytes) match {
       case jsObject: JsObject => jsObject
@@ -95,17 +95,21 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
           s"Expected a JSON object, but was [${other.getClass.getName}]")
     }
 
+    val transformMigration = migrations.get(migratedActualClassName)
+
     val migratedJson = transformMigration match {
-      case Some(migration) if migration.currentVersion > fromVersion =>
-        migration.transform(fromVersion, json)
+      case Some(m) if m.currentVersion > actualClassNameFromVersion =>
+        m.transform(actualClassNameFromVersion, json)
       case _ => json
     }
+
+    val format = registry.formatFor(migratedRegisteredClassName)
 
     val result = format.reads(migratedJson) match {
       case JsSuccess(obj, _) => obj
       case JsError(errors) =>
         throw new JsonSerializationFailed(
-          s"Failed to de-serialize bytes with manifest [$migratedManifest]",
+          s"Failed to de-serialize bytes with manifest [$manifest]",
           errors,
           migratedJson
         )
@@ -122,10 +126,53 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
     result
   }
 
-  private def parseManifest(manifest: String) = {
-    val i = manifest.lastIndexOf('#')
-    val fromVersion = if (i == -1) 1 else manifest.substring(i + 1).toInt
-    val manifestClassName = if (i == -1) manifest else manifest.substring(0, i)
-    (fromVersion, manifestClassName)
+  private def serializeManifest(manifest: Manifest) = manifest match {
+    case (registeredClassName, registeredClassNameFromVersion, actualClassName, actualClassNameFromVersion) =>
+      s"$registeredClassName#$registeredClassNameFromVersion#$actualClassName#$actualClassNameFromVersion"
+  }
+
+  private def createManifest(o: AnyRef): Manifest = {
+    registry
+      .serializers
+      .find(_.entityClass.isAssignableFrom(o.getClass))
+      .map { serializer =>
+
+        val registeredClassName = serializer.entityClass.getName
+        val registeredClassVersion = migrations.get(registeredClassName) match {
+          case Some(migration) => migration.currentVersion
+          case None            => 1
+        }
+
+        val actualClassName = o.getClass.getName
+        val actualClassNameVersion = migrations.get(actualClassName) match {
+          case Some(migration) => migration.currentVersion
+          case None            => 1
+        }
+
+        (registeredClassName, registeredClassVersion, actualClassName, actualClassNameVersion)
+      }
+      .getOrElse(throw new RuntimeException(s"Could not create manifest string: Missing play-json serializer for [${o.getClass.getName}], " +
+        s"defined are [${registry.registry.keys.mkString(", ")}]"))
+  }
+
+  private def parseManifest(manifest: String): Manifest = {
+    val parts = manifest.split("#")
+
+    parts.size match {
+      case 4 => // updated format for supporting serialization of subclasses
+        val registeredClassName = parts(0)
+        val registeredClassNameFromVersion = parts(1)
+        val actualClassName = parts(2)
+        val actualClassNameFromVersion = parts(3)
+        (registeredClassName, registeredClassNameFromVersion.toInt, actualClassName, actualClassNameFromVersion.toInt)
+
+      case 2 => // for backwards compatibility when version was specified
+        val actualClassName = parts(0)
+        val fromVersion = parts(1)
+        (actualClassName, fromVersion.toInt, actualClassName, fromVersion.toInt)
+
+      case 1 => // for backwards compatibility when no version was specified
+        (manifest, 1, manifest, 1)
+    }
   }
 }

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
@@ -10,8 +10,6 @@ import akka.event.Logging
 import akka.serialization.{ BaseSerializer, SerializerWithStringManifest }
 import play.api.libs.json._
 
-import scala.collection.immutable
-
 /**
  * Internal API
  *
@@ -151,7 +149,7 @@ private[lagom] final class PlayJsonSerializer(
 
         (registeredClassName, registeredClassVersion, actualClassName, actualClassNameVersion)
       }
-      .getOrElse(throw new RuntimeException(s"Could not create manifest string: Missing play-json serializer for [${o.getClass.getName}], " +
+      .getOrElse(throw new RuntimeException(s"Could not create manifest: Missing play-json serializer for [${o.getClass.getName}], " +
         s"defined are [${registry.registry.keys.mkString(", ")}]"))
   }
 

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -361,7 +361,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       deserialized should be(expectedEvent)
     }
 
-    "find PlayJsonSerializer for all registered types" in withActorSystem(TestRegistry4) { system =>
+    "find the PlayJsonSerializer for all registered types" in withActorSystem(TestRegistry4) { system =>
 
       val serializeExt = SerializationExtension(system)
       val specificEvent1 = SpecificEvent1(x = 1)
@@ -369,10 +369,12 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val migratedSpecificEvent = MigratedSpecificEvent(5, "test")
       val unrelatedEvent = UnrelatedEvent(true)
 
-      val s1 = serializeExt.findSerializerFor(specificEvent1).asInstanceOf[PlayJsonSerializer]
-      val s2 = serializeExt.findSerializerFor(specificEvent2).asInstanceOf[PlayJsonSerializer]
-      val s3 = serializeExt.findSerializerFor(migratedSpecificEvent).asInstanceOf[PlayJsonSerializer]
-      val s4 = serializeExt.findSerializerFor(unrelatedEvent).asInstanceOf[PlayJsonSerializer]
+      val s1 = serializeExt.findSerializerFor(specificEvent1)
+      val s2 = serializeExt.findSerializerFor(specificEvent2)
+      val s3 = serializeExt.findSerializerFor(migratedSpecificEvent)
+      val s4 = serializeExt.findSerializerFor(unrelatedEvent)
+
+      s1 should be(a[PlayJsonSerializer])
       s1 should be(s2)
       s1 should be(s3)
       s1 should be(s4)

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -13,13 +13,49 @@ import play.api.libs.json._
 
 import scala.collection.immutable.{ Seq, SortedMap }
 
-case class Event1(name: String, increment: Int)
+sealed trait GenericEvent extends Jsonable
+case class SpecificEvent1(x: Int) extends GenericEvent
+case class SpecificEvent2(s: String) extends GenericEvent
+case class MigratedSpecificEvent(addedField: Int, newName: String) extends GenericEvent
+case class UnrelatedEvent(y: Boolean) extends Jsonable
+
+object GenericEvent {
+
+  // In practice all of this could be generated via derived codecs: https://github.com/julienrf/play-json-derived-codecs
+  private val specificEvent1Format = Json.format[SpecificEvent1]
+  private val specificEvent2Format = Json.format[SpecificEvent2]
+  private val migratedSpecificEventFormat = Json.format[MigratedSpecificEvent]
+
+  implicit val format: Format[GenericEvent] = new Format[GenericEvent] {
+    override def reads(json: JsValue): JsResult[GenericEvent] = (json \ "$type").asOpt[String] match {
+      case Some(typeName) if typeName == SpecificEvent1.getClass.getName => specificEvent1Format.reads(json)
+      case Some(typeName) if typeName == SpecificEvent2.getClass.getName => specificEvent2Format.reads(json)
+      case Some(typeName) if typeName == MigratedSpecificEvent.getClass.getName => migratedSpecificEventFormat.reads(json)
+      case _ => JsError()
+    }
+
+    override def writes(o: GenericEvent): JsValue = o match {
+      case evt: SpecificEvent1 =>
+        specificEvent1Format.writes(evt) ++ Json.obj("$type" -> SpecificEvent1.getClass.getName)
+      case evt: SpecificEvent2 =>
+        specificEvent2Format.writes(evt) ++ Json.obj("$type" -> SpecificEvent2.getClass.getName)
+      case evt: MigratedSpecificEvent =>
+        migratedSpecificEventFormat.writes(evt) ++ Json.obj("$type" -> MigratedSpecificEvent.getClass.getName)
+    }
+  }
+}
+
+object UnrelatedEvent {
+  implicit val format: Format[UnrelatedEvent] = Json.format[UnrelatedEvent]
+}
+
+case class Event1(name: String, increment: Int) extends Jsonable
 object Event1 {
   implicit val format: Format[Event1] = Json.format[Event1]
 }
-case class Event2(name: String, inner: Inner)
-case class Inner(on: Boolean)
-case class MigratedEvent(addedField: Int, newName: String)
+case class Event2(name: String, inner: Inner) extends Jsonable
+case class Inner(on: Boolean) extends Jsonable
+case class MigratedEvent(addedField: Int, newName: String) extends Jsonable
 
 object TestRegistry1 extends JsonSerializerRegistry {
 
@@ -30,7 +66,6 @@ object TestRegistry1 extends JsonSerializerRegistry {
       JsonSerializer[Event1],
       JsonSerializer(Json.format[Event2])
     )
-
 }
 
 object TestRegistry2 extends JsonSerializerRegistry {
@@ -58,8 +93,7 @@ object TestRegistry2 extends JsonSerializerRegistry {
           (__ \ "addedField").json.update(Format.of[JsString].map { case JsString(value) => JsNumber(value.toInt) })
       )
     ),
-    JsonMigrations.renamed("event1.old.ClassName", inVersion = 2, toClass = classOf[Event1]),
-    JsonMigrations.renamed("MigratedEvent.old.ClassName", inVersion = 2, toClass = classOf[MigratedEvent])
+    JsonMigrations.renamed("event1.old.ClassName", inVersion = 2, toClass = classOf[Event1])
   )
 }
 
@@ -96,6 +130,37 @@ object TestRegistry3 extends JsonSerializerRegistry {
         toUpdate
       }
     }
+  )
+}
+
+object TestRegistry4 extends JsonSerializerRegistry {
+  override def serializers = Seq(
+    JsonSerializer[GenericEvent],
+    JsonSerializer[UnrelatedEvent]
+  )
+
+  override def migrations: Map[String, JsonMigration] = Map(
+    JsonMigrations.transform[MigratedSpecificEvent](
+      // something like a history of changes, if version is oldest each one needs to be applied
+      SortedMap(
+        // remove field (not really needed, here for completeness)
+        1 -> (__ \ "removedField").json.prune,
+        // add a field with some default value
+        // update the "$type" to match the new type name
+        2 -> __.json.update((__ \ "addedField").json.put(JsString("2"))).andThen(__.json.update((__ \ "$type").json.put(JsString(MigratedSpecificEvent.getClass.getName)))),
+        // a field was renamed, this one is tricky -
+        // copy value first, using "update", then remove the old key using "prune"
+        3 -> __.json.update((__ \ "newName").json.copyFrom((__ \ "oldName").json.pick))
+          .andThen((__ \ "oldName").json.prune),
+        4 ->
+          // a field changed type
+          (__ \ "addedField").json.update(Format.of[JsString].map { case JsString(value) => JsNumber(value.toInt) })
+      )
+    ),
+    JsonMigrations.renamed("MigratedSpecificEvent.older.ClassName", inVersion = 2, toClass = classOf[MigratedSpecificEvent]),
+    JsonMigrations.renamed("MigratedSpecificEvent.old.ClassName", inVersion = 3, toClass = classOf[MigratedSpecificEvent]),
+    JsonMigrations.renamed("GenericEvent.older.ClassName", inVersion = 3, toClass = classOf[GenericEvent]),
+    JsonMigrations.renamed("GenericEvent.old.ClassName", inVersion = 4, toClass = classOf[GenericEvent])
   )
 }
 
@@ -147,8 +212,45 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
       val manifest = serializer.manifest(migratedEvent)
 
-      manifest shouldEqual expectedVersionedManifest(classOf[MigratedEvent], TestRegistry3.currentMigrationVersion)
+      manifest shouldEqual expectedVersionedManifest(classOf[MigratedEvent], TestRegistry3.currentMigrationVersion, classOf[MigratedEvent], TestRegistry3.currentMigrationVersion)
 
+    }
+
+    "perform migration given previous manifest-with-version format" in withActorSystem(TestRegistry3) { system =>
+
+      val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
+      val oldJsonBytes = Json.stringify(JsObject(Seq(
+        "removedField" -> JsString("doesn't matter"),
+        "oldName" -> JsString("some value")
+      ))).getBytes(StandardCharsets.UTF_8)
+
+      val serializeExt = SerializationExtension(system)
+      val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
+
+      val oldVersion = 1
+      val oldManifestWithVersion = s"${expectedEvent.getClass.getName}#$oldVersion"
+
+      val deserialized = serializer.fromBinary(oldJsonBytes, oldManifestWithVersion)
+
+      deserialized should equal(expectedEvent)
+    }
+
+    "perform migration given previous manifest-without-version format" in withActorSystem(TestRegistry1) { system =>
+
+      val expectedEvent = Event1("test", 1)
+      val oldJsonBytes = Json.stringify(JsObject(Seq(
+        "name" -> JsString("test"),
+        "increment" -> JsNumber(1)
+      ))).getBytes(StandardCharsets.UTF_8)
+
+      val serializeExt = SerializationExtension(system)
+      val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
+
+      val oldManifestWithVersion = s"${expectedEvent.getClass.getName}"
+
+      val deserialized = serializer.fromBinary(oldJsonBytes, oldManifestWithVersion)
+
+      deserialized should equal(expectedEvent)
     }
 
     "throw runtime exception when deserialization target type version is ahead of that defined in migration registry" in withActorSystem(TestRegistry3) { system =>
@@ -159,7 +261,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val serializer = serializeExt.findSerializerFor(migratedEvent).asInstanceOf[SerializerWithStringManifest]
 
       val illegalVersion = TestRegistry3.currentMigrationVersion + 1
-      val illegalManifest = expectedVersionedManifest(classOf[MigratedEvent], illegalVersion)
+      val illegalManifest = expectedVersionedManifest(classOf[MigratedEvent], illegalVersion, classOf[MigratedEvent], illegalVersion)
 
       assertThrows[IllegalStateException] {
         serializer.fromBinary(Array[Byte](), illegalManifest)
@@ -179,7 +281,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
 
       val oldVersionBeforeThanCurrentMigration = 1
-      val manifest = expectedVersionedManifest(classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration)
+      val manifest = expectedVersionedManifest(classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration, classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration)
       val deserialized = serializer.fromBinary(oldJsonBytes, manifest)
       deserialized should be(expectedEvent)
 
@@ -197,7 +299,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
 
       val oldVersionBeforeThanCurrentMigration = 1
-      val manifest = expectedVersionedManifest(classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration)
+      val manifest = expectedVersionedManifest(classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration, classOf[MigratedEvent], oldVersionBeforeThanCurrentMigration)
       val deserialized = serializer.fromBinary(oldJsonBytes, manifest)
       deserialized should be(expectedEvent)
 
@@ -217,24 +319,67 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
     }
 
-    "apply rename migration and then use new name to apply migration transformations" in withActorSystem(TestRegistry2) { system =>
+    "serialize covariant types with generic serializer" in withActorSystem(TestRegistry4) { system =>
+      val serializeExt = SerializationExtension(system)
 
-      val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
+      List(SpecificEvent1(1), SpecificEvent2("test")).foreach { event =>
+        val serializer = serializeExt.findSerializerFor(event).asInstanceOf[SerializerWithStringManifest]
+        val bytes = serializer.toBinary(event)
+        val manifest = serializer.manifest(event)
+        val deserialized = serializer.fromBinary(bytes, manifest)
+        deserialized should be(event)
+      }
+    }
+
+    "migrate registered class name, migrated actual class name, and run migration" in withActorSystem(TestRegistry4) { system =>
+      val serializeExt = SerializationExtension(system)
+      val expectedEvent = MigratedSpecificEvent(addedField = 2, newName = "some value")
       val oldJsonBytes = Json.stringify(JsObject(Seq(
         "removedField" -> JsString("doesn't matter"),
-        "oldName" -> JsString("some value")
+        "oldName" -> JsString("some value"),
+        "$type" -> JsString("MigratedSpecificEvent.old.ClassNam")
       ))).getBytes(StandardCharsets.UTF_8)
-
-      val serializeExt = SerializationExtension(system)
       val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
-
-      val deserialized = serializer.fromBinary(oldJsonBytes, "MigratedEvent.old.ClassName")
-
+      val oldVersion = 1
+      val manifestV2 = s"GenericEvent.old.ClassName#$oldVersion#MigratedSpecificEvent.old.ClassName#$oldVersion"
+      val deserialized = serializer.fromBinary(oldJsonBytes, manifestV2)
       deserialized should be(expectedEvent)
     }
 
-    def expectedVersionedManifest[T](clazz: Class[T], migrationVersion: Int) = {
-      s"${clazz.getName}#$migrationVersion"
+    "migrate older generation registered class name, use current class name, and run migration" in withActorSystem(TestRegistry4) { system =>
+      val serializeExt = SerializationExtension(system)
+      val expectedEvent = MigratedSpecificEvent(addedField = 2, newName = "some value")
+      val oldJsonBytes = Json.stringify(JsObject(Seq(
+        "removedField" -> JsString("doesn't matter"),
+        "oldName" -> JsString("some value"),
+        "$type" -> JsString("MigratedSpecificEvent.old.ClassNam")
+      ))).getBytes(StandardCharsets.UTF_8)
+      val serializer = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
+      val oldVersion = 1
+      val manifestV2 = s"GenericEvent.older.ClassName#$oldVersion#${expectedEvent.getClass.getCanonicalName}#$oldVersion"
+      val deserialized = serializer.fromBinary(oldJsonBytes, manifestV2)
+      deserialized should be(expectedEvent)
+    }
+
+    "find PlayJsonSerializer for all registered types" in withActorSystem(TestRegistry4) { system =>
+
+      val serializeExt = SerializationExtension(system)
+      val specificEvent1 = SpecificEvent1(x = 1)
+      val specificEvent2 = SpecificEvent2(s = "test")
+      val migratedSpecificEvent = MigratedSpecificEvent(5, "test")
+      val unrelatedEvent = UnrelatedEvent(true)
+
+      val s1 = serializeExt.findSerializerFor(specificEvent1).asInstanceOf[PlayJsonSerializer]
+      val s2 = serializeExt.findSerializerFor(specificEvent2).asInstanceOf[PlayJsonSerializer]
+      val s3 = serializeExt.findSerializerFor(migratedSpecificEvent).asInstanceOf[PlayJsonSerializer]
+      val s4 = serializeExt.findSerializerFor(unrelatedEvent).asInstanceOf[PlayJsonSerializer]
+      s1 should be(s2)
+      s1 should be(s3)
+      s1 should be(s4)
+    }
+
+    def expectedVersionedManifest[A, B <: A](registeredClass: Class[A], registeredClassMigrationVersion: Int, actualClass: Class[B], actualClassMigrationVersion: Int) = {
+      s"${registeredClass.getName}#$registeredClassMigrationVersion#${actualClass.getName}#$actualClassMigrationVersion"
     }
 
   }
@@ -250,7 +395,6 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
       result.isSuccess shouldBe true
       result.get shouldBe Singleton
     }
-
   }
 
   private var counter = 0

--- a/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslClientMacroImpl.scala
+++ b/service/scaladsl/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/client/ScaladslClientMacroImpl.scala
@@ -121,3 +121,4 @@ private[lagom] object ScaladslClientMacroImpl {
   }
 
 }
+

--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/services/FakeServices.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/services/FakeServices.scala
@@ -10,7 +10,7 @@ import akka.stream.scaladsl.Flow
 import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceCall }
 import com.lightbend.lagom.scaladsl.api.Service._
 import com.lightbend.lagom.scaladsl.api.broker.Topic
-import com.lightbend.lagom.scaladsl.playjson.{ JsonSerializer, JsonSerializerRegistry }
+import com.lightbend.lagom.scaladsl.playjson.{ JsonSerializer, JsonSerializerRegistry, Jsonable }
 import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationContext }
 import play.api.libs.ws.ahc.AhcWSComponents
 
@@ -35,7 +35,7 @@ trait AlphaService extends Service {
   def messages: Topic[AlphaEvent]
 }
 
-case class AlphaEvent(message: Int)
+case class AlphaEvent(message: Int) extends Jsonable
 
 object AlphaEvent {
 
@@ -72,7 +72,7 @@ trait CharlieService extends Service {
   def messages: ServiceCall[NotUsed, Seq[ReceivedMessage]]
 }
 
-case class ReceivedMessage(topicId: String, msg: Int)
+case class ReceivedMessage(topicId: String, msg: Int) extends Jsonable
 
 object ReceivedMessage {
 


### PR DESCRIPTION
Related to #786

Summary of approach: 
- maintains 1 serializer for all lagom registered entities. 
- differentiates between the `registeredClass` and the `actualClass` where `actualClass <: registeredClass`. This is necessary for tracking and applying their rename migrations separately. 
- ensure manifest parsing is backwards compatible and migration process is backwards compatible
- Reintroduce Jsonable and require all classes registered with the `JsonSerializerRegistry` to extend this trait. This is is necessary to work around the unpredictable selection of the `JavaSerializer` when working with `trait/base class` JsonSerializers. Jsonable can be removed if [akka/issues/17252](https://github.com/akka/akka/issues/17252) is addressed.

Detail: 
- manifest creation process goes as follows
   1.) find a serializer who's `entityClass` is `assignableFrom` the given objects `Class[T]` (this is the `registeredClass`)
   2.) look up any available rename migrations for the `registeredClassName` and get the migration's `currentVersion` otherwise 1
   3.) look up any available rename migrations for the object's class (this is the `actualClass`) and return the migration's `currentVersion` otherwise 1
   4.) return a tuple of `(registeredClassName, registeredClassVersion, actualClassName, actualClassNameVersion)`
   5.) if necessary serialize the manifest using the format `s"$registeredClassName#$registeredClassNameFromVersion#$actualClassName#$actualClassNameFromVersion"`

- the serialization process goes as follows:
   1.) create unserialized manifest (`(String, Int, String, Int)`) using the object to be serialized
   2.) look up the `Format[T]` using the `registeredClassName`
   3.) serialize the object and return bytes

- the migration process goes as follows: 
   1.) parse the manifest string
   2.) migrate the `actualClassName` to `migratedActualClassName`
   3.) migrate the `registeredClassName` to `migratedRegisteredClassName`
   4.) lookup the json transofmration migration using the `migratedActualClassName` and apply the tranformation
   5.) lookup the `Formats[T]` instance using the `migratedRegisteredClassName` and parse the json to an instance of the `ActualClass`

   **Note:** The migration process is the same when not using a trait/base class serializer. In this case `actualClassName == registeredClassName`.  