### PR TITLE
EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 [*]
 charset=utf-8
 end_of_line=lf
-insert_final_newline=false
+insert_final_newline=true
 indent_style=space
 indent_size=2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@
 charset=utf-8
 end_of_line=lf
 insert_final_newline=true
+trim_trailing_whitespace = true
 indent_style=space
 indent_size=2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=false
+indent_style=space
+indent_size=2
+
+
+[*.java]
+indent_style=space
+indent_size=4


### PR DESCRIPTION
This adds an .editorconfig file to control mainly the indentation.

Java files in Lagom are supposed to be indented with 4 spaces while Scala files and configurations with 2 spaces. 

Most IDE do support EditorConfig and will take this in consideration.