### PR TITLE
Look up a migration using only the class name instead of the manifest

### DIFF
--- a/jackson/src/test/java/com/lightbend/lagom/serialization/JacksonJsonSerializerTest.java
+++ b/jackson/src/test/java/com/lightbend/lagom/serialization/JacksonJsonSerializerTest.java
@@ -190,6 +190,16 @@ public class JacksonJsonSerializerTest {
     assertEquals(event1.getField1(), event2.getField1V2());
     assertEquals(17, event2.getField2());
   }
+  
+  @Test
+  public void testDeserializeWithMigrationFromV2() {
+    Event1 event1 = Event1.of("a");
+    byte[] blob = serializer.toBinary(event1);
+
+    Event2 event2 = (Event2) serializer.fromBinary(blob, Event1.class.getName() + "#2");
+    assertEquals(event1.getField1(), event2.getField1V2());
+    assertEquals(17, event2.getField2());
+  }
 
   @Test
   public void testSerializeDone() {

--- a/jackson/src/test/java/com/lightbend/lagom/serialization/TestEventMigration.java
+++ b/jackson/src/test/java/com/lightbend/lagom/serialization/TestEventMigration.java
@@ -12,7 +12,7 @@ public class TestEventMigration extends JacksonJsonMigration {
 
   @Override
   public int currentVersion() {
-    return 2;
+    return 3;
   }
 
   @Override


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

This PR does for the java version (using jackson) what PR #588 does for the scala api (using play json)

## Purpose

With the current implementation, we need to add a line to our application.conf for each version of an event, eg:
"com.lightbend.lagom.serialization.Event1" = "com.lightbend.lagom.serialization.TestEventMigration"
"com.lightbend.lagom.serialization.Event1#2" = "com.lightbend.lagom.serialization.TestEventMigration"
"com.lightbend.lagom.serialization.Event1#3" = "com.lightbend.lagom.serialization.TestEventMigration"

Otherwise, events of versions > 1 are not migrated.

This was fixed for the scala api in PR 588, and I applied similar changes to the JacksonJsonSerializer for the java api.

The test illustrates the issue: an instance of event1 of version 2 was not migrated, resulting in a classcastexception before the changes were applied

## Background Context
/

## References

[PR 588](https://github.com/lagom/lagom/pull/588)
