### PR TITLE
Remove old infrastructure tasks.

### DIFF
--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -422,7 +422,7 @@ object LagomPlugin extends AutoPlugin {
     lagomKafkaCleanOnStart := false,
     lagomKafkaAddress := s"localhost:${lagomKafkaPort.value}",
     lagomKafkaJvmOptions := Seq("-Xms256m", "-Xmx1024m"),
-    runAll := runServiceLocatorAndMicroservicesTask.value,
+    runAll := runAllMicroservicesTask.value,
     Internal.Keys.interactionMode := PlayConsoleInteractionMode,
     lagomDevSettings := Nil
   ) ++
@@ -503,14 +503,6 @@ object LagomPlugin extends AutoPlugin {
         }
     }
 
-  private lazy val runServiceLocatorAndMicroservicesTask: Initialize[Task[Unit]] = Def.taskDyn {
-    val startInfrastructure = Def.taskDyn {
-      lagomKafkaStart.value
-      Def.sequential(lagomCassandraStart, lagomServiceLocatorStart)
-    }
-    Def.sequential(startInfrastructure, runAllMicroservicesTask)
-  }
-
   // The reason this is a dynamic task is that the tasks below don't get defined until their dynamically added
   // projects are added to the build, which happens after everything is first loaded. Consequently, we don't want
   // these dependencies to be eagerly resolved when the project loads, so we make it dynamic.
@@ -526,7 +518,7 @@ object LagomPlugin extends AutoPlugin {
     }
   }
 
-  private def runAllMicroservicesTask: Initialize[Task[Unit]] = Def.taskDyn {
+  private lazy val runAllMicroservicesTask: Initialize[Task[Unit]] = Def.taskDyn {
     val infrastructureServiceTasks = sequential(lagomInfrastructureServices.value)
     Def.taskDyn {
       // First start the infrastructure services

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
@@ -1,7 +1,7 @@
 # Structure of this test:
 # =======================
 
-# We test that the service locator can be started and stopped on demand, and that services are automatically 
+# We test that the service locator can be started and stopped on demand, and that services are automatically
 # registered to the service locator.
 
 # Service locator tests
@@ -31,16 +31,16 @@
 # Disabled service locator
 # ---------------
 
-> set lagomServiceLocatorEnabled := false
+> set lagomServiceLocatorEnabled in ThisBuild := false
 # Part 1
 > runAll
 $ sleep 1000
-> validateRequest http://localhost:8000 should-be-down
+> validateRequest http://localhost:8000/services should-be-down
 > validateFile retry-until-success target/reload.log line-count 1
 
 # Cleanup
 > stop
-> set lagomServiceLocatorEnabled := true
+> set lagomServiceLocatorEnabled in ThisBuild := true
 
 # runAll runs both service locator and cassandra
 # ---------------
@@ -64,3 +64,28 @@ $ sleep 1000
 
 # Cleanup
 > stop
+
+# Test cassandra service's availability
+> set lagomCassandraEnabled in ThisBuild := false
+
+# Preconditions - ensure everything is down
+> validateRequest http://localhost:8000 should-be-down
+> validateRequest http://localhost:9000 should-be-down
+> validateRequest http://localhost:9000/foo/cassandra should-be-down
+
+> runAll
+
+# Locator and gateway should be up
+> validateRequest retry-until-success http://localhost:8000
+> validateRequest retry-until-success http://localhost:9000
+
+# Ensure the foo service is reachable
+> validateRequest retry-until-success http://localhost:8000/services/fooservice status 200
+> validateRequest http://localhost:9000/foo status 200
+
+# Request to cassandra should have a status code of 500
+> validateRequest http://localhost:9000/foo/cassandra status 500
+
+# Cleanup
+> stop
+


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #929 

## Purpose

As @jroper has introduced the new `lagomInfrastructureServices` and all `*Enable` flag will be checked in it, there needs no `startInfrastructure` task any more. It will start all tasks of kafka, cassandra, service locator no matter what `*Enable` flag has been set.

## Background Context

Issue #929 point out the problem.
