### PR TITLE
Remove copyright from files in Maven archetype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys
 import com.typesafe.sbt.SbtMultiJvm.MultiJvmKeys.MultiJvm
 import lagom.Protobuf
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
-import de.heikoseeberger.sbtheader.HeaderPattern
+import de.heikoseeberger.sbtheader.{ HeaderKey, HeaderPattern }
 import com.typesafe.tools.mima.core._
 
 def common: Seq[Setting[_]] = releaseSettings ++ bintraySettings ++ Seq(
@@ -928,7 +928,9 @@ def archetypeProject(archetypeName: String) =
           IO.write(pomFile, newPomXml)
         }
         (copyResources in Compile).value
-      }
+      },
+      // Don't force copyright headers in Maven archetypes
+      HeaderKey.excludes := Seq("*")
     ).disablePlugins(EclipsePlugin)
 
 lazy val `maven-java-archetype` = archetypeProject("java")

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/GreetingMessage.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/GreetingMessage.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.api;
 
 import lombok.Value;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/__service1ClassName__Event.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/__service1ClassName__Event.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
- */
 package ${package}.${service1Name}.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/__service1ClassName__Service.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-api/src/main/java/__packageInPathFormat__/__service1Name__/api/__service1ClassName__Service.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.api;
 
 import static com.lightbend.lagom.javadsl.api.Service.named;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Command.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Command.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import java.util.Optional;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Entity.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Entity.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import java.time.LocalDateTime;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Event.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Event.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import com.lightbend.lagom.javadsl.persistence.AggregateEvent;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Module.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__Module.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import com.google.inject.AbstractModule;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceImpl.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceImpl.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import akka.Done;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__State.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__State.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import lombok.Value;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/resources/application.conf
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/main/resources/application.conf
@@ -1,6 +1,3 @@
-#
-# Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
-#
 play.modules.enabled += ${package}.${service1Name}.impl.${service1ClassName}Module
 
 lagom.persistence.ask-timeout = 10s

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__EntityTest.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__EntityTest.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceTest.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceTest.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service1Name}.impl;
 
 import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-api/src/main/java/__packageInPathFormat__/__service2Name__/api/__service2ClassName__Service.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-api/src/main/java/__packageInPathFormat__/__service2Name__/api/__service2ClassName__Service.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service2Name}.api;
 
 import static com.lightbend.lagom.javadsl.api.Service.named;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__Module.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__Module.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service2Name}.impl;
 
 import com.google.inject.AbstractModule;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__Repository.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__Repository.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
- */
 package ${package}.${service2Name}.impl;
 
 import akka.Done;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__ServiceImpl.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__ServiceImpl.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.${service2Name}.impl;
 
 import akka.NotUsed;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__Subscriber.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/java/__packageInPathFormat__/__service2Name__/impl/__service2ClassName__Subscriber.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
- */
 package ${package}.${service2Name}.impl;
 
 import akka.Done;

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/resources/application.conf
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service2Name__-impl/src/main/resources/application.conf
@@ -1,6 +1,3 @@
-#
-# Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
-#
 play.modules.enabled += ${package}.${service2Name}.impl.${service2ClassName}Module
 
 lagom.persistence.ask-timeout = 10s

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/it/__service2ClassName__IT.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/it/__service2ClassName__IT.java
@@ -1,6 +1,3 @@
-/*
- * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
- */
 package ${package}.it;
 
 import akka.actor.ActorSystem;


### PR DESCRIPTION
These files are templates used to create code owned by Lagom users, so they should not be populated with a Lightbend copyright notice.

Fixes #976.