### PR TITLE
Silence "Resolving" messages in the build

### DIFF
--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -6,10 +6,10 @@ set -e
 set -o pipefail
 
 runSbt() {
-  sbt --warn -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' $@
+  sbt --warn -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' 'set ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet' $@
 }
 
 runSbtNoisy() {
-  sbt -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' $@
+  sbt -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' 'set ivyLoggingLevel in ThisBuild := UpdateLogging.Quiet' $@
 }
 


### PR DESCRIPTION
These add a lot of noise to the build logs in Travis, and don't provide much value.