### PR TITLE
Update docs to use describeService

### DIFF
--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/JdbcBlogApplicationLoader.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/JdbcBlogApplicationLoader.scala
@@ -19,9 +19,7 @@ class JdbcBlogApplicationLoader extends LagomApplicationLoader {
   override def loadDevMode(context: LagomApplicationContext): LagomApplication =
     new BlogApplication(context) with LagomDevModeComponents
 
-  override def describeServices = List(
-    readDescriptor[BlogService]
-  )
+  override def describeService = Some(readDescriptor[BlogService])
 }
 
 //#load-components

--- a/docs/manual/scala/guide/production/ConductR.md
+++ b/docs/manual/scala/guide/production/ConductR.md
@@ -55,7 +55,7 @@ It also adds the ConductR libraries to your classpath, which provide components,
 
 @[conductr-application](code/ConductR.scala)
 
-Once you have added this to each of your services, you should be ready to run in ConductR. Also note that it's very important to implement the `describeServices` method on `LagomApplicationLoader`, as this will ensure that the ConductR sbt tooling is able to correctly discover the Lagom service APIs offered by each service.
+Once you have added this to each of your services, you should be ready to run in ConductR. Also note that it's very important to implement the `describeService` method on `LagomApplicationLoader`, as this will ensure that the ConductR sbt tooling is able to correctly discover the Lagom service APIs offered by each service.
 
 ## Run it all
 

--- a/docs/manual/scala/guide/production/code/ConductR.scala
+++ b/docs/manual/scala/guide/production/code/ConductR.scala
@@ -30,9 +30,7 @@ package docs.scaladsl.production.conductr {
       override def loadDevMode(context: LagomApplicationContext) =
         new HelloApplication(context) with LagomDevModeComponents
 
-      override def describeServices = List(
-        readDescriptor[HelloService]
-      )
+      override def describeService = Some(readDescriptor[HelloService])
     }
     //#conductr-application
   }

--- a/docs/manual/scala/guide/services/DependencyInjection.md
+++ b/docs/manual/scala/guide/services/DependencyInjection.md
@@ -33,7 +33,7 @@ Having created our application cake, we can now write an application loader. Pla
 
 The loader has two methods that must be implemented, `load` and `loadDevMode`. You can see that we've mixed in different service locators for each method, we've mixed in [`LagomDevModeComponents`](api/com/lightbend/lagom/scaladsl/devmode/LagomDevModeComponents.html) that provides the dev mode service locator and registers the services with it in dev mode, and in prod mode, for now, we've simply provided [`NoServiceLocator`](api/com/lightbend/lagom/scaladsl/api/ServiceLocator$$NoServiceLocator$.html) as the service locator - this is a service locator that will return nothing for every lookup. We'll see in the [[deploying to production|ProductionOverview]] documentation how to select the right service locator for production.
 
-A third method, `describeServices`, is optional, but may be used by tooling, for example by [[ConductR]], to discover what service APIs are offered by this service. The meta data read from here may in turn be used to configure service gateways and other components.
+A third method, `describeService`, is optional, but may be used by tooling, for example by [[ConductR]], to discover what service APIs are offered by this service. The metadata read from here may in turn be used to configure service gateways and other components.
 
 Finally, we need to tell Play about our application loader. We can do that by adding the following configuration to `application.conf`:
 

--- a/docs/manual/scala/guide/services/code/ServiceImplementation.scala
+++ b/docs/manual/scala/guide/services/code/ServiceImplementation.scala
@@ -51,9 +51,7 @@ package lagomloader {
         override def serviceLocator = ServiceLocator.NoServiceLocator
       }
 
-    override def describeServices = List(
-      readDescriptor[HelloService]
-    )
+    override def describeService = Some(readDescriptor[HelloService])
   }
   //#lagom-loader
 }


### PR DESCRIPTION
## Fixes

Fixes #835

## Note

**DO NOT** backport before 1.3.6 is released, please. Docs changes on the stable branch get deployed daily, but until 1.3.6, `describeService` does not actually work correctly due to #829.

It's safe to merge to `master`, since we are not deploying that to the web site.