### PR TITLE
Adds awaits on the test and bumps versions to match _root_ build.sbt

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,6 +1,6 @@
 
-val PlayVersion = "2.5.4"
-val AkkaVersion = "2.4.12"
+val PlayVersion = "2.5.13"
+val AkkaVersion = "2.4.19"
 
 val branch = {
   val rev = "git rev-parse --abbrev-ref HEAD".!!.trim
@@ -9,6 +9,7 @@ val branch = {
     "git rev-parse HEAD".!!.trim
   } else rev
 }
+
 
 lazy val docs = project
   .in(file("."))
@@ -19,7 +20,7 @@ lazy val docs = project
     scalaVersion := "2.11.7",
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % "test",
-      "org.apache.cassandra" % "cassandra-all" % "3.0.2" % "test",
+      "org.apache.cassandra" % "cassandra-all" % "3.0.9" % "test",
       "junit" % "junit" % "4.12" % "test",
       "com.novocode" % "junit-interface" % "0.11" % "test",
       "org.scalatest" %% "scalatest" % "3.0.1" % Test,


### PR DESCRIPTION
I noticed the test 3rd and 4th phases were not awaiting the command response and suspect that could be a cause for flakiness. I really can't tell because I can't reproduce the errror. This code change only addresses one of the two causes of the `CqrsIntegrationTest` flakyness: last assertion times out because it starts the await too early.

This PR also bumps the dependency version of play and akka to match those on master.

Fixes #461 (?)