### PR TITLE
Bumps play to 2.6 GA

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,5 +1,5 @@
 
-val PlayVersion = "2.6.0-RC2"
+val PlayVersion = "2.6.0"
 val AkkaVersion = "2.5.3"
 
 val branch = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -198,11 +198,7 @@ object Dependencies {
 
     ) ++ crossLibraryFamily("com.typesafe.play", PlayVersion)(
       "play", "play-datacommons", "play-guice", "play-iteratees", "play-java", "play-jdbc", "play-jdbc-api",
-      "play-netty-server", "play-server", "play-streams"
-
-    ) ++ crossLibraryFamily("com.typesafe.play", PlayStandaloneWsVersion)(
-      "play-ws-standalone", "play-ws-standalone-xml", "play-ws-standalone-json", "play-ahc-ws-standalone",
-      "shaded-asynchttpclient", "shaded-oauth"
+      "play-netty-server", "play-server", "play-streams", "play-ws", "play-ahc-ws"
 
     ) ++ libraryFamily("ch.qos.logback", "1.1.3")(
       "logback-classic", "logback-core"
@@ -360,6 +356,7 @@ object Dependencies {
   )
 
   val `integration-client-javadsl` = libraryDependencies ++= Seq(
+    playWs,
     playAhcWs
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,6 +5,8 @@ object Dependencies {
 
   // Version numbers
   val PlayVersion = "2.6.0"
+  val PlayStandaloneWsVersion = "1.0.0"
+  val PlayJsonVersion = "2.6.0"
   val AkkaVersion = "2.5.3"
   val ScalaVersion = "2.11.11"
   val AkkaPersistenceCassandraVersion = "0.54"
@@ -62,10 +64,11 @@ object Dependencies {
   private val playJdbc = "com.typesafe.play" %% "play-jdbc" % PlayVersion
   private val playNettyServer = "com.typesafe.play" %% "play-netty-server" % PlayVersion
   private val playServer = "com.typesafe.play" %% "play-server" % PlayVersion
-  private val playAhcWs = "com.typesafe.play" %% "play-ahc-ws" % PlayVersion
-
   private val playFunctional = "com.typesafe.play" %% "play-functional" % PlayVersion
-  private val playJson = "com.typesafe.play" %% "play-json" % PlayVersion
+
+  private val playWs = "com.typesafe.play" %% "play-ws" % PlayVersion
+  private val playAhcWs = "com.typesafe.play" %% "play-ahc-ws" % PlayVersion
+  private val playJson = "com.typesafe.play" %% "play-json" % PlayJsonVersion
 
   // A whitelist of dependencies that Lagom is allowed to depend on, either directly or transitively.
   // This list is used to validate all of Lagom's dependencies.
@@ -112,12 +115,10 @@ object Dependencies {
       "com.typesafe.play" %% "cachecontrol" % "1.1.2",
       playJson,
       playFunctional,
-      "com.typesafe.play" %% "play-ws-standalone" % "1.0.0",
-      "com.typesafe.play" %% "play-ws-standalone-xml" % "1.0.0",
-      "com.typesafe.play" %% "play-ws-standalone-json" % "1.0.0",
-      "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0",
-      "com.typesafe.play" % "shaded-asynchttpclient" % "1.0.0",
-      "com.typesafe.play" % "shaded-oauth" % "1.0.0",
+      // play client libs
+      playWs,
+      playAhcWs,
+
       "com.typesafe.play" %% "twirl-api" % "1.3.2",
       "com.typesafe.slick" %% "slick" % SlickVersion,
       "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
@@ -190,8 +191,12 @@ object Dependencies {
       "build-link", "play-exceptions", "play-netty-utils"
 
     ) ++ crossLibraryFamily("com.typesafe.play", PlayVersion)(
-      "play", "play-ahc-ws", "play-datacommons", "play-guice", "play-iteratees", "play-java", "play-jdbc", "play-jdbc-api",
-      "play-netty-server", "play-server", "play-streams", "play-ws"
+      "play", "play-datacommons", "play-guice", "play-iteratees", "play-java", "play-jdbc", "play-jdbc-api",
+      "play-netty-server", "play-server", "play-streams"
+
+    ) ++ crossLibraryFamily("com.typesafe.play", PlayStandaloneWsVersion)(
+      "play-ws-standalone", "play-ws-standalone-xml", "play-ws-standalone-json", "play-ahc-ws-standalone",
+      "shaded-asynchttpclient", "shaded-oauth"
 
     ) ++ libraryFamily("ch.qos.logback", "1.1.3")(
       "logback-classic", "logback-core"
@@ -330,6 +335,7 @@ object Dependencies {
   )
 
   val client = libraryDependencies ++= Seq(
+    playWs,
     playAhcWs,
     "io.dropwizard.metrics" % "metrics-core" % "3.2.2",
     "com.typesafe.netty" % "netty-reactive-streams" % "2.0.0-M1",
@@ -347,7 +353,9 @@ object Dependencies {
     scalaTest % Test
   )
 
-  val `integration-client-javadsl` = libraryDependencies ++= Nil
+  val `integration-client-javadsl` = libraryDependencies ++= Seq(
+    playAhcWs
+  )
 
   val server = libraryDependencies ++= Nil
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -118,6 +118,12 @@ object Dependencies {
       // play client libs
       playWs,
       playAhcWs,
+      "com.typesafe.play" %% "play-ws-standalone" % PlayStandaloneWsVersion,
+      "com.typesafe.play" %% "play-ws-standalone-xml" % PlayStandaloneWsVersion,
+      "com.typesafe.play" %% "play-ws-standalone-json" % PlayStandaloneWsVersion,
+      "com.typesafe.play" %% "play-ahc-ws-standalone" % PlayStandaloneWsVersion,
+      "com.typesafe.play" % "shaded-asynchttpclient" % PlayStandaloneWsVersion,
+      "com.typesafe.play" % "shaded-oauth" % PlayStandaloneWsVersion,
 
       "com.typesafe.play" %% "twirl-api" % "1.3.2",
       "com.typesafe.slick" %% "slick" % SlickVersion,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,16 +4,16 @@ import sbt.Keys._
 object Dependencies {
 
   // Version numbers
-  val PlayVersion = "2.6.0-RC2"
+  val PlayVersion = "2.6.0"
   val AkkaVersion = "2.5.3"
   val ScalaVersion = "2.11.11"
   val AkkaPersistenceCassandraVersion = "0.54"
   val ScalaTestVersion = "3.0.3"
-  val JacksonVersion = "2.8.8"
+  val JacksonVersion = "2.8.9"
   val CassandraAllVersion = "3.8"
   val GuavaVersion = "22.0"
   val MavenVersion = "3.3.9"
-  val NettyVersion = "4.1.11.Final"
+  val NettyVersion = "4.1.12.Final"
   val KafkaVersion = "0.10.2.0"
   val AkkaStreamKafkaVersion = "0.15"
   val Log4jVersion = "1.2.17"
@@ -56,7 +56,7 @@ object Dependencies {
 
   private val play = "com.typesafe.play" %% "play" % PlayVersion
   private val playBuildLink = "com.typesafe.play" % "build-link" % PlayVersion
-  private val playExceptions =  "com.typesafe.play" % "play-exceptions" % PlayVersion
+  private val playExceptions = "com.typesafe.play" % "play-exceptions" % PlayVersion
   private val playGuice = "com.typesafe.play" %% "play-guice" % PlayVersion
   private val playJava = "com.typesafe.play" %% "play-java" % PlayVersion
   private val playJdbc = "com.typesafe.play" %% "play-jdbc" % PlayVersion
@@ -112,14 +112,16 @@ object Dependencies {
       "com.typesafe.play" %% "cachecontrol" % "1.1.2",
       playJson,
       playFunctional,
-      "com.typesafe.play" %% "play-ws-standalone" % "1.0.0-RC1",
-      "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0-RC1",
-      "com.typesafe.play" % "shaded-asynchttpclient" % "1.0.0-RC1",
-      "com.typesafe.play" % "shaded-oauth" % "1.0.0-RC1",
-      "com.typesafe.play" %% "twirl-api" % "1.3.0",
+      "com.typesafe.play" %% "play-ws-standalone" % "1.0.0",
+      "com.typesafe.play" %% "play-ws-standalone-xml" % "1.0.0",
+      "com.typesafe.play" %% "play-ws-standalone-json" % "1.0.0",
+      "com.typesafe.play" %% "play-ahc-ws-standalone" % "1.0.0",
+      "com.typesafe.play" % "shaded-asynchttpclient" % "1.0.0",
+      "com.typesafe.play" % "shaded-oauth" % "1.0.0",
+      "com.typesafe.play" %% "twirl-api" % "1.3.2",
       "com.typesafe.slick" %% "slick" % SlickVersion,
       "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
-      "com.zaxxer" % "HikariCP" % "2.6.2",
+      "com.zaxxer" % "HikariCP" % "2.6.3",
       "commons-codec" % "commons-codec" % "1.10",
       "commons-logging" % "commons-logging" % "1.2",
       "io.aeron" % "aeron-client" % "1.2.5",
@@ -144,7 +146,7 @@ object Dependencies {
       "org.antlr" % "antlr-runtime" % "3.5.2",
       "org.apache.cassandra" % "cassandra-all" % CassandraAllVersion,
       "org.apache.cassandra" % "cassandra-thrift" % CassandraAllVersion,
-      "org.apache.commons" % "commons-lang3" % "3.5",
+      "org.apache.commons" % "commons-lang3" % "3.6",
       "org.apache.commons" % "commons-math3" % "3.2",
       "org.apache.httpcomponents" % "httpclient" % "4.5.2",
       "org.apache.httpcomponents" % "httpcore" % "4.4.4",
@@ -179,13 +181,7 @@ object Dependencies {
       "tyrex" % "tyrex" % "1.0.1",
       "xml-apis" % "xml-apis" % "1.4.01"
 
-    ) ++ libraryFamily("com.fasterxml.jackson.core", JacksonVersion)(
-      "jackson-annotations", "jackson-core", "jackson-databind"
-
-    ) ++ libraryFamily("com.fasterxml.jackson.datatype", JacksonVersion)(
-      "jackson-datatype-jdk8", "jackson-datatype-jsr310", "jackson-datatype-guava", "jackson-datatype-pcollections"
-
-    ) ++ crossLibraryFamily("com.typesafe.akka", AkkaVersion)(
+    ) ++ jacksonFamily ++ crossLibraryFamily("com.typesafe.akka", AkkaVersion)(
       "akka-actor", "akka-cluster", "akka-cluster-sharding", "akka-cluster-tools", "akka-distributed-data",
       "akka-multi-node-testkit", "akka-persistence", "akka-persistence-query", "akka-protobuf", "akka-remote",
       "akka-slf4j", "akka-stream", "akka-stream-testkit", "akka-testkit"
@@ -217,6 +213,15 @@ object Dependencies {
       "jcl-over-slf4j", "jul-to-slf4j", "log4j-over-slf4j", "slf4j-api"
     )
   }
+
+
+  private val jacksonFamily =
+    libraryFamily("com.fasterxml.jackson.core", JacksonVersion)(
+      "jackson-annotations", "jackson-core", "jackson-databind"
+    ) ++ libraryFamily("com.fasterxml.jackson.datatype", JacksonVersion)(
+      "jackson-datatype-jdk8", "jackson-datatype-jsr310", "jackson-datatype-guava", "jackson-datatype-pcollections"
+    )
+
 
   // These dependencies are used by JPA to test, but we don't want to export them as part of our regular whitelist,
   // so we maintain it separately.
@@ -308,6 +313,10 @@ object Dependencies {
     scalaJava8Compat,
     scalaXml % Test,
     scalaParserCombinators % Test
+    // explicitly depend on particular versions of jackson
+  ) ++ jacksonFamily ++ Seq(
+    // explicitly depend on particular versions of guava
+    guava
   )
 
   val `api-tools` = libraryDependencies ++= Seq(
@@ -414,6 +423,10 @@ object Dependencies {
 
     // Upgrades needed to match whitelist
     scalaXml % Test
+    // explicitly depend on particular versions of jackson
+  ) ++ jacksonFamily ++ Seq(
+    // explicitly depend on particular versions of guava
+    guava
   )
 
   val `pubsub-javadsl` = libraryDependencies ++= Seq(
@@ -423,6 +436,10 @@ object Dependencies {
     akkaStreamTestkit % Test,
     scalaTest % Test,
     "com.novocode" % "junit-interface" % "0.11" % Test
+    // explicitly depend on particular versions of jackson
+  ) ++ jacksonFamily ++ Seq(
+    // explicitly depend on particular versions of guava
+    guava
   )
 
   val `pubsub-scaladsl` = libraryDependencies ++= Seq(
@@ -690,4 +707,5 @@ object Dependencies {
   private class DependencyWhitelistValidationFailed extends RuntimeException with FeedbackProvidedException {
     override def toString = "Dependency whitelist validation failed!"
   }
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,5 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.8")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")


### PR DESCRIPTION
This includes few changes in the dependency whitelist.
Most notably, changes in jackson since play-core depends on jackson 2.8.9 and play-json depends on 2.8.8. Because play-json is now an independent project those versions may diverge (as they have in this case).

I get some deserialization errors locally so I don't espect this build to pass but I wanted to push this ASAP.