### PR TITLE
Strongly type the Lagom service router

### DIFF
--- a/docs/manual/java/guide/services/code/docs/services/test/ServiceTestModule.java
+++ b/docs/manual/java/guide/services/code/docs/services/test/ServiceTestModule.java
@@ -9,6 +9,7 @@ import com.lightbend.lagom.internal.javadsl.server.ResolvedServicesProvider;
 import com.lightbend.lagom.internal.javadsl.server.ServiceInfoProvider;
 import com.lightbend.lagom.internal.server.status.MetricsServiceImpl;
 import com.lightbend.lagom.javadsl.api.ServiceInfo;
+import com.lightbend.lagom.javadsl.server.LagomServiceRouter;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
 import com.lightbend.lagom.javadsl.server.status.MetricsService;
 import docs.services.HelloService;
@@ -74,7 +75,7 @@ public class ServiceTestModule extends AbstractModule implements ServiceGuiceSup
     binder.bind(ResolvedServices.class).toProvider(new ResolvedServicesProvider(allServiceBindings));
 
     // And bind the router
-    binder.bind(JavadslServicesRouter.class);
+    binder.bind(LagomServiceRouter.class).to(JavadslServicesRouter.class);
   }
 
 

--- a/service/javadsl/integration-tests/src/test/scala/com/lightbend/lagom/it/JavadslErrorHandlingSpec.scala
+++ b/service/javadsl/integration-tests/src/test/scala/com/lightbend/lagom/it/JavadslErrorHandlingSpec.scala
@@ -36,7 +36,8 @@ import akka.actor.ReflectiveDynamicAccess
 import com.lightbend.lagom.internal.jackson.JacksonObjectMapperProvider
 import com.lightbend.lagom.internal.javadsl.api._
 import com.lightbend.lagom.internal.javadsl.client.JavadslServiceClientImplementor
-import com.lightbend.lagom.internal.javadsl.server.{ JavadslServerBuilder, ResolvedService, ResolvedServices, ServiceInfoProvider }
+import com.lightbend.lagom.internal.javadsl.server._
+import com.lightbend.lagom.javadsl.server.LagomServiceRouter
 
 /**
  * A brief explanation of this spec.
@@ -228,7 +229,8 @@ class JavadslErrorHandlingSpec extends ServiceSupport {
 
     withServer(
       _.bindings(
-        bind[ServiceInfo].to(new ServiceInfoProvider(classOf[MockService], Array.empty))
+        bind[ServiceInfo].to(new ServiceInfoProvider(classOf[MockService], Array.empty)),
+        bind[LagomServiceRouter].to[JavadslServicesRouter]
       )
         .overrides(bind[ResolvedServices].to(new MockResolvedServicesProvider(resolved, changeServer)))
     ) { app =>

--- a/service/javadsl/server/src/main/java/com/lightbend/lagom/javadsl/server/LagomServiceRouter.java
+++ b/service/javadsl/server/src/main/java/com/lightbend/lagom/javadsl/server/LagomServiceRouter.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.server;
+
+import play.api.routing.Router;
+
+/**
+ * A Lagom service router.
+ *
+ * This interface doesn't add anything, except that it makes the router created by the LagomServer
+ * strongly typed. This allows it to be dependency injected by type, making it simple to use it
+ * in combination with the Play routes file.
+ *
+ * For example, if using a custom router, the Lagom router could be routed to from the routes file
+ * like this:
+ *
+ * <pre>
+ * -&gt;   /     com.lightbend.lagom.javadsl.server.LagomServiceRouter
+ * </pre>
+ */
+public interface LagomServiceRouter extends Router {
+}

--- a/service/javadsl/server/src/main/java/com/lightbend/lagom/javadsl/server/ServiceGuiceSupport.java
+++ b/service/javadsl/server/src/main/java/com/lightbend/lagom/javadsl/server/ServiceGuiceSupport.java
@@ -4,6 +4,7 @@
 package com.lightbend.lagom.javadsl.server;
 
 import com.google.inject.Binder;
+import com.google.inject.Key;
 import com.lightbend.lagom.internal.javadsl.BinderAccessor;
 import com.lightbend.lagom.internal.javadsl.server.JavadslServicesRouter;
 import com.lightbend.lagom.internal.javadsl.server.ResolvedServices;
@@ -50,7 +51,7 @@ public interface ServiceGuiceSupport extends ServiceClientGuiceSupport {
         binder.bind(ResolvedServices.class).toProvider(new ResolvedServicesProvider(allServiceBindings));
 
         // And bind the router
-        binder.bind(JavadslServicesRouter.class);
+        binder.bind(LagomServiceRouter.class).to(JavadslServicesRouter.class);
     }
 
     /**
@@ -105,7 +106,7 @@ public interface ServiceGuiceSupport extends ServiceClientGuiceSupport {
         binder.bind(ResolvedServices.class).toProvider(new ResolvedServicesProvider(allServiceBindings));
 
         // And bind the router
-        binder.bind(JavadslServicesRouter.class);
+        binder.bind(LagomServiceRouter.class).to(JavadslServicesRouter.class);
     }
 
     /**

--- a/service/javadsl/server/src/main/resources/play/reference-overrides.conf
+++ b/service/javadsl/server/src/main/resources/play/reference-overrides.conf
@@ -1,1 +1,1 @@
-play.http.router = com.lightbend.lagom.internal.javadsl.server.JavadslServicesRouter
+play.http.router = com.lightbend.lagom.javadsl.server.LagomServiceRouter

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
@@ -14,7 +14,7 @@ import com.lightbend.lagom.scaladsl.api.Descriptor.RestCallId
 import com.lightbend.lagom.scaladsl.api.ServiceSupport.ScalaMethodServiceCall
 import com.lightbend.lagom.scaladsl.api.deser.StreamedMessageSerializer
 import com.lightbend.lagom.scaladsl.api.transport._
-import com.lightbend.lagom.scaladsl.server.PlayServiceCall
+import com.lightbend.lagom.scaladsl.server.{ LagomServiceRouter, PlayServiceCall }
 import play.api.Logger
 import play.api.http.HttpConfiguration
 import play.api.mvc.EssentialAction
@@ -23,7 +23,7 @@ import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 
 class ScaladslServiceRouter(override protected val descriptor: Descriptor, service: Any, httpConfiguration: HttpConfiguration)(implicit ec: ExecutionContext, mat: Materializer)
-  extends ServiceRouter(httpConfiguration) with ScaladslServiceApiBridge {
+  extends ServiceRouter(httpConfiguration) with LagomServiceRouter with ScaladslServiceApiBridge {
 
   private class ScaladslServiceRoute(override val call: Call[Any, Any]) extends ServiceRoute {
     override val path: Path = ScaladslPath.fromCallId(call.callId)


### PR DESCRIPTION
If you want to use a custom router that delegates to the Lagom router, or in my case, if you're writing a Play app but you want to embed a Lagom service implementation into it, then in order to take advantage of type based dependency injection, you need to be able to refer to the Lagom service router by type. This introduces a type for the Lagom service router in both the Java and Scala APIs, so that they can be injected by type into another Play router.