### PR TITLE
Sets akka.cluster.jmx.multi-mbeans-in-same-jvm = on in Dev mode 

### DIFF
--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -63,9 +63,15 @@ object LagomReloadableDevServerStart {
         val process = new RealServerProcess(args = Seq.empty)
         val path: File = buildLink.projectPath
 
-        val dirAndDevSettings: Map[String, String] = ServerConfig.rootDirConfig(path) ++ buildLink.settings.asScala.toMap ++
-          (httpPort.toList.map("play.server.http.port" -> _.toString).toMap) +
-          ("play.server.http.address" -> httpAddress)
+        val dirAndDevSettings: Map[String, String] =
+          ServerConfig.rootDirConfig(path) ++
+            buildLink.settings.asScala.toMap ++
+            httpPort.toList.map("play.server.http.port" -> _.toString).toMap +
+            ("play.server.http.address" -> httpAddress) +
+            {
+              // on dev-mode, we often have more than one cluster on the same jvm
+              "akka.cluster.jmx.multi-mbeans-in-same-jvm" -> "on"
+            }
 
         // Use plain Java call here in case of scala classloader mess
         {


### PR DESCRIPTION
Adds property to configuration in `LagomReloadableDevServerStart`

This was verified with: `hello-scala.g8`, `hello-java.g8` and `maven-archetype`. It removes the warning in all cases. 

Only affects 1.4.x because the warning and property was only added in Akka 2.5.x. Branch 1.3.x use Akka 2.4.19. 
(fixes #906)

