### PR TITLE
Revert logback file appender (1.3.x)

### DIFF
--- a/docs/manual/common/guide/logging/code/log4j2-lagom-default.xml
+++ b/docs/manual/common/guide/logging/code/log4j2-lagom-default.xml
@@ -12,7 +12,7 @@
 
     <Console name="STDOUT">
       <PatternLayout>
-        <Pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %highlight{%level} %logger{0} [%mdc] - %msg%n</Pattern>
+        <Pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %highlight{%level} %logger{10} [%mdc] - %msg%n</Pattern>
       </PatternLayout>
     </Console>
   </Appenders>

--- a/docs/manual/common/guide/logging/code/log4j2-lagom-dev.xml
+++ b/docs/manual/common/guide/logging/code/log4j2-lagom-dev.xml
@@ -12,7 +12,7 @@
 
     <Console name="STDOUT">
       <PatternLayout>
-        <Pattern>%d{HH:mm:ss.SSS} %highlight{%level} %logger{0} [%mdc] - %msg%n</Pattern>
+        <Pattern>%d{HH:mm:ss.SSS} %highlight{%level} %logger{10} [%mdc] - %msg%n</Pattern>
       </PatternLayout>
     </Console>
   </Appenders>

--- a/docs/manual/common/guide/logging/code/logback-lagom-default.xml
+++ b/docs/manual/common/guide/logging/code/logback-lagom-default.xml
@@ -21,7 +21,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",UTC} %coloredLevel %logger{0} [%mdc] - %msg%n</pattern>
+      <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",UTC} %coloredLevel %logger{10} [%mdc] - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/docs/manual/common/guide/logging/code/logback-lagom-default.xml
+++ b/docs/manual/common/guide/logging/code/logback-lagom-default.xml
@@ -6,14 +6,8 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="com.lightbend.lagom.internal.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${application.home:-.}/logs/application-%d{yyyy-MM-dd}.%i.log.gz}</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>30</maxHistory>
-      <totalSizeCap>300MB</totalSizeCap>
-    </rollingPolicy>
     <encoder>
       <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",UTC} ${HOSTNAME} %-5level %logger{0} [%mdc] - %msg%n</pattern>
     </encoder>

--- a/docs/manual/common/guide/logging/code/logback-lagom-dev.xml
+++ b/docs/manual/common/guide/logging/code/logback-lagom-dev.xml
@@ -15,7 +15,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%date{"HH:mm:ss.SSS"} %coloredLevel %logger{0} [%mdc] - %msg%n</pattern>
+      <pattern>%date{"HH:mm:ss.SSS"} %coloredLevel %logger{10} [%mdc] - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/log4j2/src/main/resources/log4j2-lagom-default.xml
+++ b/log4j2/src/main/resources/log4j2-lagom-default.xml
@@ -12,7 +12,7 @@
 
     <Console name="STDOUT">
       <PatternLayout>
-        <Pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %highlight{%level} %logger{0} [%mdc] - %msg%n</Pattern>
+        <Pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}{GMT+0} %highlight{%level} %logger{10} [%mdc] - %msg%n</Pattern>
       </PatternLayout>
     </Console>
   </Appenders>

--- a/log4j2/src/main/resources/log4j2-lagom-dev.xml
+++ b/log4j2/src/main/resources/log4j2-lagom-dev.xml
@@ -12,7 +12,7 @@
 
     <Console name="STDOUT">
       <PatternLayout>
-        <Pattern>%d{HH:mm:ss.SSS} %highlight{%level} %logger{0} [%mdc] - %msg%n</Pattern>
+        <Pattern>%d{HH:mm:ss.SSS} %highlight{%level} %logger{10} [%mdc] - %msg%n</Pattern>
       </PatternLayout>
     </Console>
   </Appenders>

--- a/logback/src/main/resources/logback-lagom-default.xml
+++ b/logback/src/main/resources/logback-lagom-default.xml
@@ -21,7 +21,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",UTC} %coloredLevel %logger{0} [%mdc] - %msg%n</pattern>
+      <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",UTC} %coloredLevel %logger{10} [%mdc] - %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/logback/src/main/resources/logback-lagom-default.xml
+++ b/logback/src/main/resources/logback-lagom-default.xml
@@ -6,14 +6,8 @@
 
   <conversionRule conversionWord="coloredLevel" converterClass="com.lightbend.lagom.internal.logback.ColoredLevel" />
 
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-      <fileNamePattern>${application.home:-.}/logs/application-%d{yyyy-MM-dd}.%i.log.gz}</fileNamePattern>
-      <maxFileSize>10MB</maxFileSize>
-      <maxHistory>30</maxHistory>
-      <totalSizeCap>300MB</totalSizeCap>
-    </rollingPolicy>
     <encoder>
       <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",UTC} ${HOSTNAME} %-5level %logger{0} [%mdc] - %msg%n</pattern>
     </encoder>

--- a/logback/src/main/resources/logback-lagom-dev.xml
+++ b/logback/src/main/resources/logback-lagom-dev.xml
@@ -15,7 +15,7 @@
 
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%date{"HH:mm:ss.SSS"} %coloredLevel %logger{0} [%mdc] - %msg%n</pattern>
+      <pattern>%date{"HH:mm:ss.SSS"} %coloredLevel %logger{10} [%mdc] - %msg%n</pattern>
     </encoder>
   </appender>
 


### PR DESCRIPTION
This PR reverts the RollingFileAppender introduced in a previous backport.

Another PR updates logback in master, but unfortunately updating logback in 1.3.x is not an option as it pulls another version of slf4j and we'll be forced to change many dependencies. It's preferable to avoid this cascading dependencies upgrades in a maintenance branch.

