### PR TITLE
Fixes run-services test and ScriptedTools

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
@@ -1,7 +1,7 @@
 # Structure of this test:
 # =======================
 
-# We test that the service locator can be started and stopped on demand, and that services are automatically 
+# We test that the service locator can be started and stopped on demand, and that services are automatically
 # registered to the service locator.
 
 # Service locator tests
@@ -31,16 +31,16 @@
 # Disabled service locator
 # ---------------
 
-> set lagomServiceLocatorEnabled := false
+> set lagomServiceLocatorEnabled in ThisBuild := false
 # Part 1
 > runAll
 $ sleep 1000
-> validateRequest http://localhost:8000 should-be-down
+> validateRequest http://localhost:8000/services should-be-down
 > validateFile retry-until-success target/reload.log line-count 1
 
 # Cleanup
 > stop
-> set lagomServiceLocatorEnabled := true
+> set lagomServiceLocatorEnabled in ThisBuild := true
 
 # runAll runs both service locator and cassandra
 # ---------------


### PR DESCRIPTION
During review of https://github.com/lagom/lagom/pull/934 @rcavalcanti, @WayneWang12  and I realised something was wrong on `should-be-down` when writing custom `scripted` tests. This PR fixes `should-be-down` and considers a service to be down when it doesn't respond HTTP at all. This PR also allows checking status code 500 so it is now possible to distinguish when a service is down from when a service is up but fails.