### PR TITLE
Improve Migration Guides with play/Akka upgrade

### DIFF
--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -79,3 +79,22 @@ Previous versions of Lagom automatically calculated a default Cassandra keyspace
 In Lagom 1.4, services that use Cassandra persistence will fail on startup when these properties are not defined.
 
 See [[Storing Persistent Entities in Cassandra|PersistentEntityCassandra#Configuration]] for more details.
+
+
+## Upgrading to Play 2.6 and Akka 2.5
+
+The internal upgrade to latest major versions of Play and Akka may need some changes in your code if you are using either of them directly. Please refer to the [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26) and the [Akka 2.5 migration guide](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html) for more details.
+
+### Deprecations
+
+Lagom uses Play and Akka under the covers and in occasions Lagom exposes the API provided by Play or Akka. In general this is a good enough solution to avoid adding extra layers of abstraction and wrapping. Sometimes, changes in Play or Akka can leak into our users. One such change is the [deprecation of `play.Configuration`](https://www.playframework.com/documentation/2.6.x/JavaConfigMigration26) in favour of Typesafe-Config. You may need to review your code to fix these deprecation warnings.
+
+### Rolling upgrade
+
+When running a rolling upgrade the nodes composing your Akka cluster must keep the ability to connect to each other and must use the same serialization formats.
+
+If you are running Lagom 1.2.x and must do a rolling upgrade, you must first migrate to Lagom  1.3.5. Lagom 1.2.x nodes can't forma cluster with Lagom 1.4.x nodes.
+
+One relevant change Akka 2.5 introduced involves a new method (DData) [internally handle the sharding](http://doc.akka.io/docs/akka/current/java/project/migration-guide-2.4.x-2.5.x.html#cluster-sharding-state-store-mode) of your Persistent Entities in Lagom. We have decided to not enable that new method so your migration from Lagom 1.3.x to 1.4.x should be fine. You may opt in and use DData instead of the default persistence-based one but keep in mind that switching from persistence-based to DData requires a complete-cluster shutdown.
+
+The Java serialization was already discouraged and since Lagom 1.4.0 it is not the default anymore. This is a setting we inherit from Akka and which we are propagating transparently. If your code was dependant on the Java serialization you will need to review your serializers. This change in the defaults will also affect your ability to do a rolling upgrade. If you must support rolling upgrades and you depended on the default serializations you may override the new defaults using the [additional-serialization-bindings](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html#additional-serialization-bindings) settings.

--- a/docs/manual/scala/releases/Migration14.md
+++ b/docs/manual/scala/releases/Migration14.md
@@ -17,13 +17,27 @@ Binding multiple Lagom service descriptors in one Lagom service has been depreca
 Consequently, we have deprecated the methods for binding multiple service descriptors. To migrate, in your application cake that binds your services, change the following code:
 
 ```scala
-lazy val lagomServer = LagomServer.forServices(bindService[MyService].to(wire[MyServiceImpl]))
+lazy val lagomServer = LagomServer.forServices(bindService[ItemService].to(wire[ItemServiceImpl]))
 ```
 
 to:
 
 ```scala
-lazy val lagomServer = serverFor[MyService](wire[MyServiceImpl])
+lazy val lagomServer = serverFor[ItemService](wire[ItemServiceImpl])
+```
+
+The change to drop support for multiple services will require another code update on your `Application` class. Before you had to override `describeServices` like this:
+
+```scala
+  override def describeServices = List(
+    readDescriptor[ItemService]
+  )
+```
+
+That is now deprecated and will issue a warning on runtime (unfortunately scala 2.11 will not cause a compilation warning because of the deprecation). The method replacing `describeServices` is `describeService` (in singular) and it will take an `Option[Descriptor]` instead of a list:
+
+```scala
+  override def describeService = Some(readDescriptor[ItemService])
 ```
 
 ## Configuring Cassandra keyspaces
@@ -73,3 +87,15 @@ Previous versions of Lagom automatically calculated a default Cassandra keyspace
 In Lagom 1.4, services that use Cassandra persistence will fail on startup when these properties are not defined.
 
 See [[Storing Persistent Entities in Cassandra|PersistentEntityCassandra#Configuration]] for more details.
+
+## Upgrading to Play 2.6 and Akka 2.5
+
+The internal upgrade to latest major versions of Play and Akka may need some changes in your code if you are using either of them directly. Please refer to the [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26) and the [Akka 2.5 migration guide](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html) for more details.
+
+### Rolling upgrade
+
+When running a rolling upgrade the nodes composing your Akka cluster must keep the ability to connect to each other and must use the same serialization formats. 
+
+One relevant change Akka 2.5 introduced involves a new method (DData) to [internally handle the sharding](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html#cluster-sharding-state-store-mode) of your Persistent Entities in Lagom. We have decided to not enable that new method so your migration from Lagom 1.3.x to 1.4.x should be fine. You may opt in and use DData instead of the default persistence-based one. Switching from persistence-based to DData requires a complete-cluster shutdown.
+
+The Java serialization was already discouraged and since Lagom 1.4.0 it is not the default anymore. This is a setting we inherit from Akka and which we are propagating transparently. If your code was dependant on the Java serialization you will need to review your serializers. This change in the defaults will also affect your ability to do a rolling upgrade. If you must support rolling upgrades and you depended on the default serializations you may override the new defaults using the [additional-serialization-bindings](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html#additional-serialization-bindings) settings.


### PR DESCRIPTION
Adds a section wrt underlying stack upgrade and possible side effects.

The migration guides differ slightly because the javadsl users have more to take care of (lagom 12 to lagom 13 to lagom 14, play.Configuration deprecation,...).


Also includes the details wrt `describeService` in the scaladsl version. See #849 