### PR TITLE
bump sbt version to 0.13.15 and removes deprecated syntax.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -161,7 +161,7 @@ def multiJvmTestSettings: Seq[Setting[_]] =
       parallelExecution in Test := false,
       MultiJvmKeys.jvmOptions in MultiJvm := databasePortSetting :: defaultMultiJvmOptions,
       // make sure that MultiJvm test are compiled by the default test compilation
-      compile in MultiJvm <<= (compile in MultiJvm) triggeredBy (compile in Test),
+      compile in MultiJvm := ((compile in MultiJvm) triggeredBy (compile in Test)).value,
       // tag MultiJvm tests so that we can use concurrentRestrictions to disable parallel tests
       executeTests in MultiJvm := ((executeTests in MultiJvm) tag Tags.Test).value,
       // make sure that MultiJvm tests are executed by the default test target,

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
@@ -53,7 +53,8 @@ InputKey[Unit]("absence") := {
 }
 
 lazy val checkDevRuntimeClasspath = inputKey[Unit]("Checks presence of a jar in the DevRuntime classpath")
-checkDevRuntimeClasspath <<= checkDevClasspathTask(Internal.Configs.DevRuntime)
+
+checkDevRuntimeClasspath := checkDevClasspathTask(Internal.Configs.DevRuntime).evaluated
 
 def checkDevClasspathTask(config: Configuration): Def.Initialize[InputTask[Unit]] = Def.inputTaskDyn {
   val parsed = Def.spaceDelimited().parsed

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Typesafe Inc. <http://www.typesafe.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
 #
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -105,7 +105,7 @@ def forkedTests: Seq[Setting[_]] = Seq(
   fork in Test := true,
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
   javaOptions in Test ++= Seq("-Xms256M", "-Xmx512M"),
-  testGrouping in Test <<= definedTests in Test map singleTestsGrouping
+  testGrouping in Test := (definedTests in Test map singleTestsGrouping).value
 )
 
 // group tests, a single test per group

--- a/docs/project/build.properties
+++ b/docs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
## Fixes

Fixes #666 

## References

This is going to be the first in a series of cascading PRs for almost every project in the Lagom project. 
