### PR TITLE
Fix Zookeeper typos. Deprecate public-facing API with typo by introdu…

### DIFF
--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
@@ -222,8 +222,8 @@ private[lagom] object Servers {
 
     protected type Server = KafkaProcess
 
-    def start(log: LoggerProxy, cp: Seq[File], kafkaPort: Int, zooKeperPort: Int, kafkaPropertiesFile: Option[File], jvmOptions: Seq[String], targetDir: File, cleanOnStart: Boolean): Closeable = {
-      val args = kafkaPort.toString :: zooKeperPort.toString :: targetDir.getAbsolutePath :: cleanOnStart.toString :: kafkaPropertiesFile.toList.map(_.getAbsolutePath)
+    def start(log: LoggerProxy, cp: Seq[File], kafkaPort: Int, zooKeeperPort: Int, kafkaPropertiesFile: Option[File], jvmOptions: Seq[String], targetDir: File, cleanOnStart: Boolean): Closeable = {
+      val args = kafkaPort.toString :: zooKeeperPort.toString :: targetDir.getAbsolutePath :: cleanOnStart.toString :: kafkaPropertiesFile.toList.map(_.getAbsolutePath)
 
       val log4jOutput = targetDir.getAbsolutePath + java.io.File.separator + "log4j_output"
       val sysProperties = List(s"-Dkafka.logs.dir=$log4jOutput")

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -309,7 +309,9 @@ object LagomPlugin extends AutoPlugin {
     val lagomKafkaEnabled = settingKey[Boolean]("Enable/Disable the kafka server")
     val lagomKafkaCleanOnStart = settingKey[Boolean]("Wipe the kafka log before starting")
     val lagomKafkaJvmOptions = settingKey[Seq[String]]("JVM options used by the forked kafka process")
-    val lagomKafkaZookeperPort = settingKey[Int]("Port used by the local zookeper server (kafka requires zookeeper)")
+    @deprecated("Use lagomKafkaZookeeperPort instead", "1.3.6")
+    val lagomKafkaZookeperPort = settingKey[Int]("Port used by the local zookeeper server (kafka requires zookeeper)")
+    val lagomKafkaZookeeperPort = settingKey[Int]("Port used by the local zookeeper server (kafka requires zookeeper)")
     val lagomKafkaPort = settingKey[Int]("Port used by the local kafka broker")
     val lagomKafkaAddress = settingKey[String]("Address of the kafka brokers (comma-separated list)")
 
@@ -413,6 +415,7 @@ object LagomPlugin extends AutoPlugin {
     lagomKafkaEnabled := true,
     lagomKafkaPropertiesFile := None,
     lagomKafkaZookeperPort := 2181,
+    lagomKafkaZookeeperPort := lagomKafkaZookeperPort.value,
     lagomKafkaPort := 9092,
     lagomKafkaCleanOnStart := false,
     lagomKafkaAddress := s"localhost:${lagomKafkaPort.value}",
@@ -475,7 +478,7 @@ object LagomPlugin extends AutoPlugin {
 
   private lazy val startKafkaServerTask = Def.task {
     val log = new SbtLoggerProxy(state.value.log)
-    val zooKeeperPort = lagomKafkaZookeperPort.value
+    val zooKeeperPort = lagomKafkaZookeeperPort.value
     val kafkaPort = lagomKafkaPort.value
     val kafkaPropertiesFile = lagomKafkaPropertiesFile.value
     val classpath = (managedClasspath in Compile).value.map(_.data)

--- a/docs/manual/common/guide/devmode/code/build-kafka-opts.sbt
+++ b/docs/manual/common/guide/devmode/code/build-kafka-opts.sbt
@@ -1,7 +1,7 @@
 
 //#kafka-port
 lagomKafkaPort in ThisBuild := 10000
-lagomKafkaZookeperPort in ThisBuild := 9999
+lagomKafkaZookeeperPort in ThisBuild := 9999
 //#kafka-port
 
 //#kafka-properties

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -668,7 +668,7 @@ object Dependencies {
     // http://stackoverflow.com/questions/4908651/the-following-artifacts-could-not-be-resolved-javax-jmsjmsjar1-1
     // for more context.
     log4J,
-    // Note that curator 3.x is only compatible with zookeper 3.5.x. Kafka currently uses zookeeper 3.4, hence we have
+    // Note that curator 3.x is only compatible with zookeeper 3.5.x. Kafka currently uses zookeeper 3.4, hence we have
     // to use curator 2.x, which is compatible with zookeeper 3.4 (see the notice in
     // http://curator.apache.org/index.html - make sure to scroll to the bottom)
     "org.apache.curator" % "curator-framework" % "2.10.0",


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #802 

## Purpose

Fixes typos associated with Zookeeper, including public-facing API. In order to fix this typo, I have labeled the API deprecated since 1.3.5 and introduced a new preferred API.
