### PR TITLE
upgrades akka-persistence-jdbc to 3.0.0

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
@@ -45,7 +45,7 @@ db.default {
   url = "jdbc:postgresql://database.example.com/playdb"
 }
 
-jdbc-defaults.slick.driver = "slick.jdbc.PostgresProfile$"
+jdbc-defaults.slick.profile = "slick.jdbc.PostgresProfile$"
 ```
 
 ## Table creation

--- a/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
@@ -23,7 +23,7 @@ In sbt:
 You will also need to add the jar for your JDBC database driver.
 
 To enable the RDBMS Persistence on your Application you will have to mix in | [JdbcPersistenceComponents](api/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceComponents.html) and [HikariCPComponents](https://www.playframework.com/documentation/2.6.x/api/scala/play/api/db/HikariCPComponents.html) as described in [[Dependency Injection|DependencyInjection#Wiring-together-a-Lagom-application]].
- 
+
 
 ## Configuration
 
@@ -48,7 +48,7 @@ db.default {
   url = "jdbc:postgresql://database.example.com/playdb"
 }
 
-jdbc-defaults.slick.driver = "slick.jdbc.PostgresProfile$"
+jdbc-defaults.slick.profile = "slick.jdbc.PostgresProfile$"
 ```
 
 ## Table creation

--- a/persistence-jdbc/core/src/main/resources/play/reference-overrides.conf
+++ b/persistence-jdbc/core/src/main/resources/play/reference-overrides.conf
@@ -1,15 +1,21 @@
 jdbc-journal.slick {
-  driver = ${jdbc-defaults.slick.driver}
+  profile = ${?jdbc-defaults.slick.profile}
+  # for backward compatibility only, will be removed in 1.5.0 (@deprecated)
+  driver = ${?jdbc-defaults.slick.driver}
   jndiName = ${jdbc-defaults.slick.jndiName}
 }
 
 jdbc-read-journal.slick {
-  driver = ${jdbc-defaults.slick.driver}
+  profile = ${?jdbc-defaults.slick.profile}
+  # for backward compatibility only, will be removed in 1.5.0 (@deprecated)
+  driver = ${?jdbc-defaults.slick.driver}
   jndiName = ${jdbc-defaults.slick.jndiName}
 }
 
 jdbc-snapshot-store.slick {
-  driver = ${jdbc-defaults.slick.driver}
+  profile = ${?jdbc-defaults.slick.profile}
+  # for backward compatibility only, will be removed in 1.5.0 (@deprecated)
+  driver = ${?jdbc-defaults.slick.driver}
   jndiName = ${jdbc-defaults.slick.jndiName}
 }
 

--- a/persistence-jdbc/core/src/main/resources/reference.conf
+++ b/persistence-jdbc/core/src/main/resources/reference.conf
@@ -2,8 +2,9 @@
 # Defaults to use for each Akka persistence plugin
 jdbc-defaults.slick {
 
-  # The driver to use
-  driver = "slick.jdbc.H2Profile$"
+  # The Slick profile to use
+  # set to one of: slick.jdbc.PostgresProfile$, slick.jdbc.MySQLProfile$, slick.jdbc.OracleProfile$ or slick.jdbc.H2Profile$
+  # profile = "slick.jdbc.PostgresProfile$"
 
   # The JNDI name
   jndiName = "DefaultDS"
@@ -70,8 +71,11 @@ lagom.persistence.read-side.jdbc {
   # Slick configuration
   slick {
 
-    # The Slick driver
-    driver = ${jdbc-defaults.slick.driver}
+    # The Slick profile
+    profile = ${?jdbc-defaults.slick.profile}
+
+    # The Slick driver - for backward compatibility only, will be removed in 1.5.0 (@deprecated)
+    driver = ${?jdbc-defaults.slick.driver}
 
     # The JNDI name to use
     jndiName = ${jdbc-defaults.slick.jndiName}

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -31,11 +31,4 @@ private[lagom] final class JdbcPersistentEntityRegistry @Inject() (system: Actor
   private val jdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](journalId)
   override protected val eventsByTagQuery: Option[EventsByTagQuery] = Some(jdbcReadJournal)
 
-  override protected def mapStartingOffset(storedOffset: Offset): AkkaOffset = storedOffset match {
-    case Offset.NONE          => NoOffset
-    case seq: Offset.Sequence => Sequence(seq.value())
-    case other =>
-      throw new IllegalArgumentException(s"JDBC does not support ${other.getClass.getSimpleName} offsets")
-  }
-
 }

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -33,7 +33,7 @@ private[lagom] final class JdbcPersistentEntityRegistry @Inject() (system: Actor
 
   override protected def mapStartingOffset(storedOffset: Offset): AkkaOffset = storedOffset match {
     case Offset.NONE          => NoOffset
-    case seq: Offset.Sequence => Sequence(seq.value() + 1)
+    case seq: Offset.Sequence => Sequence(seq.value())
     case other =>
       throw new IllegalArgumentException(s"JDBC does not support ${other.getClass.getSimpleName} offsets")
   }

--- a/persistence-jdbc/javadsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-jdbc/javadsl/src/multi-jvm/resources/reference.conf
@@ -1,0 +1,1 @@
+jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"

--- a/persistence-jdbc/javadsl/src/test/resources/reference.conf
+++ b/persistence-jdbc/javadsl/src/test/resources/reference.conf
@@ -1,0 +1,1 @@
+jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -28,11 +28,4 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
   private val jdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](journalId)
   override protected val eventsByTagQuery: Option[EventsByTagQuery] = Some(jdbcReadJournal)
 
-  override protected def mapStartingOffset(storedOffset: Offset): Offset = storedOffset match {
-    case NoOffset        => NoOffset
-    case Sequence(value) => Sequence(value)
-    case other =>
-      throw new IllegalArgumentException(s"JDBC does not support ${other.getClass.getSimpleName} offsets")
-  }
-
 }

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -30,7 +30,7 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
 
   override protected def mapStartingOffset(storedOffset: Offset): Offset = storedOffset match {
     case NoOffset        => NoOffset
-    case Sequence(value) => Sequence(value + 1)
+    case Sequence(value) => Sequence(value)
     case other =>
       throw new IllegalArgumentException(s"JDBC does not support ${other.getClass.getSimpleName} offsets")
   }

--- a/persistence-jdbc/scaladsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-jdbc/scaladsl/src/multi-jvm/resources/reference.conf
@@ -1,0 +1,1 @@
+jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"

--- a/persistence-jdbc/scaladsl/src/test/resources/reference.conf
+++ b/persistence-jdbc/scaladsl/src/test/resources/reference.conf
@@ -1,0 +1,1 @@
+jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"

--- a/persistence-jpa/javadsl/src/test/resources/reference.conf
+++ b/persistence-jpa/javadsl/src/test/resources/reference.conf
@@ -1,0 +1,1 @@
+jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
@@ -150,7 +150,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
 
     }
 
-    "persisted offsets unhandled events" in {
+    "persisted offsets for unhandled events" in {
 
       // count = 5 from previous test steps
       assertSelectCount("1", 5L)

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -112,9 +112,7 @@ abstract class AbstractPersistentEntityRegistry(system: ActorSystem) extends Per
       case Some(queries) =>
         val tag = aggregateTag.tag
 
-        val startingOffset = mapStartingOffset(fromOffset)
-
-        queries.eventsByTag(tag, startingOffset)
+        queries.eventsByTag(tag, fromOffset)
           .map(env =>
             new EventStreamElement[Event](
               PersistentEntityActor.extractEntityId(env.persistenceId),
@@ -125,24 +123,6 @@ abstract class AbstractPersistentEntityRegistry(system: ActorSystem) extends Per
         throw new UnsupportedOperationException(s"The $journalId Lagom persistence plugin does not support streaming events by tag")
     }
   }
-
-  /**
-   * Converts a stored event journal offset into the argument to an
-   * `eventsByTag` query.
-   *
-   * Different Akka Persistence back ends interpret the `offset` parameter to
-   * `eventsByTag` differently. Some return events starting ''after'' the given
-   * `offset`, others start with the event ''at'' that offset. In Lagom, we
-   * shield end users from this difference, and always want to return
-   * unprocessed events. Subclasses can override this method as necessary to
-   * convert a stored offset into a starting offset that ensures no stored
-   * values will be repeated in the stream.
-   *
-   * @param storedOffset the most recently seen offset
-   * @return an offset that can be provided to the `eventsByTag` query to
-   *         retrieve only unseen events
-   */
-  protected def mapStartingOffset(storedOffset: Offset): Offset = storedOffset
 
   override def gracefulShutdown(timeout: FiniteDuration): Future[Done] = {
     import scala.collection.JavaConverters._

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -145,7 +145,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
       assertSelectCount("1", 5L)
     }
 
-    "persisted offsets unhandled events" in {
+    "persisted offsets for unhandled events" in {
 
       createReadSideProcessor()
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   val AkkaHttpVersion = "10.0.9"
   val ScalaVersion = "2.11.11"
   val AkkaPersistenceCassandraVersion = "0.54"
+  val AkkaPersistenceJdbcVersion = "3.0.0"
   val ScalaTestVersion = "3.0.3"
   val JacksonVersion = "2.8.9"
   val CassandraAllVersion = "3.8"
@@ -25,7 +26,7 @@ object Dependencies {
   val Log4jVersion = "1.2.17"
   val ScalaJava8CompatVersion = "0.8.0"
   val ScalaXmlVersion = "1.0.6"
-  val SlickVersion = "3.2.0"
+  val SlickVersion = "3.2.1"
   val JUnitVersion = "4.11"
   val LogbackVersion = "1.2.3"
 
@@ -55,7 +56,7 @@ object Dependencies {
   private val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
   private val reactiveStreams = "org.reactivestreams" % "reactive-streams" % "1.0.1"
 
-  private val akkaPersistenceJdbc = "com.github.dnvriend" %% "akka-persistence-jdbc" % "2.5.2.0"
+  private val akkaPersistenceJdbc = "com.github.dnvriend" %% "akka-persistence-jdbc" % AkkaPersistenceJdbcVersion
 
   // latest version of APC depend on a Cassandra driver core that's not compatible with Lagom (newer netty/guava/etc... under the covers)
   private val akkaPersistenceCassandra = "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion


### PR DESCRIPTION
This PR upgrades Lagom to the upcoming akka-persistence-jdbc v3.0.0 (not yet released)

A few issues will be fixed once we can merge this PR:
- upgrades Slick to 3.2.1 (#918)
- promotes the usage of `slick.profile` instead of deprecated `slick.driver` (#764)