### PR TITLE
[WIP] increase barrier-timeout for multi-jvm tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-sudo: false
+sudo: true
 jdk:
   - oraclejdk8
 env:

--- a/persistence-cassandra/scaladsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-cassandra/scaladsl/src/multi-jvm/resources/reference.conf
@@ -1,0 +1,1 @@
+akka.testconductor.barrier-timeout = 2m


### PR DESCRIPTION
this is just a test to see if we get this timeout under control

I'm not really convinced that we need more than 30s (default value). This is probably falling because Cassandra is not starting at all.