### PR TITLE
Bumps APC version to 0.29

### DIFF
--- a/.travis-jvmopts
+++ b/.travis-jvmopts
@@ -4,5 +4,3 @@
 -Xmx1024M
 -Xss2M
 -XX:MaxMetaspaceSize=512M
--XX:+UseConcMarkSweepGC
--XX:+CMSClassUnloadingEnabled

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: scala
-sudo: false
+dist: trusty
+sudo: required
 jdk:
   - oraclejdk8
 env:

--- a/dev/kafka-server/src/main/scala/com/lightbend/lagom/internal/kafka/KafkaLocalServer.scala
+++ b/dev/kafka-server/src/main/scala/com/lightbend/lagom/internal/kafka/KafkaLocalServer.scala
@@ -181,7 +181,7 @@ object KafkaLocalServer {
   }
 
   object ZooKeeperLocalServer {
-    private[kafka] final val DefaultPort = 2181
+    final val DefaultPort = 2181
     private final val ZookeeperDataFolderName = "zookeeper_data"
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,13 +7,13 @@ object Dependencies {
   val PlayVersion = "2.5.13"
   val AkkaVersion = "2.4.19"
   val ScalaVersion = "2.11.11"
-  val AkkaPersistenceCassandraVersion = "0.26"
+  val AkkaPersistenceCassandraVersion = "0.29"
   val ScalaTestVersion = "3.0.1"
   val JacksonVersion = "2.7.8"
   val CassandraAllVersion = "3.0.9"
   val GuavaVersion = "19.0"
   val MavenVersion = "3.3.9"
-  val NettyVersion = "4.0.42.Final"
+  val NettyVersion = "4.0.44.Final"
   val KafkaVersion = "0.10.0.1"
   val AkkaStreamKafkaVersion = "0.13"
   val Log4jVersion = "1.2.17"
@@ -70,7 +70,7 @@ object Dependencies {
       "com.addthis.metrics" % "reporter-config3" % "3.0.0",
       "com.boundary" % "high-scale-lib" % "1.0.6",
       "com.clearspring.analytics" % "stream" % "2.5.2",
-      "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.4",
+      "com.datastax.cassandra" % "cassandra-driver-core" % "3.2.0",
       "com.fasterxml" % "classmate" % "1.3.0",
       "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
       "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.4.17.1",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,9 +11,10 @@ object Dependencies {
   val ScalaTestVersion = "3.0.1"
   val JacksonVersion = "2.7.8"
   val CassandraAllVersion = "3.0.9"
+  val CassandraDriverVersion = "3.1.4"
   val GuavaVersion = "19.0"
   val MavenVersion = "3.3.9"
-  val NettyVersion = "4.0.44.Final"
+  val NettyVersion = "4.0.42.Final"
   val KafkaVersion = "0.10.0.1"
   val AkkaStreamKafkaVersion = "0.13"
   val Log4jVersion = "1.2.17"
@@ -42,7 +43,10 @@ object Dependencies {
   private val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion
   private val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
 
-  private val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion
+  // latest version of APC depend on a Cassandra driver core that's not compatible with Lagom (newer netty/guava/etc... under the covers)
+  private val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion exclude ("com.datastax.cassandra" , "cassandra-driver-core")
+  private val cassandraDriverCore = "com.datastax.cassandra" % "cassandra-driver-core" % CassandraDriverVersion
+
   private val akkaStreamKafka = "com.typesafe.akka" %% "akka-stream-kafka" % AkkaStreamKafkaVersion
 
   private val play = "com.typesafe.play" %% "play" % PlayVersion
@@ -70,7 +74,7 @@ object Dependencies {
       "com.addthis.metrics" % "reporter-config3" % "3.0.0",
       "com.boundary" % "high-scale-lib" % "1.0.6",
       "com.clearspring.analytics" % "stream" % "2.5.2",
-      "com.datastax.cassandra" % "cassandra-driver-core" % "3.2.0",
+      cassandraDriverCore,
       "com.fasterxml" % "classmate" % "1.3.0",
       "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
       "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.4.17.1",
@@ -475,7 +479,7 @@ object Dependencies {
   )
   val `persistence-cassandra-core` = libraryDependencies ++= Seq(
     akkaPersistenceCassandra,
-
+    cassandraDriverCore,
     // cassandra-driver-core pulls in an older version of all these
     "io.netty" % "netty-buffer" % NettyVersion,
     "io.netty" % "netty-codec" % NettyVersion,
@@ -489,9 +493,13 @@ object Dependencies {
     "org.apache.httpcomponents" % "httpclient" % "4.5.2" % Test
   )
 
-  val `persistence-cassandra-javadsl` = libraryDependencies ++= Nil
+  val `persistence-cassandra-javadsl` = libraryDependencies ++= Seq(
+    cassandraDriverCore
+  )
 
-  val `persistence-cassandra-scaladsl` = libraryDependencies ++= Nil
+  val `persistence-cassandra-scaladsl` = libraryDependencies ++= Seq(
+    cassandraDriverCore
+  )
 
   val `persistence-jdbc-core` = libraryDependencies ++= Seq(
     "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.4.17.1",

--- a/service/javadsl/kafka/server/src/test/resources/logback.xml
+++ b/service/javadsl/kafka/server/src/test/resources/logback.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.cassandra" level="ERROR" />
+    <logger name="org.apache.kafka" level="ERROR" />
+    <logger name="org.apache.zookeeper" level="ERROR" />
+    <logger name="kafka" level="ERROR" />
+    <logger name="com.datastax.driver" level="WARN" />
+
+    <logger name="mockservice" level="OFF" />
+
+    <logger name="akka" level="WARN" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -8,8 +8,6 @@ import java.util.Optional
 import java.util.concurrent.{ CompletableFuture, CompletionStage, CountDownLatch, TimeUnit }
 import java.util.function.{ Function => JFunction }
 
-
-import akka.{ Done, NotUsed }
 import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.japi.{ Pair => JPair }
@@ -17,6 +15,7 @@ import akka.stream.javadsl.{ Source => JSource }
 import akka.stream.scaladsl.{ Flow, Sink, Source, SourceQueueWithComplete }
 import akka.stream.{ Materializer, OverflowStrategy }
 import akka.testkit.EventFilter
+import akka.{ Done, NotUsed }
 import com.google.inject.AbstractModule
 import com.lightbend.lagom.internal.javadsl.broker.kafka.JavadslKafkaApiSpec.{ InMemoryOffsetStore, NullPersistentEntityRegistry }
 import com.lightbend.lagom.internal.javadsl.persistence.OffsetAdapter
@@ -34,14 +33,14 @@ import kafka.utils.ZkUtils
 import org.I0Itec.zkclient.ZkClient
 import org.I0Itec.zkclient.exception.ZkMarshallingError
 import org.I0Itec.zkclient.serialize.ZkSerializer
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 import play.api.inject._
 import play.api.inject.guice.GuiceApplicationBuilder
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 class JavadslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
 

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -3,11 +3,9 @@
  */
 package com.lightbend.lagom.scaladsl.kafka.broker
 
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{ CountDownLatch, TimeUnit }
 
 import akka.Done
-import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.persistence.query.{ NoOffset, Offset, Sequence }
 import akka.stream.OverflowStrategy
@@ -16,7 +14,7 @@ import akka.testkit.EventFilter
 import com.lightbend.lagom.internal.kafka.KafkaLocalServer
 import com.lightbend.lagom.internal.kafka.KafkaLocalServer.ZooKeeperLocalServer
 import com.lightbend.lagom.scaladsl.api.broker.Topic
-import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceLocator }
+import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service }
 import com.lightbend.lagom.scaladsl.broker.TopicProducer
 import com.lightbend.lagom.scaladsl.broker.kafka.LagomKafkaComponents
 import com.lightbend.lagom.scaladsl.client.ConfigurationServiceLocatorComponents
@@ -29,14 +27,14 @@ import kafka.utils.ZkUtils
 import org.I0Itec.zkclient.ZkClient
 import org.I0Itec.zkclient.exception.ZkMarshallingError
 import org.I0Itec.zkclient.serialize.ZkSerializer
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 import play.api.Configuration
 import play.api.libs.ws.ahc.AhcWSComponents
 
 import scala.collection.concurrent.TrieMap
-import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
+import scala.concurrent.{ Future, Promise }
 
 class ScaladslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfterAll with ScalaFutures {
 
@@ -57,8 +55,7 @@ class ScaladslKafkaApiSpec extends WordSpecLike with Matchers with BeforeAndAfte
     }
   }
 
-  import application.executionContext
-  import application.materializer
+  import application.{ executionContext, materializer }
 
   private val kafkaServer = KafkaLocalServer(cleanOnStart = true)
 


### PR DESCRIPTION
Fixes #797

~I had to upgrade a few transitive dependencies in the whitelist so I suspect something could break.~

After further investigation this PR bumps `akka-persistence-cassandra` (APC) to `0.29` but it excludes the cassandra driver that APC will bring in transitively. That exclusion is required because the version of the cassandra driver APC depends on bumps Guava and Netty. While Guava doesn't seem to be causing issues, the Netty bump does cause issues with other code in Lagom (See comments in #797).

