### PR TITLE
Documents Service Gateway DevEnv settings (including impl choice).

### DIFF
--- a/docs/manual/common/guide/devmode/DevEnvironment.md
+++ b/docs/manual/common/guide/devmode/DevEnvironment.md
@@ -71,10 +71,10 @@ Now we're able to start Elastic Search, we need to add this task to Lagom's list
 <!-- copied this section to concepts, perhaps it can be removed later -->
 What's happening behind the scenes when you `runAll`?
 
-* an embedded Service Locator is started
-* an embedded Service Gateway is started
-* a Cassandra server is started
-* a Kafka server is started
+* an embedded [[Service Locator|ServiceLocator]] is started
+* an embedded [[Service Gateway|ServiceLocator#Service-Gateway]] is started
+* a [[Cassandra server|CassandraServer]] is started
+* a [[Kafka server|KafkaServer]] is started
 * your services start
     * ...and register with the Service Locator
     * ...and register the publicly accessible paths in the Service Gateway

--- a/docs/manual/common/guide/devmode/DevEnvironment.md
+++ b/docs/manual/common/guide/devmode/DevEnvironment.md
@@ -72,10 +72,12 @@ Now we're able to start Elastic Search, we need to add this task to Lagom's list
 What's happening behind the scenes when you `runAll`?
 
 * an embedded Service Locator is started
+* an embedded Service Gateway is started
 * a Cassandra server is started
 * a Kafka server is started
 * your services start
     * ...and register with the Service Locator
+    * ...and register the publicly accessible paths in the Service Gateway
 
 This all happens automatically without special code or additional configuration.
 

--- a/docs/manual/common/guide/devmode/code/build-service-locator.sbt
+++ b/docs/manual/common/guide/devmode/code/build-service-locator.sbt
@@ -1,3 +1,12 @@
+//#service-gateway-port
+lagomServiceGatewayPort in ThisBuild := 9010
+//#service-gateway-port
+
+//#service-gateway-impl
+// Implementation of the service gateway: "akka-http" (default) or "netty"
+lagomServiceGatewayImpl in ThisBuild := "netty"
+//#service-gateway-impl
+
 //#service-locator-port
 lagomServiceLocatorPort in ThisBuild := 10000
 //#service-locator-port

--- a/docs/manual/common/guide/devmode/index.toc
+++ b/docs/manual/common/guide/devmode/index.toc
@@ -1,6 +1,6 @@
 DevEnvironment:Development Environment
 RunningServices:Running Services
 ServicePort:How are ports assigned to services?
-ServiceLocator:Service Locator
+ServiceLocator:Service Locator and Service Gateway
 CassandraServer:Cassandra Server
 KafkaServer:Kafka Server

--- a/docs/manual/java/guide/devmode/ServiceLocator.md
+++ b/docs/manual/java/guide/devmode/ServiceLocator.md
@@ -83,8 +83,9 @@ In sbt:
 
 The Lagom development environment provides an implementation of a Service Gateway based on [Akka HTTP](https://github.com/akka/akka-http) and the (now legacy) implementation based on [Netty](https://netty.io/). 
 
-You may opt in to use the old `netty` implementation using:
+You may opt in to use the old `netty` implementation.
 
+In the Maven root project pom:
 
 ```xml
 <plugin>
@@ -128,4 +129,10 @@ In sbt:
 
 @[service-locator-disabled](code/build-service-locator.sbt)
 
-Be aware that by disabling the Service Locator your services will not be able to communicate. You will also be unable to access to your services from the outside unless you access the exact host:port. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html) in your service.
+Be aware that by disabling the Service Locator your services will not be able to communicate with each other. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html) in your service. You will also be unable to access to your services via the Service Gateway running on http://localhost:9000 (by default). Instead, you will need to access each service directly on its own port. Each service port is logged to the console when starting in development mode, for example:
+
+```
+[info] Service hello-impl listening for HTTP on 0:0:0:0:0:0:0:0:57797
+```
+
+For more information, see [[How are ports assigned to services?|ServicePort]].

--- a/docs/manual/java/guide/devmode/ServiceLocator.md
+++ b/docs/manual/java/guide/devmode/ServiceLocator.md
@@ -52,13 +52,64 @@ The above ensures that the Service Locator knows about the `weather` service. Th
 
 Note that if the service you want to communicate with is actually a Lagom service, you may want to read the documentation for [[integrating with an external Lagom projects|MultipleBuilds]].
 
+
+# Service Gateway
+
+Some clients that want to connect to your services will not have access to your Service Locator. External clients need a stable address to communicate to and here's where the Service Gateway comes in. The Service Gateway will expose and reverse proxy all public endpoints registered by your services. A Service Gateway is embedded in Lagom's development environment, allowing clients from the outside (e.g. a browser) to connect to your Lagom services. 
+
+## Default port
+
+By default the Service Gateway is listening for connections on port `9000` in `localhost`. It is possible to change that port by adding this to your build.
+
+In the Maven root project pom:
+
+```xml
+<plugin>
+    <groupId>com.lightbend.lagom</groupId>
+    <artifactId>lagom-maven-plugin</artifactId>
+    <version>${lagom.version}</version>
+    <configuration>
+        <serviceGatewayPort>9010</serviceGatewayPort>
+    </configuration>
+</plugin>
+```
+
+In sbt:
+
+@[service-gateway-port](code/build-service-locator.sbt)
+
+
+## Default gateway implementation
+
+The Lagom development environment provides an implementation of a Service Gateway based on [Akka HTTP](https://github.com/akka/akka-http) and the (now legacy) implementation based on [Netty](https://netty.io/). 
+
+You may opt in to use the old `netty` implementation using:
+
+
+```xml
+<plugin>
+    <groupId>com.lightbend.lagom</groupId>
+    <artifactId>lagom-maven-plugin</artifactId>
+    <version>${lagom.version}</version>
+    <configuration>
+        <serviceGatewayImpl>netty</serviceGatewayImpl>
+    </configuration>
+</plugin>
+```
+
+In sbt:
+
+@[service-gateway-impl](code/build-service-locator.sbt)
+
+
+
 ## Start and stop
 
-The Service Locator is automatically started when executing the `runAll` task. However, there are times when you might want to manually start only a few services, and hence you won't use the `runAll` task. In this case, you can manually start the Service Locator via the `lagom:startServiceLocator` Maven task or the `lagomServiceLocatorStart` sbt task, and stopping it with the `lagom:stopServiceLocator` Maven task or the`lagomServiceLocatorStop` sbt task.
+The Service Locator and the Service Gateway are automatically started when executing the `runAll` task. However, there are times when you might want to manually start only a few services, and hence you won't use the `runAll` task. In this case, you can manually start the Service Locator and Service Gateway pair via the `lagom:startServiceLocator` Maven task or the `lagomServiceLocatorStart` sbt task, and stopping it with the `lagom:stopServiceLocator` Maven task or the`lagomServiceLocatorStop` sbt task.
 
 ## Disable it
 
-You can disable the embedded Service Locator by adding the following in your build.
+You can disable the embedded Service Locator and Service Gateway by adding the following in your build.
 
 In the Maven root project pom:
 
@@ -77,4 +128,4 @@ In sbt:
 
 @[service-locator-disabled](code/build-service-locator.sbt)
 
-Be aware that by disabling the Service Locator your services will not be able to communicate. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html) in your service.
+Be aware that by disabling the Service Locator your services will not be able to communicate. You will also be unable to access to your services from the outside unless you access the exact host:port. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html) in your service.

--- a/docs/manual/scala/guide/devmode/ServiceLocator.md
+++ b/docs/manual/scala/guide/devmode/ServiceLocator.md
@@ -52,6 +52,31 @@ The above ensures that the Service Locator knows about the `weather` service. Th
 
 Note that if the service you want to communicate with is actually a Lagom service, you may want to read the documentation for [[integrating with an external Lagom projects|MultipleBuilds]].
 
+
+
+# Service Gateway
+
+Some clients that want to connect to your services will not have access to your Service Locator. External clients need a stable address to communicate to and here's where the Service Gateway comes in. The Service Gateway will expose and reverse proxy all public endpoints registered by your services. A Service Gateway is embedded in Lagom's development environment, allowing clients from the outside (e.g. a browser) to connect to your Lagom services. 
+
+## Default port
+
+By default the Service Gateway is listening for connections on port `9000` in `localhost`. It is possible to change that port by adding this to your build.
+
+In sbt:
+
+@[service-gateway-port](code/build-service-locator.sbt)
+
+
+## Default gateway implementation
+
+The Lagom development environment provides an implementation of a Service Gateway based on [Akka HTTP](https://github.com/akka/akka-http) and the (now legacy) implementation based on [Netty](https://netty.io/). 
+
+You may opt in to use the old `netty` implementation with this setting in sbt:
+
+@[service-gateway-impl](code/build-service-locator.sbt)
+
+
+
 ## Start and stop
 
 The Service Locator is automatically started when executing the `runAll` task. However, there are times when you might want to manually start only a few services, and hence you won't use the `runAll` task. In this case, you can manually start the Service Locator via the `lagom:startServiceLocator` Maven task or the `lagomServiceLocatorStart` sbt task, and stopping it with the `lagom:stopServiceLocator` Maven task or the`lagomServiceLocatorStop` sbt task.

--- a/docs/manual/scala/guide/devmode/ServiceLocator.md
+++ b/docs/manual/scala/guide/devmode/ServiceLocator.md
@@ -79,11 +79,11 @@ You may opt in to use the old `netty` implementation with this setting in sbt:
 
 ## Start and stop
 
-The Service Locator is automatically started when executing the `runAll` task. However, there are times when you might want to manually start only a few services, and hence you won't use the `runAll` task. In this case, you can manually start the Service Locator via the `lagom:startServiceLocator` Maven task or the `lagomServiceLocatorStart` sbt task, and stopping it with the `lagom:stopServiceLocator` Maven task or the`lagomServiceLocatorStop` sbt task.
+The Service Locator and the Service Gateway are automatically started when executing the `runAll` task. However, there are times when you might want to manually start only a few services, and hence you won't use the `runAll` task. In this case, you can manually start the Service Locator and Service Gateway pair via the `lagom:startServiceLocator` Maven task or the `lagomServiceLocatorStart` sbt task, and stopping it with the `lagom:stopServiceLocator` Maven task or the`lagomServiceLocatorStop` sbt task.
 
 ## Disable it
 
-You can disable the embedded Service Locator by adding the following in your build.
+You can disable the embedded Service Locator and Service Gateway by adding the following in your build.
 
 In the Maven root project pom:
 
@@ -102,4 +102,4 @@ In sbt:
 
 @[service-locator-disabled](code/build-service-locator.sbt)
 
-Be aware that by disabling the Service Locator your services will not be able to communicate. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/com/lightbend/lagom/scaladsl/api/ServiceLocator.html) in your service.
+Be aware that by disabling the Service Locator your services will not be able to communicate.You will also be unable to access to your services from the outside unless you access the exact host:port. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/com/lightbend/lagom/scaladsl/api/ServiceLocator.html) in your service.

--- a/docs/manual/scala/guide/devmode/ServiceLocator.md
+++ b/docs/manual/scala/guide/devmode/ServiceLocator.md
@@ -102,4 +102,10 @@ In sbt:
 
 @[service-locator-disabled](code/build-service-locator.sbt)
 
-Be aware that by disabling the Service Locator your services will not be able to communicate.You will also be unable to access to your services from the outside unless you access the exact host:port. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/com/lightbend/lagom/scaladsl/api/ServiceLocator.html) in your service.
+Be aware that by disabling the Service Locator your services will not be able to communicate with each other. To restore communication, you will have to provide an implementation of [`ServiceLocator`](api/com/lightbend/lagom/scaladsl/api/ServiceLocator.html) in your service. You will also be unable to access to your services via the Service Gateway running on http://localhost:9000 (by default). Instead, you will need to access each service directly on its own port. Each service port is logged to the console when starting in development mode, for example:
+
+```
+[info] Service hello-impl listening for HTTP on 0:0:0:0:0:0:0:0:57797
+```
+
+For more information, see [[How are ports assigned to services?|ServicePort]].


### PR DESCRIPTION
Fixes #953 for `master`.

When backporting, the following need a review:

 - wording on the section `Default gateway implementation` 
 - sample code and docs on `build-service-locator.sbt`