### PR TITLE
suppresses warnings if credentials file is nonexistent.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,8 @@ def bintraySettings: Seq[Setting[_]] = Seq(
   bintrayOrganization := Some("lagom"),
   bintrayRepository := "sbt-plugin-releases",
   bintrayPackage := "lagom-sbt-plugin",
-  bintrayReleaseOnPublish := false
+  bintrayReleaseOnPublish := false,
+  credentials := List(Path.userHome / ".bintray").filter(_.exists).map(Credentials(_))
 )
 
 def releaseSettings: Seq[Setting[_]] = Seq(


### PR DESCRIPTION
## Fixes

Fixes #825

## Purpose

Suppresses warnings for missing credentials file.

## Background Context

To eliminate scary (and unnecessary) warnings... especially in CI. 😅 