### PR TITLE
Adds JsonSerializer.compressed to conditionally compress when payload is too big

### DIFF
--- a/play-json/src/main/resources/reference.conf
+++ b/play-json/src/main/resources/reference.conf
@@ -3,3 +3,14 @@ akka.actor {
     "com.lightbend.lagom.scaladsl.playjson.PlayJsonSerializer" = 1000004
   }
 }
+
+
+lagom.serialization.json {
+
+  # The serializer will compress the payload if the message class
+  # was registered using JsonSerializer.compressed and the payload
+  # is larger than this value. Only used for remote messages within
+  # the cluster of the service.
+  compress-larger-than = 1024b
+
+}

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
@@ -32,7 +32,24 @@ object JsonSerializer {
   def apply[T: ClassTag](format: Format[T]): JsonSerializer[T] =
     JsonSerializerImpl(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], format)
 
-  private case class JsonSerializerImpl[T](entityClass: Class[T], format: Format[T]) extends JsonSerializer[T]
+  /**
+   * Create a serializer for the PlayJsonSerializationRegistry that will apply a GZIP compression when the generated
+   * JSON content is longer than <code>compress-larger-than</code> bytes, describes how a specific class can be read
+   * and written as json using separate play-json [[Reads]] and [[Writes]].
+   */
+  def compressed[T: ClassTag: Format]: JsonSerializer[T] =
+    CompressedJsonSerializerImpl(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], implicitly[Format[T]])
+
+  /**
+   * Create a serializer for the PlayJsonSerializationRegistry that will apply a GZIP compression when the generated
+   * JSON content is longer than <code>compress-larger-than</code> bytes, describes how a specific class can be read
+   * and written as json using separate play-json [[Reads]] and [[Writes]].
+   */
+  def compressed[T: ClassTag](format: Format[T]): JsonSerializer[T] =
+    CompressedJsonSerializerImpl(implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]], format)
+
+  private[lagom] case class JsonSerializerImpl[T](entityClass: Class[T], format: Format[T]) extends JsonSerializer[T]
+  private[lagom] case class CompressedJsonSerializerImpl[T](entityClass: Class[T], format: Format[T]) extends JsonSerializer[T]
 }
 
 /**

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonSerializer.scala
@@ -34,7 +34,7 @@ object JsonSerializer {
 
   /**
    * Create a serializer for the PlayJsonSerializationRegistry that will apply a GZIP compression when the generated
-   * JSON content is longer than <code>compress-larger-than</code> bytes, describes how a specific class can be read
+   * JSON content is larger than <code>compress-larger-than</code> bytes, describes how a specific class can be read
    * and written as json using separate play-json [[Reads]] and [[Writes]].
    */
   def compressed[T: ClassTag: Format]: JsonSerializer[T] =
@@ -42,7 +42,7 @@ object JsonSerializer {
 
   /**
    * Create a serializer for the PlayJsonSerializationRegistry that will apply a GZIP compression when the generated
-   * JSON content is longer than <code>compress-larger-than</code> bytes, describes how a specific class can be read
+   * JSON content is larger than <code>compress-larger-than</code> bytes, describes how a specific class can be read
    * and written as json using separate play-json [[Reads]] and [[Writes]].
    */
   def compressed[T: ClassTag](format: Format[T]): JsonSerializer[T] =


### PR DESCRIPTION
Fixes #502

Brings feature parity to scaladsl. The approach is the same: a user configuring a serializer may choose (with class granularity) if compression should be applied. Compression will only be applied when a `compress-larger-than`threshold is reached (defaults to 1Kb).