### PR TITLE
[WIP] [1.3.x] Force the JVM to halt in the last-resort exit

### DIFF
--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -47,7 +47,7 @@ private[lagom] object JoinClusterImpl {
           val t = new Thread(new Runnable {
             override def run(): Unit = {
               if (Try(Await.ready(system.whenTerminated, 10.seconds)).isFailure)
-                System.exit(-1)
+                sys.runtime.halt(-1)
             }
           })
           t.setDaemon(true)


### PR DESCRIPTION
System.exit (which calls Runtime.getRuntime().exit) will block if the runtime is currently in the process of running shutdown hooks. This means that if the shutdown hooks deadlock, this will too.

Since the purpose of this is to force shutdown in the case where the actor system is not stopping cleanly in a reasonable amount of time, this commit changes the behavior to call Runtime.halt instead. This method exits the JVM immediately, without running shutdown hooks or otherwise cleaning up.

I made this change against the 1.3.x branch so that we can use it for testing split brain resolver/ConductR behavior with Lagom services written with Lagom 1.3.

Lagom 1.4/Akka 2.5 have the coordinated shutdown process, and it's possible that we should be taking a different approach there.

## Fixes

Fixes #971
