### PR TITLE
Fix support for overriding describeService

### DIFF
--- a/api-tools/src/test/scala/com/lightbend/lagom/api/tools/tests/scaladsl/ServiceLoaders.scala
+++ b/api-tools/src/test/scala/com/lightbend/lagom/api/tools/tests/scaladsl/ServiceLoaders.scala
@@ -18,6 +18,20 @@ class AclServiceLoader extends LagomApplicationLoader {
       override def serviceLocator: ServiceLocator = NoServiceLocator
     }
 
+  override def describeService = Some(readDescriptor[AclService])
+}
+
+// Just like AclServiceLoader but overriding the deprecated describeServices method instead of describeService
+class LegacyAclServiceLoader extends LagomApplicationLoader {
+  override def load(context: LagomApplicationContext): LagomApplication =
+    new AclServiceApplication(context) {
+      override def serviceLocator: ServiceLocator = NoServiceLocator
+    }
+  override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+    new AclServiceApplication(context) {
+      override def serviceLocator: ServiceLocator = NoServiceLocator
+    }
+
   override def describeServices = List(readDescriptor[AclService])
 }
 
@@ -40,7 +54,7 @@ class NoAclServiceLoader extends LagomApplicationLoader {
       override def serviceLocator: ServiceLocator = NoServiceLocator
     }
 
-  override def describeServices = List(readDescriptor[NoAclService])
+  override def describeService = Some(readDescriptor[NoAclService])
 }
 
 abstract class NoAclServiceApplication(context: LagomApplicationContext)
@@ -51,6 +65,19 @@ abstract class NoAclServiceApplication(context: LagomApplicationContext)
 }
 // ---------------------------------------
 class UndescribedServiceLoader extends LagomApplicationLoader {
+  override def load(context: LagomApplicationContext): LagomApplication =
+    new NoAclServiceApplication(context) {
+      override def serviceLocator: ServiceLocator = NoServiceLocator
+    }
+  override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+    new NoAclServiceApplication(context) {
+      override def serviceLocator: ServiceLocator = NoServiceLocator
+    }
+  override def describeService = None
+}
+
+// Just like AclServiceLoader but overriding the deprecated describeServices method instead of describeService
+class LegacyUndescribedServiceLoader extends LagomApplicationLoader {
   override def load(context: LagomApplicationContext): LagomApplication =
     new NoAclServiceApplication(context) {
       override def serviceLocator: ServiceLocator = NoServiceLocator

--- a/api-tools/src/test/scala/com/lightbend/lagom/internal/api/tools/ServiceDetectorSpec.scala
+++ b/api-tools/src/test/scala/com/lightbend/lagom/internal/api/tools/ServiceDetectorSpec.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.internal.api.tools
 import java.net.URL
 import java.util
 
-import com.lightbend.lagom.api.tools.tests.scaladsl.{ AclServiceLoader, NoAclServiceLoader, UndescribedServiceLoader }
+import com.lightbend.lagom.api.tools.tests.scaladsl._
 import com.lightbend.lagom.internal.javadsl.server.JavadslServiceDiscovery
 import com.lightbend.lagom.javadsl.api.{ Descriptor, Service }
 import org.scalatest._
@@ -98,6 +98,30 @@ class ServiceDetectorSpec extends WordSpec with Matchers with Inside {
       Json.parse(actualJsonString) shouldBe Json.parse(expectedJsonString)
     }
 
+    "resolve the service descriptions for a LagomScala project using the deprecated `describeServices` (with ACLs)" in {
+      val expectedJsonString =
+        """
+          |[
+          |  {
+          |    "name": "/aclservice",
+          |    "acls": [
+          |      {
+          |        "method": "GET",
+          |        "pathPattern": "\\Q/scala-mocks/\\E([^/]+)"
+          |      },
+          |      {
+          |        "method": "POST",
+          |        "pathPattern": "\\Q/scala-mocks\\E"
+          |      }
+          |    ]
+          |  }
+          |]
+        """.stripMargin
+
+      val actualJsonString = ServiceDetector.services(this.getClass.getClassLoader, classOf[LegacyAclServiceLoader].getName)
+      Json.parse(actualJsonString) shouldBe Json.parse(expectedJsonString)
+    }
+
     "resolve the service descriptions for a LagomScala project using `describeService` (without ACLs)" in {
       val expectedJsonString =
         """
@@ -117,6 +141,13 @@ class ServiceDetectorSpec extends WordSpec with Matchers with Inside {
       val expectedJsonString = "[]"
 
       val actualJsonString = ServiceDetector.services(this.getClass.getClassLoader, classOf[UndescribedServiceLoader].getName)
+      Json.parse(actualJsonString) shouldBe Json.parse(expectedJsonString)
+    }
+
+    "resolve the service descriptions for a LagomScala project using the deprecated `describeServices` (service is not locatable)" in {
+      val expectedJsonString = "[]"
+
+      val actualJsonString = ServiceDetector.services(this.getClass.getClassLoader, classOf[LegacyUndescribedServiceLoader].getName)
       Json.parse(actualJsonString) shouldBe Json.parse(expectedJsonString)
     }
 

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -82,7 +82,7 @@ abstract class LagomApplicationLoader extends ApplicationLoader with ServiceDisc
   def loadDevMode(context: LagomApplicationContext): LagomApplication = load(context)
 
   /**
-   * Describe a service, for use when implementing [[describeServices]].
+   * Describe a service, for use when implementing [[describeService]].
    */
   protected def readDescriptor[S <: Service]: Descriptor = macro ScaladslServerMacroImpl.readDescriptor[S]
 
@@ -100,7 +100,7 @@ abstract class LagomApplicationLoader extends ApplicationLoader with ServiceDisc
   def describeService: Option[Descriptor] = None
 
   @deprecated("Binding multiple locatable ServiceDescriptors per Lagom service is unsupported. Override LagomApplicationLoader.describeService() instead", "1.3.2")
-  def describeServices: immutable.Seq[Descriptor] = Nil
+  def describeServices: immutable.Seq[Descriptor] = describeService.to[immutable.Seq]
 
   override final def discoverServices(classLoader: ClassLoader) = {
     import scala.collection.JavaConverters._


### PR DESCRIPTION
Overriding describeServices was deprecated in Lagom 1.3.2, but the internal implementation still uses it for backward compatibility.

The default implementation returned `Nil`, which resulted in no services discovered when only overriding `describeService` and not `describeServices`.

Fixes #829

Note that this is just a minimal fix to make it work again. There are several other follow-up actions described in #829 that will be submitted as separate pull requests.