### PR TITLE
Update sbt-bintray to 0.5.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.8.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 // need this for com.typesafe.sbt.preprocess.Preprocess
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")


### PR DESCRIPTION
We won't really know if it works until we try to release. I suggest we skip backporting this one.