### PR TITLE
Update jboss-logging to 3.3.0.Final

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -636,6 +636,10 @@ object Dependencies {
     akkaPersistenceCassandra
       exclude("io.netty", "netty-all") exclude("io.netty", "netty-handler") exclude("io.netty", "netty-buffer")
       exclude("io.netty", "netty-common") exclude("io.netty", "netty-transport") exclude("io.netty", "netty-codec"),
+    // Explicitly override the jboss-logging transitive dependency from cassandra-all.
+    // By default, it uses jboss-logging 3.1.0.CR2, which is under LGPL.
+    // This forces it to a newer version that is licensed under Apache v2.
+    jbossLogging,
     "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion
   )
 


### PR DESCRIPTION
This is the version that's used everywhere in Lagom other than in the transitive dependency of Cassandra. This change forces it to use that version in Cassandra, too.

This fixes a license issue: the version used by Cassandra by default is licensed under the LGPL. This uses a version licensed under Apache v2.

cc: @eed3si9n

Needs backport to 1.3.x.