### PR TITLE
Implemented akka-http service gateway

### DIFF
--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
@@ -82,19 +82,19 @@ private[lagom] object Servers {
 
   object ServiceLocator extends ServerContainer {
     protected type Server = Closeable {
-      def start(serviceLocatorPort: Int, serviceGatewayPort: Int, unmanagedServices: JMap[String, String]): Unit
+      def start(serviceLocatorPort: Int, serviceGatewayPort: Int, unmanagedServices: JMap[String, String], gatewayImpl: String): Unit
       def serviceLocatorAddress: URI
       def serviceGatewayAddress: URI
     }
 
     def start(log: LoggerProxy, parentClassLoader: ClassLoader, classpath: Array[URL], serviceLocatorPort: Int,
-              serviceGatewayPort: Int, unmanagedServices: Map[String, String]): Closeable = synchronized {
+              serviceGatewayPort: Int, unmanagedServices: Map[String, String], gatewayImpl: String): Closeable = synchronized {
       if (server == null) {
         withContextClassloader(new java.net.URLClassLoader(classpath, parentClassLoader)) { loader =>
           val serverClass = loader.loadClass("com.lightbend.lagom.discovery.ServiceLocatorServer")
           server = serverClass.newInstance().asInstanceOf[Server]
           try {
-            server.start(serviceLocatorPort, serviceGatewayPort, unmanagedServices.asJava)
+            server.start(serviceLocatorPort, serviceGatewayPort, unmanagedServices.asJava, gatewayImpl)
           } catch {
             case e: Exception =>
               val msg = "Failed to start embedded Service Locator or Service Gateway. " +

--- a/dev/maven-plugin/src/main/maven/plugin.xml
+++ b/dev/maven-plugin/src/main/maven/plugin.xml
@@ -185,6 +185,16 @@
             </configuration>
         </parameter>
         <parameter>
+            <name>serviceGatewayImpl</name>
+            <type>java.lang.String</type>
+            <required>false</required>
+            <editable>true</editable>
+            <description>The implementation of the service gateway.</description>
+            <configuration>
+                <serviceGatewayImpl implementation="java.lang.String" default-value="netty">${service.gateway.impl}</serviceGatewayImpl>
+            </configuration>
+        </parameter>
+        <parameter>
             <name>serviceLocatorEnabled</name>
             <type>boolean</type>
             <required>false</required>
@@ -389,6 +399,9 @@
                 </parameter>
                 <parameter>
                     <name>serviceGatewayPort</name>
+                </parameter>
+                <parameter>
+                    <name>serviceGatewayImpl</name>
                 </parameter>
                 <parameter>
                     <name>serviceLocatorEnabled</name>

--- a/dev/maven-plugin/src/main/maven/plugin.xml
+++ b/dev/maven-plugin/src/main/maven/plugin.xml
@@ -189,7 +189,7 @@
             <type>java.lang.String</type>
             <required>false</required>
             <editable>true</editable>
-            <description>The implementation of the service gateway.</description>
+            <description>The implementation of the service gateway: "netty" (default) or "akka-http" (experimental).</description>
             <configuration>
                 <serviceGatewayImpl implementation="java.lang.String" default-value="netty">${service.gateway.impl}</serviceGatewayImpl>
             </configuration>

--- a/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
+++ b/dev/maven-plugin/src/main/scala/com/lightbend/lagom/maven/ServerMojos.scala
@@ -132,6 +132,8 @@ class StartServiceLocatorMojo @Inject() (logger: MavenLoggerProxy, facade: Maven
   @BeanProperty
   var serviceGatewayPort: Int = _
   @BeanProperty
+  var serviceGatewayImpl: String = _
+  @BeanProperty
   var unmanagedServices: JMap[String, String] = Collections.emptyMap[String, String]
 
   @BeanProperty
@@ -159,7 +161,7 @@ class StartServiceLocatorMojo @Inject() (logger: MavenLoggerProxy, facade: Maven
         unmanagedServices.asScala.toMap
 
       Servers.ServiceLocator.start(logger, scalaClassLoader, cp.map(_.getFile.toURI.toURL).toArray,
-        serviceLocatorPort, serviceGatewayPort, scalaUnmanagedServices)
+        serviceLocatorPort, serviceGatewayPort, scalaUnmanagedServices, serviceGatewayImpl)
     }
   }
 }

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -289,7 +289,7 @@ object LagomPlugin extends AutoPlugin {
     val lagomServiceLocatorUrl = settingKey[String]("URL of the service locator")
     val lagomServiceLocatorPort = settingKey[Int]("Port used by the service locator")
     val lagomServiceGatewayPort = settingKey[Int]("Port used by the service gateway")
-    val lagomServiceGatewayImpl = settingKey[String]("Implementation of the service gateway")
+    val lagomServiceGatewayImpl = settingKey[String]("Implementation of the service gateway: \"netty\" (default) or \"akka-http\" (experimental)")
     val lagomServiceLocatorEnabled = settingKey[Boolean]("Enable/Disable the service locator")
     val lagomServiceLocatorStart = taskKey[Closeable]("Start the service locator")
     val lagomServiceLocatorStop = taskKey[Unit]("Stop the service locator")

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -289,6 +289,7 @@ object LagomPlugin extends AutoPlugin {
     val lagomServiceLocatorUrl = settingKey[String]("URL of the service locator")
     val lagomServiceLocatorPort = settingKey[Int]("Port used by the service locator")
     val lagomServiceGatewayPort = settingKey[Int]("Port used by the service gateway")
+    val lagomServiceGatewayImpl = settingKey[String]("Implementation of the service gateway")
     val lagomServiceLocatorEnabled = settingKey[Boolean]("Enable/Disable the service locator")
     val lagomServiceLocatorStart = taskKey[Closeable]("Start the service locator")
     val lagomServiceLocatorStop = taskKey[Unit]("Stop the service locator")
@@ -406,6 +407,7 @@ object LagomPlugin extends AutoPlugin {
     lagomServiceLocatorEnabled := true,
     lagomServiceLocatorPort := 8000,
     lagomServiceGatewayPort := 9000,
+    lagomServiceGatewayImpl := "netty",
     lagomServiceLocatorUrl := s"http://localhost:${lagomServiceLocatorPort.value}",
     lagomCassandraEnabled := true,
     lagomCassandraPort := 4000, // If you change the default make sure to also update the play/reference-overrides.conf in the persistence project
@@ -460,10 +462,11 @@ object LagomPlugin extends AutoPlugin {
 
     val serviceLocatorPort = lagomServiceLocatorPort.value
     val serviceGatewayPort = lagomServiceGatewayPort.value
+    val serivceGatewayImpl = lagomServiceGatewayImpl.value
     val urls = (managedClasspath in Compile).value.files.map(_.toURI.toURL).toArray
     val scala211 = scalaInstance.value
     val log = new SbtLoggerProxy(state.value.log)
-    Servers.ServiceLocator.start(log, scala211.loader, urls, serviceLocatorPort, serviceGatewayPort, unmanagedServices)
+    Servers.ServiceLocator.start(log, scala211.loader, urls, serviceLocatorPort, serviceGatewayPort, unmanagedServices, serivceGatewayImpl)
   }
 
   private lazy val startCassandraServerTask = Def.task {

--- a/dev/service-registry/service-locator/src/main/resources/application.conf
+++ b/dev/service-registry/service-locator/src/main/resources/application.conf
@@ -1,0 +1,16 @@
+// Turn off all limits and timeouts for the proxy, let the server handle it.
+akka.http {
+  server {
+    request-timeout = infinite
+    idle-timeout = infinite
+    transparent-head-requests = off
+  }
+
+  client {
+    idle-timeout = infinite
+  }
+
+  parsing {
+    max-content-length = infinite
+  }
+}

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceLocatorServer.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceLocatorServer.scala
@@ -4,11 +4,11 @@
 package com.lightbend.lagom.discovery
 
 import java.io.Closeable
-import java.net.URI
+import java.net.{ InetSocketAddress, URI }
 import java.util.{ Map => JMap }
 
 import com.lightbend.lagom.discovery.impl.ServiceRegistryModule
-import com.lightbend.lagom.gateway.{ ServiceGateway, ServiceGatewayConfig, ServiceGatewayFactory }
+import com.lightbend.lagom.gateway._
 import play.api.Application
 import play.api.Logger
 import play.api.Mode
@@ -25,9 +25,9 @@ class ServiceLocatorServer extends Closeable {
   private val logger: Logger = Logger(this.getClass())
 
   @volatile private var server: ReloadableServer = _
-  @volatile private var gateway: ServiceGateway = _
+  @volatile private var gatewayAddress: InetSocketAddress = _
 
-  def start(serviceLocatorPort: Int, serviceGatewayPort: Int, unmanagedServices: JMap[String, String]): Unit = synchronized {
+  def start(serviceLocatorPort: Int, serviceGatewayPort: Int, unmanagedServices: JMap[String, String], gatewayImpl: String): Unit = synchronized {
     require(server == null, "Service locator is already running on " + server.mainAddress)
 
     val application = createApplication(ServiceGatewayConfig(serviceGatewayPort), unmanagedServices)
@@ -39,7 +39,11 @@ class ServiceLocatorServer extends Closeable {
         throw new RuntimeException(s"Unable to start service locator on port $serviceLocatorPort", e)
     }
     try {
-      gateway = application.injector.instanceOf[ServiceGatewayFactory].start()
+      gatewayAddress = gatewayImpl match {
+        case "netty"     => application.injector.instanceOf[NettyServiceGatewayFactory].start().address
+        case "akka-http" => application.injector.instanceOf[AkkaHttpServiceGatewayFactory].start()
+        case other       => sys.error("Unknown gateway implementation: " + other)
+      }
     } catch {
       case NonFatal(e) =>
         throw new RuntimeException(s"Unable to start service gateway on port $serviceGatewayPort", e)
@@ -77,6 +81,6 @@ class ServiceLocatorServer extends Closeable {
   }
 
   def serviceGatewayAddress: URI = {
-    new URI(s"http://localhost:${gateway.address.getPort}")
+    new URI(s"http://localhost:${gatewayAddress.getPort}")
   }
 }

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceRegistryActor.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/discovery/ServiceRegistryActor.scala
@@ -39,6 +39,10 @@ class ServiceRegistryActor @Inject() (unmanagedServices: UnmanagedServices) exte
   private var router = PartialFunction.empty[Route, InetSocketAddress]
   private var routerFunctions = Seq.empty[PartialFunction[Route, InetSocketAddress]]
 
+  override def preStart(): Unit = {
+    rebuildRouter()
+  }
+
   override def receive: Receive = {
     case Lookup(name) => sender() ! registry.get(name).map(_.uri())
     case Remove(name) =>

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
@@ -42,7 +42,7 @@ class AkkaHttpServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGat
   private implicit val timeout = Timeout(5.seconds)
   val http = Http()
 
-  private val handler = Flow[HttpRequest].mapAsync(4) { request =>
+  private val handler = Flow[HttpRequest].mapAsync(1) { request =>
     log.debug("Routing request {}", request)
     val path = request.uri.path.toString()
 

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.gateway
+
+import java.net.InetSocketAddress
+import java.util.Locale
+import javax.inject.{ Inject, Named }
+
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.ws._
+import akka.pattern.ask
+import akka.stream.Materializer
+import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import akka.util.Timeout
+import com.lightbend.lagom.discovery.ServiceRegistryActor.{ Found, NotFound, Route, RouteResult }
+import com.lightbend.lagom.internal.javadsl.registry.ServiceRegistryService
+import org.slf4j.LoggerFactory
+import play.api.inject.ApplicationLifecycle
+import play.api.routing.Router.Routes
+import play.api.routing.SimpleRouter
+
+import scala.collection.immutable
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.duration._
+
+class AkkaHttpServiceGatewayFactory @Inject() (lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig,
+                                               @Named("serviceRegistryActor") registry: ActorRef)(implicit actorSystem: ActorSystem, mat: Materializer) {
+
+  def start(): InetSocketAddress = {
+    new AkkaHttpServiceGateway(lifecycle, config, registry).address
+  }
+}
+
+class AkkaHttpServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig, registry: ActorRef)(implicit actorSystem: ActorSystem, mat: Materializer) {
+
+  private val log = LoggerFactory.getLogger(classOf[AkkaHttpServiceGateway])
+
+  import actorSystem.dispatcher
+  private implicit val timeout = Timeout(5.seconds)
+  val http = Http()
+
+  private val handler = Flow[HttpRequest].mapAsync(4) { request =>
+    log.debug("Routing request {}", request)
+    val path = request.uri.path.toString()
+
+    (registry ? Route(request.method.name, path)).mapTo[RouteResult].flatMap {
+      case Found(serviceAddress) =>
+        log.debug("Request is to be routed to {}", serviceAddress)
+        val newUri = request.uri.withAuthority(serviceAddress.getHostName, serviceAddress.getPort)
+        request.header[UpgradeToWebSocket] match {
+          case Some(upgrade) =>
+            handleWebSocketRequest(request, newUri, upgrade)
+          case None =>
+            http.singleRequest(request.withUri(newUri).withHeaders(filterHeaders(request.headers)))
+        }
+      case NotFound(registryMap) =>
+        log.debug("Sending not found response")
+        Future.successful(renderNotFound(request, path, registryMap))
+    }
+  }
+
+  private def handleWebSocketRequest(request: HttpRequest, uri: Uri, upgrade: UpgradeToWebSocket) = {
+    log.debug("Switching to WebSocket protocol")
+    val wsUri = uri.withScheme("ws")
+    val flow = Flow.fromSinkAndSourceMat(Sink.asPublisher[Message](fanout = false), Source.asSubscriber[Message])(Keep.both)
+
+    val (responseFuture, (publisher, subscriber)) = http.singleWebSocketRequest(
+      WebSocketRequest(wsUri, extraHeaders = filterHeaders(request.headers),
+        upgrade.requestedProtocols.headOption),
+      flow
+    )
+
+    responseFuture.map {
+
+      case ValidUpgrade(response, chosenSubprotocol) =>
+        val webSocketResponse = upgrade.handleMessages(
+          Flow.fromSinkAndSource(Sink.fromSubscriber(subscriber), Source.fromPublisher(publisher)),
+          chosenSubprotocol
+        )
+        webSocketResponse.withHeaders(webSocketResponse.headers ++ filterHeaders(response.headers))
+
+      case InvalidUpgradeResponse(response, cause) =>
+        log.debug("WebSocket upgrade response was invalid: {}", cause)
+        response
+    }
+  }
+
+  private def renderNotFound(request: HttpRequest, path: String, registry: Map[String, ServiceRegistryService]): HttpResponse = {
+    import scala.collection.JavaConverters._
+    import scala.compat.java8.OptionConverters._
+    // We're reusing Play's not found error page here, which lists the routes, we need to convert the service registry
+    // to a Play router with all the acls in the documentation variable so that it can render it
+    val router = new SimpleRouter {
+      override def routes: Routes = PartialFunction.empty
+      override val documentation: Seq[(String, String, String)] = registry.toSeq.flatMap {
+        case (serviceName, service) =>
+          val call = s"Service: $serviceName (${service.uri})"
+          service.acls().asScala.map { acl =>
+            val method = acl.method.asScala.fold("*")(_.name)
+            val path = acl.pathRegex.orElse(".*")
+            (method, path, call)
+          }
+      }
+    }
+
+    val html = views.html.defaultpages.devNotFound(request.method.name, path, Some(router)).body
+    HttpResponse(
+      status = StatusCodes.NotFound,
+      entity = HttpEntity(
+        ContentTypes.`text/html(UTF-8)`,
+        html
+      )
+    )
+  }
+
+  private val HeadersToFilter = Set(
+    "Timeout-Access",
+    "Sec-WebSocket-Accept",
+    "Sec-WebSocket-Version",
+    "Sec-WebSocket-Key",
+    "UpgradeToWebSocket",
+    "Upgrade",
+    "Connection"
+  ).map(_.toLowerCase(Locale.ENGLISH))
+
+  private def filterHeaders(headers: immutable.Seq[HttpHeader]) = {
+    headers.filterNot(header => HeadersToFilter(header.lowercaseName()))
+  }
+
+  private val bindingFuture = Http().bindAndHandle(handler, "0.0.0.0", config.port)
+  lifecycle.addStopHook(() => {
+    for {
+      binding <- bindingFuture
+      unbind <- binding.unbind()
+    } yield unbind
+  })
+
+  val address: InetSocketAddress = Await.result(bindingFuture, 10.seconds).localAddress
+}

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
@@ -46,17 +46,20 @@ case class ServiceGatewayConfig(
 )
 
 @Singleton
-class ServiceGatewayFactory @Inject() (lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig,
-                                       @Named("serviceRegistryActor") registry: ActorRef) {
-  def start(): ServiceGateway = {
-    new ServiceGateway(lifecycle, config, registry)
+class NettyServiceGatewayFactory @Inject() (lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig,
+                                            @Named("serviceRegistryActor") registry: ActorRef) {
+  def start(): NettyServiceGateway = {
+    new NettyServiceGateway(lifecycle, config, registry)
   }
 }
 
-class ServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig, registry: ActorRef) {
+/**
+ * Netty implementation of the service gateway.
+ */
+class NettyServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig, registry: ActorRef) {
 
   private implicit val timeout = Timeout(5.seconds)
-  private val log = LoggerFactory.getLogger(classOf[ServiceGateway])
+  private val log = LoggerFactory.getLogger(classOf[NettyServiceGateway])
   private val eventLoop = new NioEventLoopGroup
 
   private val server = new ServerBootstrap()

--- a/dev/service-registry/service-locator/src/test/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGatewaySpec.scala
+++ b/dev/service-registry/service-locator/src/test/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGatewaySpec.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.gateway
+
+import java.net.URI
+
+import akka.actor.{ ActorSystem, Props }
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.ws.{ Message, TextMessage, UpgradeToWebSocket, WebSocketRequest }
+import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse, Uri }
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+import akka.util.ByteString
+import com.lightbend.lagom.discovery.{ ServiceRegistryActor, UnmanagedServices }
+import com.lightbend.lagom.internal.javadsl.registry.ServiceRegistryService
+import com.lightbend.lagom.javadsl.api.ServiceAcl
+import com.lightbend.lagom.javadsl.api.transport.Method
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
+import play.api.inject.DefaultApplicationLifecycle
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.collection.JavaConverters._
+
+class AkkaHttpServiceGatewaySpec extends WordSpec with Matchers with BeforeAndAfterAll {
+
+  implicit val actorSystem = ActorSystem()
+  import actorSystem.dispatcher
+  implicit val mat = ActorMaterializer()
+  val http = Http()
+
+  var serviceBinding: Http.ServerBinding = _
+  var gateway: AkkaHttpServiceGateway = _
+
+  override protected def beforeAll(): Unit = {
+    serviceBinding = Await.result(http.bindAndHandle(Flow[HttpRequest].map {
+      case hello if hello.uri.path.toString() == "/hello" => HttpResponse(entity = HttpEntity("Hello!"))
+      case stream if stream.uri.path.toString() == "/stream" =>
+        stream.header[UpgradeToWebSocket].get.handleMessages(Flow[Message])
+    }, "localhost", port = 0), 10.seconds)
+
+    val serviceRegistry = actorSystem.actorOf(Props(new ServiceRegistryActor(new UnmanagedServices(
+      Map("service" -> new ServiceRegistryService(
+        URI.create(s"http://localhost:${serviceBinding.localAddress.getPort}"),
+        Seq(
+          ServiceAcl.methodAndPath(Method.GET, "/hello"),
+          ServiceAcl.methodAndPath(Method.GET, "/stream")
+        ).asJava
+      ))
+    ))))
+
+    gateway = new AkkaHttpServiceGateway(new DefaultApplicationLifecycle, ServiceGatewayConfig(0), serviceRegistry)
+  }
+
+  def gatewayUri = "http://localhost:" + gateway.address.getPort
+  def gatewayWsUri = "ws://localhost:" + gateway.address.getPort
+
+  "The Akka HTTP service gateway" should {
+
+    "serve simple requests" in {
+      val answer = Await.result(for {
+        response <- http.singleRequest(HttpRequest(uri = s"$gatewayUri/hello"))
+        data <- response.entity.dataBytes.runFold(ByteString.empty)(_ ++ _)
+      } yield data.utf8String, 10.seconds)
+
+      answer should ===("Hello!")
+    }
+
+    "serve websocket requests" in {
+      val flow = http.webSocketClientFlow(WebSocketRequest(s"$gatewayWsUri/stream"))
+      val result = Await.result(Source(List("Hello", "world")).map(TextMessage(_)).via(flow).collect {
+        case TextMessage.Strict(text) => text
+      }.runWith(Sink.seq), 10.seconds)
+
+      result should contain inOrderOnly ("Hello", "world")
+    }
+
+    "serve not found when no ACL matches" in {
+      val response = Await.result(http.singleRequest(HttpRequest(uri = s"$gatewayUri/notfound")), 10.seconds)
+      response.status.intValue() should ===(404)
+    }
+
+  }
+
+  override protected def afterAll(): Unit = {
+    actorSystem.terminate()
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
   val PlayStandaloneWsVersion = "1.0.0"
   val PlayJsonVersion = "2.6.0"
   val AkkaVersion = "2.5.3"
+  val AkkaHttpVersion = "10.0.9"
   val ScalaVersion = "2.11.11"
   val AkkaPersistenceCassandraVersion = "0.54"
   val ScalaTestVersion = "3.0.3"
@@ -55,6 +56,9 @@ object Dependencies {
   private val akkaPersistenceCassandraLauncher = "com.typesafe.akka" %% "akka-persistence-cassandra-launcher" % AkkaPersistenceCassandraVersion
   private val akkaStreamKafka = "com.typesafe.akka" %% "akka-stream-kafka" % AkkaStreamKafkaVersion
 
+  private val akkaHttpCore = "com.typesafe.akka" %% "akka-http-core" % AkkaHttpVersion
+  private val akkaParsing = "com.typesafe.akka" %% "akka-parsing" % AkkaHttpVersion
+
   private val play = "com.typesafe.play" %% "play" % PlayVersion
   private val playBuildLink = "com.typesafe.play" % "build-link" % PlayVersion
   private val playExceptions = "com.typesafe.play" % "play-exceptions" % PlayVersion
@@ -101,7 +105,9 @@ object Dependencies {
       "com.novocode" % "junit-interface" % "0.11",
       typesafeConfig,
       sslConfig,
+      akkaHttpCore,
       akkaStreamKafka,
+      akkaParsing,
       akkaPersistenceCassandra,
       akkaPersistenceCassandraLauncher,
       "com.typesafe.netty" % "netty-reactive-streams" % "2.0.0-M1",
@@ -592,6 +598,7 @@ object Dependencies {
 
   val `service-locator` = libraryDependencies ++= Seq(
     playNettyServer,
+    akkaHttpCore,
     scalaTest % Test
   )
 


### PR DESCRIPTION
By default, it uses the existing Netty gateway, but you can set:

```
lagomServiceGatewayImpl in ThisBuild := "akka-http"
```

And it will switch to an akka-http one. This should be able to be backported to Lagom 1.3.x.