### PR TITLE
deprecate Descriptor#publishing 

### DIFF
--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/__service1ClassName__Service.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/__service1ClassName__Service.java
@@ -47,7 +47,7 @@ public interface ${service1ClassName}Service extends Service {
     return named("${service1Name}").withCalls(
         pathCall("/api/${service1Name}/:id",  this::hello),
         pathCall("/api/${service1Name}/:id", this::useGreeting)
-      ).publishing(
+      ).withTopics(
           topic("hello-events", this::helloEvents)
           // Kafka partitions messages, messages within the same partition will
           // be delivered in order, to ensure that all messages for the same user

--- a/docs/manual/java/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/java/guide/broker/MessageBrokerApi.md
@@ -8,7 +8,7 @@ To publish data to a topic a service needs to declare the topic in its [[service
 
 @[hello-service](code/docs/javadsl/mb/HelloService.java)
 
-The syntax for declaring a topic is similar to the one used already to define services' endpoints. The [`Descriptor.publishing`](api/index.html?com/lightbend/lagom/javadsl/api/Descriptor.html#publishing-com.lightbend.lagom.javadsl.api.Descriptor.TopicCall...-) method accepts a sequence of topic calls, each topic call can be defined via the [`Service.topic`](api/index.html?com/lightbend/lagom/javadsl/api/Service.html#topic-java.lang.String-java.lang.reflect.Method-) static method. The latter takes a topic name (i.e., the topic identifier), and a reference to a method that returns a [`Topic`](api/index.html?com/lightbend/lagom/javadsl/api/broker/Topic.html) instance.
+The syntax for declaring a topic is similar to the one used already to define services' endpoints. The [`Descriptor.withTopics`](api/index.html?com/lightbend/lagom/javadsl/api/Descriptor.html#withTopics-com.lightbend.lagom.javadsl.api.Descriptor.TopicCall...-) method accepts a sequence of topic calls, each topic call can be defined via the [`Service.topic`](api/index.html?com/lightbend/lagom/javadsl/api/Service.html#topic-java.lang.String-java.lang.reflect.Method-) static method. The latter takes a topic name (i.e., the topic identifier), and a reference to a method that returns a [`Topic`](api/index.html?com/lightbend/lagom/javadsl/api/broker/Topic.html) instance.
 
 Data flowing through a topic is serialized to JSON by default. Of course, it is possible to use a different serialization format, and you can do so by passing a different message serializer for each topic defined in a service descriptor. For instance, using the above service definition, here is how you could have passed a custom serializer: `topic("greetings", this::greetingsTopic).withMessageSerializer(<your-custom-serializer>)`.
 
@@ -18,7 +18,7 @@ Kafka will distribute messages for a particular topic across many partitions, so
 
 Lagom allows this by allowing you to configure a partition key strategy, which extracts the partition key out of a message. Kafka will then use this key to help decide what partition to send each message to. The partition can be selected using the [`partitionKeyStrategy`](api/index.html?com/lightbend/lagom/javadsl/api/broker/kafka/KafkaProperties.html#partitionKeyStrategy--) property, by passing a [`PartitionKeyStrategy`](api/index.html?com/lightbend/lagom/javadsl/api/broker/kafka/PartitionKeyStrategy.html) to it: 
 
-@[publishing](code/docs/javadsl/mb/BlogPostService.java)
+@[withTopics](code/docs/javadsl/mb/BlogPostService.java)
 
 ## Implementing a topic
 

--- a/docs/manual/java/guide/broker/code/docs/javadsl/mb/BlogPostService.java
+++ b/docs/manual/java/guide/broker/code/docs/javadsl/mb/BlogPostService.java
@@ -10,14 +10,14 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 public interface BlogPostService extends Service {
   @Override
   default Descriptor descriptor() {
+    //#withTopics
     return named("blogpostservice")
-            //#publishing
-            .publishing(
+            .withTopics(
                     topic("blogposts", this::blogPostEvents)
                         .withProperty(KafkaProperties.partitionKeyStrategy(),
                                 BlogPostEvent::getPostId)
             );
-            //#publishing
+    //#withTopics
   }
   Topic<BlogPostEvent> blogPostEvents();
 }

--- a/docs/manual/java/guide/broker/code/docs/javadsl/mb/HelloService.java
+++ b/docs/manual/java/guide/broker/code/docs/javadsl/mb/HelloService.java
@@ -18,7 +18,7 @@ public interface HelloService extends Service {
         pathCall("/api/hello/:id", this::useGreeting)
       )
       // here we declare the topic(s) this service will publish to
-      .publishing(
+      .withTopics(
         topic(GREETINGS_TOPIC, this::greetingsTopic)
       )
       .withAutoAcl(true);

--- a/docs/manual/scala/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/scala/guide/broker/MessageBrokerApi.md
@@ -18,7 +18,7 @@ Kafka will distribute messages for a particular topic across many partitions, so
 
 Lagom allows this by allowing you to configure a partition key strategy, which extracts the partition key out of a message. Kafka will then use this key to help decide what partition to send each message to. The partition can be selected using the [`partitionKeyStrategy`](api/com/lightbend/lagom/scaladsl/api/broker/kafka/KafkaProperties$.html#partitionKeyStrategy[Message]:com.lightbend.lagom.scaladsl.api.Descriptor.Property[Message,com.lightbend.lagom.scaladsl.api.broker.kafka.PartitionKeyStrategy[Message]]) property, by passing a [`PartitionKeyStrategy`](api/com/lightbend/lagom/scaladsl/api/broker/kafka/PartitionKeyStrategy.html) to it:
 
-@[publishing](code/docs/scaladsl/mb/BlogPostService.scala)
+@[withTopics](code/docs/scaladsl/mb/BlogPostService.scala)
 
 ## Implementing a topic
 

--- a/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/BlogPostService.scala
+++ b/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/BlogPostService.scala
@@ -16,7 +16,7 @@ trait BlogPostService extends Service {
   override final def descriptor: Descriptor = {
     import Service._
 
-    //#publishing
+    //#withTopics
     named("blogpostservice")
       .withTopics(
         topic("blogposts", blogPostEvents)
@@ -25,7 +25,7 @@ trait BlogPostService extends Service {
             PartitionKeyStrategy[BlogPostEvent](_.postId)
           )
       )
-    //#publishing
+    //#withTopics
   }
 
   def blogPostEvents: Topic[BlogPostEvent]

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/Descriptor.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/Descriptor.java
@@ -852,9 +852,22 @@ public final class Descriptor {
      *
      * @param topicCalls The topic calls to add.
      * @return A copy of this descriptor with the new calls added.
+     *
+     * @deprecated use {@link Descriptor#withTopics(TopicCall[])} instead.
      */
+    @Deprecated
     public Descriptor publishing(TopicCall<?>... topicCalls) {
-      return new Descriptor(name, calls, pathParamSerializers, messageSerializers, serializerFactory, exceptionSerializer, autoAcl, acls, headerFilter, locatableService, circuitBreaker,
-          this.topicCalls.plusAll(Arrays.asList(topicCalls)));
+      return withTopics(topicCalls);
+    }
+
+    /**
+     * Add the given topic calls to this service.
+     *
+     * @param topicCalls The topic calls to add.
+     * @return A copy of this descriptor with the new calls added.
+     */
+    public Descriptor withTopics(TopicCall<?>... topicCalls) {
+        return new Descriptor(name, calls, pathParamSerializers, messageSerializers, serializerFactory, exceptionSerializer, autoAcl, acls, headerFilter, locatableService, circuitBreaker,
+                this.topicCalls.plusAll(Arrays.asList(topicCalls)));
     }
 }

--- a/service/javadsl/integration-tests/src/test/java/com/lightbend/lagom/it/none/PublisherService.java
+++ b/service/javadsl/integration-tests/src/test/java/com/lightbend/lagom/it/none/PublisherService.java
@@ -16,7 +16,7 @@ public interface PublisherService extends Service {
     String TOPIC = "the-topic";
 
     default Descriptor descriptor() {
-        return named("/publisher").publishing(
+        return named("/publisher").withTopics(
                 Service.topic(TOPIC, this::messages)
         );
     }

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -278,7 +278,7 @@ object JavadslKafkaApiSpec {
 
     override def descriptor(): Descriptor =
       named("testservice")
-        .publishing(
+        .withTopics(
           topic("test1", test1Topic _),
           topic("test2", test2Topic _),
           topic("test3", test3Topic _),

--- a/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/TestTopicService.java
+++ b/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/TestTopicService.java
@@ -21,7 +21,7 @@ public interface TestTopicService extends Service {
     @Override
     default Descriptor descriptor() {
         return named("testtopicservice")
-                .publishing(topic("testtopic", this::testTopic));
+                .withTopics(topic("testtopic", this::testTopic));
     }
 
     class Impl implements TestTopicService {

--- a/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/AlphaUpstreamService.java
+++ b/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/AlphaUpstreamService.java
@@ -17,7 +17,7 @@ public interface AlphaUpstreamService extends Service {
     @Override
     default Descriptor descriptor() {
         return Service.named("upstream-a")
-                .publishing(
+                .withTopics(
                         Service.topic(TOPIC_ID, this::messageTopic)
                 );
     }

--- a/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/BetaUpstreamService.java
+++ b/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/BetaUpstreamService.java
@@ -17,7 +17,7 @@ public interface BetaUpstreamService extends Service {
     @Override
     default Descriptor descriptor() {
         return Service.named("upstream-b")
-                .publishing(
+                .withTopics(
                         Service.topic(TOPIC_ID, this::messageTopic)
                 );
     }

--- a/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/PublishService.java
+++ b/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/PublishService.java
@@ -16,7 +16,7 @@ public interface PublishService extends Service {
     @Override
     default Descriptor descriptor() {
         return Service.named("publish-service")
-                .publishing(
+                .withTopics(
                         Service.topic(TOPIC_ID, this::messageTopic)
                 );
     }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #769

## Purpose

Deprecates the `Descriptor#publishing` API in favor of the more consistent `Descriptor#withTopics` API.
