### PR TITLE
[WIP] Improves Cassandra persistence consistency defaults

### DIFF
--- a/persistence-cassandra/core/src/main/resources/not-logback.xml
+++ b/persistence-cassandra/core/src/main/resources/not-logback.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+  -->
+<!-- The default logback configuration that Lagom uses if no other configuration is provided -->
+<configuration>
+    
+  <conversionRule conversionWord="coloredLevel" converterClass="com.lightbend.lagom.internal.logback.ColoredLevel" />
+
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+     <file>${application.home:-.}/logs/application.log</file>
+     <encoder>
+       <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+     </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+    </encoder>
+  </appender>
+
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
+  </appender>
+
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
+  </appender>
+
+  <!-- Set logging for all Play library classes to INFO -->
+  <logger name="play" level="WARN" />
+  <!-- Set logging for all Akka library classes to WARN -->
+  <logger name="akka" level="WARN" />
+  <!-- Set logging for all Lagom library classes to WARN -->
+  <logger name="com.lightbend.lagom" level="WARN" />
+  <!-- Cassandra and the datasta driver are used by the Lagom event sourcing modules -->
+  <logger name="org.apache.cassandra" level="ERROR" />
+  <logger name="com.datastax.driver" level="ERROR" />
+  <!-- Turn down Kafka noise -->
+  <logger name="org.apache.kafka" level="WARN" />
+
+  <root level="WARN">
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
+  </root>
+  
+</configuration>

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidator.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidator.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import play.api.{ Configuration, Environment }
+
+object CassandraConsistencyValidator {
+
+  def validate(configuration: Configuration, environment: Environment): Boolean = {
+    val journalConfig: Option[Configuration] = configuration.getConfig("cassandra-journal")
+
+    CassandraConsistencyConfig.load(journalConfig.get).exists {
+      case CassandraConsistencyConfig("QUORUM", "QUORUM", Some(rf)) if rf >= 3 => true
+      case _ => false
+    }
+  }
+
+}
+
+case class CassandraConsistencyConfig(
+  readConsistency:   String,
+  writeConsistency:  String,
+  replicationFactor: Option[Int]
+)
+
+object CassandraConsistencyConfig {
+  def load(configuration: Configuration): Option[CassandraConsistencyConfig] = {
+    for {
+      rc <- configuration.getString("read-consistency")
+      wc <- configuration.getString("write-consistency")
+    } yield {
+      val rf = configuration.getInt("replication-factor")
+      CassandraConsistencyConfig(rc, wc, rf)
+    }
+  }
+}

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidatorSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidatorSpec.scala
@@ -1,30 +1,56 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
 package com.lightbend.lagom.internal.persistence.cassandra
 
 import org.scalatest.{ FlatSpec, Matchers }
 import play.api.{ Configuration, Environment, Mode }
 
-
 class CassandraConsistencyValidatorSpec extends FlatSpec with Matchers {
+
+  import CassandraConsistencyValidatorSpec._
+
+  private val quorum3 = CassandraConsistencyConfig("QUORUM", "QUORUM", Some(3))
+  private val quorum2 = quorum3.copy(replicationFactor = Some(2))
 
   behavior of "CassandraConsistencyValidator"
 
-  it should "(for APC-journal in Prod) accept a read/write QUORUM with replication-factor >= 3" in {
-    val config = Configuration.from(Map(
-      "cassandra-journal.write-consistency" -> "QUORUM",
-      "cassandra-journal.read-consistency" -> "QUORUM",
-      "cassandra-journal.replication-factor" -> 3
-    ))
-
-    CassandraConsistencyValidator.validate(config, Environment.simple(mode = Mode.Prod)) should be (true)
-
-  }
-  it should "(for APC-journal in Prod) deny a read/write QUORUM with replication-factor under 3" in {
-    val config = Configuration.from(Map(
-      "cassandra-journal.write-consistency" -> "QUORUM",
-      "cassandra-journal.read-consistency" -> "QUORUM",
-      "cassandra-journal.replication-factor" -> 2
-    ))
-    CassandraConsistencyValidator.validate(config, Environment.simple(mode = Mode.Prod)) should be (false)
+  it should "(for APC-journal) accept a read/write QUORUM with replication-factor >= 3" in {
+    val config = Configuration.from(asJournalConfig(quorum3))
+    CassandraConsistencyValidator.validateWriteSide(config) should be(true)
   }
 
+  it should "(for APC-journal) deny a read/write QUORUM with replication-factor under 3" in {
+    val config = Configuration.from(asJournalConfig(quorum2))
+    CassandraConsistencyValidator.validateWriteSide(config) should be(false)
+  }
+
+  it should "(for Lagom's read-side) accept a read/write QUORUM with replication-factor >= 3" in {
+    val config = Configuration.from(asReadSideConfig(quorum3))
+    CassandraConsistencyValidator.validateReadSide(config) should be(true)
+  }
+  it should "(for Lagom's read-side) deny a read/write QUORUM with replication-factor under 3" in {
+    val config = Configuration.from(asReadSideConfig(quorum2))
+    CassandraConsistencyValidator.validateReadSide(config) should be(false)
+  }
+
+}
+
+object CassandraConsistencyValidatorSpec {
+  def asReadSideConfig(cassandraConsistencyConfig: CassandraConsistencyConfig): Map[String, Any] = {
+    asTypeSafeConfig("lagom.persistence.read-side.cassandra", cassandraConsistencyConfig)
+  }
+
+  def asJournalConfig(cassandraConsistencyConfig: CassandraConsistencyConfig): Map[String, Any] = {
+    asTypeSafeConfig("cassandra-journal", cassandraConsistencyConfig)
+  }
+
+  private def asTypeSafeConfig(prefix: String, cassandraConsistencyConfig: CassandraConsistencyConfig): Map[String, Any] = {
+    Map(
+      s"$prefix.write-consistency" -> cassandraConsistencyConfig.writeConsistency,
+      s"$prefix.read-consistency" -> cassandraConsistencyConfig.readConsistency
+    ) ++ cassandraConsistencyConfig.replicationFactor.map { rf =>
+        Map(s"$prefix.replication-factor" -> rf)
+      }.getOrElse(Map.empty[String, Any])
+  }
 }

--- a/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidatorSpec.scala
+++ b/persistence-cassandra/core/src/test/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraConsistencyValidatorSpec.scala
@@ -1,0 +1,30 @@
+package com.lightbend.lagom.internal.persistence.cassandra
+
+import org.scalatest.{ FlatSpec, Matchers }
+import play.api.{ Configuration, Environment, Mode }
+
+
+class CassandraConsistencyValidatorSpec extends FlatSpec with Matchers {
+
+  behavior of "CassandraConsistencyValidator"
+
+  it should "(for APC-journal in Prod) accept a read/write QUORUM with replication-factor >= 3" in {
+    val config = Configuration.from(Map(
+      "cassandra-journal.write-consistency" -> "QUORUM",
+      "cassandra-journal.read-consistency" -> "QUORUM",
+      "cassandra-journal.replication-factor" -> 3
+    ))
+
+    CassandraConsistencyValidator.validate(config, Environment.simple(mode = Mode.Prod)) should be (true)
+
+  }
+  it should "(for APC-journal in Prod) deny a read/write QUORUM with replication-factor under 3" in {
+    val config = Configuration.from(Map(
+      "cassandra-journal.write-consistency" -> "QUORUM",
+      "cassandra-journal.read-consistency" -> "QUORUM",
+      "cassandra-journal.replication-factor" -> 2
+    ))
+    CassandraConsistencyValidator.validate(config, Environment.simple(mode = Mode.Prod)) should be (false)
+  }
+
+}

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -9,8 +9,9 @@ import java.net.URI
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry, ReadSidePersistenceComponents, WriteSidePersistenceComponents }
-import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraReadSideSettings, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder }
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraReadSideSettings, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder, CassandraConsistencyValidator }
 import com.lightbend.lagom.spi.persistence.OffsetStore
+import play.api.{ Configuration, Environment }
 
 /**
  * Persistence Cassandra components (for compile-time injection).
@@ -28,6 +29,10 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
 
   def serviceLocator: ServiceLocator
 
+  def configuration: Configuration
+  def environment: Environment
+  require(CassandraConsistencyValidator.validate(configuration, environment))
+
   // eager initialization
   private[lagom] val serviceLocatorHolder: ServiceLocatorHolder = {
     val holder = ServiceLocatorHolder(actorSystem)
@@ -43,6 +48,11 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
  * Read-side persistence Cassandra components (for compile-time injection).
  */
 trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponents {
+
+  def configuration: Configuration
+  def environment: Environment
+  require(CassandraConsistencyValidator.validate(configuration, environment))
+
   lazy val cassandraSession: CassandraSession = new CassandraSession(actorSystem)
   lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(actorSystem)
 

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -6,12 +6,39 @@ package com.lightbend.lagom.scaladsl.persistence.cassandra
 import scala.concurrent.Future
 import java.net.URI
 
+import akka.actor.ActorSystem
+import akka.event.{ Logging, LoggingAdapter }
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.{ CassandraPersistentEntityRegistry, CassandraReadSideImpl, ScaladslCassandraOffsetStore }
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry, ReadSidePersistenceComponents, WriteSidePersistenceComponents }
-import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraReadSideSettings, CassandraOffsetStore, ServiceLocatorAdapter, ServiceLocatorHolder, CassandraConsistencyValidator }
+import com.lightbend.lagom.internal.persistence.cassandra.{ CassandraConsistencyValidator, CassandraOffsetStore, CassandraReadSideSettings, ServiceLocatorAdapter, ServiceLocatorHolder }
 import com.lightbend.lagom.spi.persistence.OffsetStore
-import play.api.{ Configuration, Environment }
+import org.slf4j.LoggerFactory
+import play.api.{ Configuration, Environment, Mode }
+
+trait Validating {
+
+  def environment: Environment
+
+  def actorSystem: ActorSystem
+
+  //  private val logger = LoggerFactory.getLogger(getClass)
+  val loggingAdapter: LoggingAdapter = Logging(actorSystem, this.getClass)
+
+  protected def validate(errors: Seq[String]): Unit = {
+    if (errors.nonEmpty) {
+      // TODO: improve details wrt why it's not valid.
+      val failureMsg = s"Your Cassandra setup is not valid for Production. Errors: ${errors.mkString("[", ", ", "]")}"
+      if (environment.mode == Mode.Prod) {
+        throw new IllegalArgumentException(failureMsg)
+      } else {
+        loggingAdapter.warning("loggingAdapte: " + failureMsg)
+        //        logger.warn("logger: " + failureMsg)
+      }
+    }
+  }
+
+}
 
 /**
  * Persistence Cassandra components (for compile-time injection).
@@ -23,15 +50,15 @@ trait CassandraPersistenceComponents extends PersistenceComponents
 /**
  * Write-side persistence Cassandra components (for compile-time injection).
  */
-trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceComponents {
+trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceComponents with Validating {
   override lazy val persistentEntityRegistry: PersistentEntityRegistry =
     new CassandraPersistentEntityRegistry(actorSystem)
 
   def serviceLocator: ServiceLocator
 
   def configuration: Configuration
-  def environment: Environment
-  require(CassandraConsistencyValidator.validate(configuration, environment))
+
+  validate(CassandraConsistencyValidator.validateWriteSide(configuration))
 
   // eager initialization
   private[lagom] val serviceLocatorHolder: ServiceLocatorHolder = {
@@ -47,11 +74,13 @@ trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceCompon
 /**
  * Read-side persistence Cassandra components (for compile-time injection).
  */
-trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponents {
+trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponents with Validating {
 
   def configuration: Configuration
+
   def environment: Environment
-  require(CassandraConsistencyValidator.validate(configuration, environment))
+
+  validate(CassandraConsistencyValidator.validateReadSide(configuration))
 
   lazy val cassandraSession: CassandraSession = new CassandraSession(actorSystem)
   lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(actorSystem)


### PR DESCRIPTION
(I mistakenly closed #743 this PR is a continuation of that)

Related to #730

 - [ ] prevent service start in Production Mode when QUORUM / 3 (at least) is setup
 - [ ] relax consistency levels in Dev and Test Mode
 - [ ] default consistency levels to those described in #730
 - [ ] allow users to disable the check (see https://github.com/lagom/lagom/pull/743#issuecomment-301357826)
 - [ ] make checks pass if setup is more strict that those described in #730 (higher `replication-factor` or more restrictive `consistency-level`)
 - [ ] list all offending settings separately
 - [ ] run validations for read and write side in separate classes to ease using different read and write implementations.