### PR TITLE
Subscribe to topics to receive keys along with messages

### DIFF
--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
@@ -115,7 +115,7 @@ private[lagom] class JavadslKafkaSubscriber[Message](kafkaConfig: KafkaConfig, t
   }
 
   override def atLeastOnceWithKey(flow: Flow[Pair[String, Message], Done, _]): CompletionStage[Done] = {
-    val sflow = ScalaFlow[(String, Message)].map(tup => Pair[String, Message](tup._1, tup._2)).via(flow)
+    val sflow = ScalaFlow[(String, Message)].map(tup => Pair(tup._1, tup._2)).via(flow)
     atLeastOnceWithKeyImpl(sflow)
   }
 

--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
@@ -9,11 +9,13 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.Done
 import akka.actor.{ ActorSystem, SupervisorStrategy }
+import akka.japi.Pair
 import akka.kafka.{ ConsumerSettings, Subscriptions }
 import akka.kafka.scaladsl.Consumer
 import akka.pattern.BackoffSupervisor
 import akka.stream.Materializer
 import akka.stream.javadsl.{ Flow, Source }
+import akka.stream.scaladsl.{ Flow => ScalaFlow }
 import com.lightbend.lagom.internal.api.UriUtils
 import com.lightbend.lagom.internal.broker.kafka.{ ConsumerConfig, KafkaConfig, KafkaSubscriberActor, NoKafkaBrokersException }
 import com.lightbend.lagom.javadsl.api.Descriptor.TopicCall
@@ -76,7 +78,10 @@ private[lagom] class JavadslKafkaSubscriber[Message](kafkaConfig: KafkaConfig, t
 
   private def subscription = Subscriptions.topics(topicCall.topicId().value)
 
-  override def atMostOnceSource: Source[Message, _] = {
+  override def atMostOnceSource: Source[Message, _] =
+    atMostOnceSourceWithKey.asScala.map(_.second).asJava
+
+  override def atMostOnceSourceWithKey: Source[Pair[String, Message], _] = {
     kafkaConfig.serviceName match {
       case Some(name) =>
         log.debug("Creating at most once source using service locator to look up Kafka services at {}", name)
@@ -93,22 +98,31 @@ private[lagom] class JavadslKafkaSubscriber[Message](kafkaConfig: KafkaConfig, t
               Consumer.atMostOnceSource(
                 consumerSettings.withBootstrapServers(endpoints),
                 subscription
-              ).map(_.value)
+              ).map(record => Pair(record.key, record.value))
 
           }.asJava
 
       case None =>
         log.debug("Creating at most once source with configured brokers: {}", kafkaConfig.brokers)
         Consumer.atMostOnceSource(consumerSettings, subscription)
-          .map(_.value).asJava
+          .map(record => Pair(record.key, record.value)).asJava
     }
+  }
+
+  override def atLeastOnce(flow: Flow[Message, Done, _]): CompletionStage[Done] = {
+    val sflow = ScalaFlow[(String, Message)].map(_._2).via(flow)
+    atLeastOnceWithKeyImpl(sflow)
+  }
+
+  override def atLeastOnceWithKey(flow: Flow[Pair[String, Message], Done, _]): CompletionStage[Done] = {
+    val sflow = ScalaFlow[(String, Message)].map(tup => Pair[String, Message](tup._1, tup._2)).via(flow)
+    atLeastOnceWithKeyImpl(sflow)
   }
 
   private def locateService(name: String): Future[Seq[URI]] =
     serviceLocator.locateAll(name).toScala.map(_.asScala)
 
-  override def atLeastOnce(flow: Flow[Message, Done, _]): CompletionStage[Done] = {
-
+  private def atLeastOnceWithKeyImpl(sflow: ScalaFlow[(String, Message), Done, _]): CompletionStage[Done] = {
     val streamCompleted = Promise[Done]
     val consumerProps =
       KafkaSubscriberActor.props(
@@ -116,7 +130,7 @@ private[lagom] class JavadslKafkaSubscriber[Message](kafkaConfig: KafkaConfig, t
         consumerConfig,
         locateService,
         topicCall.topicId().value(),
-        flow.asScala,
+        sflow,
         consumerSettings,
         subscription,
         streamCompleted

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Subscriber.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Subscriber.scala
@@ -30,6 +30,14 @@ trait Subscriber[Message] {
   def atMostOnceSource: Source[Message, _]
 
   /**
+   * Returns a stream of key -> message pairs with at most once delivery semantic.
+   *
+   * If a failure occurs (e.g., an exception is thrown), the user is responsible
+   * of deciding how to recover from it (e.g., restarting the stream, aborting, ...).
+   */
+  def atMostOnceSourceWithKey: Source[(String, Message), _]
+
+  /**
    * Applies the passed `flow` to the messages processed by this subscriber. Messages are delivered to the passed
    * `flow` at least once.
    *
@@ -44,6 +52,22 @@ trait Subscriber[Message] {
    * @return A `Future` that will be completed if the `flow` completes.
    */
   def atLeastOnce(flow: Flow[Message, Done, _]): Future[Done]
+
+  /**
+   * Applies the passed `flow` to the key -> message pairs processed by this subscriber. Messages are delivered to the passed
+   * `flow` at least once.
+   *
+   * If a failure occurs (e.g., an exception is thrown), the stream may be automatically restarted starting with the
+   * message that caused the failure.
+   *
+   * Whether the stream is automatically restarted depends on the Lagom message broker implementation in use. If the
+   * Kafka Lagom message broker module is being used, then by default the stream is automatically restarted when a
+   * failure occurs.
+   *
+   * @param flow The flow to apply to each received message.
+   * @return A `Future` that will be completed if the `flow` completes.
+   */
+  def atLeastOnceWithKey(flow: Flow[(String, Message), Done, _]): Future[Done]
 }
 
 object Subscriber {

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ProducerStubFactory.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ProducerStubFactory.scala
@@ -54,7 +54,9 @@ private[lagom] class TopicStub[T](val topicId: Topic.TopicId, topicBuffer: Actor
 
     override def withGroupId(groupId: String): Subscriber[Message] = new SubscriberStub[Message](groupId, topicBuffer)
     override def atMostOnceSource: Source[Message, _] = super.mostOnceSource
+    override def atMostOnceSourceWithKey: Source[(String, Message), _] = super.mostOnceSourceWithKey
     override def atLeastOnce(flow: Flow[Message, Done, _]): Future[Done] = super.leastOnce(flow)
+    override def atLeastOnceWithKey(flow: Flow[(String, Message), Done, _]): Future[Done] = super.leastOnceWithKey(flow)
   }
 
 }

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/TestTopicComponents.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/TestTopicComponents.scala
@@ -73,7 +73,7 @@ private[lagom] class TestTopic[Message, Event <: AggregateEvent[Event]](
   override def subscribe: Subscriber[Message] = new Subscriber[Message] {
     override def withGroupId(groupId: String): Subscriber[Message] = this
 
-    override def atMostOnceSource(): Source[Message, _] = atMostOnceSourceWithKey.map(_._2)
+    override def atMostOnceSource: Source[Message, _] = atMostOnceSourceWithKey.map(_._2)
 
     override def atMostOnceSourceWithKey: Source[(String, Message), _] = {
       val serializer = topicCall.messageSerializer


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

When Lagom services want to subscribe to topics produced outside of Lagom, the key is sometimes required to process the full semantics of the message/event payload.  The current broker `Subscriber` interfaces `atLeastOnce` and `atMostOnceSource` discard the key (or event tag) and only present the message/event payload.  New, parallel interfaces `atLeastOnceWithKey` and `atMostOnceSourceWithKey` expose the key to allow more flexibility interfacing with external topics.

## Background Context

The approach tries to expose the underlying key which is already just under the surface of the interface.  The goal is minimum disruption and minimum duplication (DRY).

## References

See Gitter discussion from [August 10, 2017 2:48 PM](https://gitter.im/lagom/contributors?at=598caa93a7b406262d77f283)
