### PR TITLE
Propagate the exception from the stream to cause actor death

### DIFF
--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
@@ -101,6 +101,8 @@ private[lagom] object Producer {
     def generalHandler: Receive = {
       case Failure(e) =>
         throw e
+      case t: Throwable =>
+        throw t
 
       case EnsureActive(tagName) =>
     }


### PR DESCRIPTION
The `Producer.scala` object creates a `TaggedOffsetProducerActor` with supervision so that when it crashes it's properly restarted.

ATTENTION: this PR wants to be merged onto `1.3.x`! I worked on `1.3.x` to ease the manual testing and avoid side-effects.