### PR TITLE
Simplifies the actor system termination and JVM shutdown

### DIFF
--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -2,21 +2,16 @@
 lagom.cluster {
 
   # The cluster node will join itself if akka.cluster.seed-nodes is not configured.
-  # In dev-mode this setting will be on, otherwise the default is off. It's possible 
+  # In dev-mode this setting will be on, otherwise the default is off. It's possible
   # to override that by defining akka.cluster.seed-nodes or set this property to off in
   # the application.conf
   join-self = ${lagom.defaults.cluster.join-self}
-  
+
   # The ActorSystem is terminated when the cluster member
   # is removed. The delay is to give ClusterSingleton actors
   # some time to stop gracefully.
   terminate-system-after-member-removed = 10s
-  
-  # Exit the JVM forcefully when the ActorSystem has been terminated.
-  # This is by default off, but you may want to turn it on in production
-  # to restart the process.
-  exit-jvm-when-system-terminated = off
-  
+
 }
 
 lagom.defaults.cluster.join-self = off

--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -12,9 +12,11 @@ lagom.cluster {
   # some time to stop gracefully.
   terminate-system-after-member-removed = 10s
 
-  # Exit the JVM forcefully when the ActorSystem has been terminated.
-  # This is by default off, but you may want to turn it on in production
-  # to restart the process.
+  # Exit the JVM forcefully when the ActorSystem has been terminated after
+  # removing the cluster membership (other causes of actor system termination
+  # will not trigger a JVM exit).
+  # This is by default off, but it should be turned on in production so the
+  # process restarts.
   # The recommended value (depending on the environment) is:
   #    * development mode : off
   #    * running tests : off

--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -12,6 +12,15 @@ lagom.cluster {
   # some time to stop gracefully.
   terminate-system-after-member-removed = 10s
 
+  # Exit the JVM forcefully when the ActorSystem has been terminated.
+  # This is by default off, but you may want to turn it on in production
+  # to restart the process.
+  # The recommended value (depending on the environment) is:
+  #    * development mode : off
+  #    * running tests : off
+  #    * production / staging  : on
+  exit-jvm-when-system-terminated = off
+
 }
 
 lagom.defaults.cluster.join-self = off

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -51,9 +51,8 @@ private[lagom] object JoinClusterImpl {
                 Runtime.getRuntime.halt(-2)
               }
 
-              val CLUSTER_MEMBERSHIP_REMOVED = -128
               // this is reached only when `system.whenTerminated` completes successfully.
-              println("Proceed to JVM shutdown with exit status: " + CLUSTER_MEMBERSHIP_REMOVED)
+              val CLUSTER_MEMBERSHIP_REMOVED = -128
               System.exit(CLUSTER_MEMBERSHIP_REMOVED)
 
             }

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -4,13 +4,13 @@
 package com.lightbend.lagom.internal.cluster
 
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+
+import akka.actor.ActorSystem
+import akka.cluster.Cluster
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
-import akka.actor.ActorSystem
-import akka.cluster.Cluster
 
 private[lagom] object JoinClusterImpl {
 
@@ -24,67 +24,38 @@ private[lagom] object JoinClusterImpl {
       "lagom.cluster.terminate-system-after-member-removed", TimeUnit.MILLISECONDS
     ).millis
 
-    def exitJvm = config.getBoolean("lagom.cluster.exit-jvm-when-system-terminated")
-
     // join self if seed-nodes are not configured in dev-mode,
     // otherwise it will join the seed-nodes automatically
     val cluster = Cluster(system)
     if (cluster.settings.SeedNodes.isEmpty && joinSelf)
       cluster.join(cluster.selfAddress)
 
-    val SUCCESSFUL_EXIT = 0
-    val exitStatus = new AtomicInteger(SUCCESSFUL_EXIT)
-
-    val isExiting = new AtomicBoolean(false)
-
-    if (exitJvm) {
-      // exit JVM when ActorSystem has been terminated
-      system.registerOnTermination {
-        new Thread("Sys-exiting-from-akka-termination") {
-          override def run(): Unit = {
-            if (isExiting.compareAndSet(false, true)) {
-              println("Proceed to JVM shutdown with exit status: " + exitStatus.get())
-              System.exit(exitStatus.get())
-            } else {
-              println("JVM shutdown already handled. Ignore.")
-            }
-          }
-        }
-      }
-    }
-
     Cluster(system).registerOnMemberRemoved {
       // The delay is to give ClusterSingleton actors some time to stop gracefully.
       system.scheduler.scheduleOnce(terminateSystemAfter) {
-        val CLUSTER_MEMBERSHIP_REMOVED = -128
-        val EXIT_TIMEOUT_WITH_HALT = -2
-        exitStatus.compareAndSet(SUCCESSFUL_EXIT, CLUSTER_MEMBERSHIP_REMOVED)
 
-        // `needsExiting` must be set before invoking `system.terminate`
-        val needsExiting = isExiting.compareAndSet(false, true)
         system.terminate()
 
-        if (exitJvm) {
-          // In case ActorSystem shutdown takes longer than 10 seconds,
-          // exit the JVM forcefully anyway.
-          // We must spawn a separate thread to not block current thread,
-          // since that would have blocked the shutdown of the ActorSystem.
-          val t = new Thread(new Runnable {
-            override def run(): Unit = {
-              if (Try(Await.ready(system.whenTerminated, 10.seconds)).isFailure) {
-                System.err.println("Halting JVM.")
-                Runtime.getRuntime.halt(EXIT_TIMEOUT_WITH_HALT)
-              }
-              // this is reached only when `system.whenTerminated` completes successfully.
-              if (needsExiting) {
-                println("Proceed to JVM shutdown with exit status: " + exitStatus.get())
-                System.exit(exitStatus.get())
-              }
+        // In case ActorSystem shutdown takes longer than 10 seconds,
+        // exit the JVM forcefully anyway.
+        // We must spawn a separate thread to not block current thread,
+        // since that would have blocked the shutdown of the ActorSystem.
+        new Thread(new Runnable {
+          override def run(): Unit = {
+            if (Try(Await.ready(system.whenTerminated, 10.seconds)).isFailure) {
+              System.err.println("Halting JVM.")
+              Runtime.getRuntime.halt(-2)
             }
-          })
-          t.setDaemon(true)
-          t.start()
-        }
+
+            val CLUSTER_MEMBERSHIP_REMOVED = -128
+            // this is reached only when `system.whenTerminated` completes successfully.
+            println("Proceed to JVM shutdown with exit status: " + CLUSTER_MEMBERSHIP_REMOVED)
+            System.exit(CLUSTER_MEMBERSHIP_REMOVED)
+
+          }
+        }).start()
+
+
       }(system.dispatcher)
 
     }


### PR DESCRIPTION
Iterates over changes introduced on #974.

This PR introduces a simpler implementation that aims to achieve the same goals than #974:

 - shutdown cleanly on SIGTERM
 - shutdown cleanly with non-zero exit status on cluster node downing
 - avoid deadlocking
 - system.halt when a 10s delay passes without actor system termination

This is WIP. I'd like to review the shutdown process/setup in upper layers (lagom/play). For example:

- get rid (or make configurable) of [this Infinite](https://github.com/playframework/playframework/blob/2.5.15/framework/src/play/src/main/scala/play/api/Play.scala#L128)
- review the [default timeout](https://github.com/playframework/playframework/blob/2.6.3/framework/src/play/src/main/resources/reference.conf#L853-L854) in Lagom for the [ActorSystemProvide#hook](https://github.com/playframework/playframework/blob/2.6.3/framework/src/play/src/main/scala/play/api/libs/concurrent/Akka.scala#L143-L162).