### PR TITLE
Reproduce failure to call afterPersist callback with zero events

### DIFF
--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
@@ -175,6 +175,9 @@ private[lagom] class PersistentEntityActor[C, E, S](
                     throw e
                 }
               }
+              if (events.size == 0) {
+                afterPersist.apply();
+              }
           } catch { // exception thrown from handler.apply
             case NonFatal(e) =>
               ctx.commandFailed(e) // reply with failure

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
@@ -147,6 +147,33 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
       expectTerminated(entity)
     }
 
+    "invoke afterPersist" in {
+      val probe = TestProbe()
+      val p = system.actorOf(PersistentEntityActor.props("test", Optional.of("6"),
+        () => new TestEntity(system, probe.ref), Optional.empty(), 10.seconds))
+      probe.expectMsgType[TestEntity.AfterRecovery]
+      p ! new TestEntity.Add("a", 1)
+      probe.expectMsgType[TestEntity.CallbackCalled]
+    }
+
+    "invoke afterPersist with several events from one command" in {
+      val probe = TestProbe()
+      val p = system.actorOf(PersistentEntityActor.props("test", Optional.of("7"),
+        () => new TestEntity(system, probe.ref), Optional.empty(), 10.seconds))
+      probe.expectMsgType[TestEntity.AfterRecovery]
+      p ! new TestEntity.Add("a", 2)
+      probe.expectMsgType[TestEntity.CallbackCalled]
+    }
+
+    "invoke afterPersist with zero events from one command" in {
+      val probe = TestProbe()
+      val p = system.actorOf(PersistentEntityActor.props("test", Optional.of("8"),
+        () => new TestEntity(system, probe.ref), Optional.empty(), 10.seconds))
+      probe.expectMsgType[TestEntity.AfterRecovery]
+      p ! new TestEntity.Add("a", 0)
+      probe.expectMsgType[TestEntity.CallbackCalled]
+    }
+
   }
 
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

```ctx.thenPersistAll(emptyCollection, callback)``` does not invoke the ```callback```

## Purpose

Unit tests for the issue, and a proposed fix

## Background Context

Writing idempotent commands is very tedious if we need to check that no further events are needed before calling ctx.thenPersistsAll()

