### PR TITLE
Update play-file-watch to 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -976,7 +976,11 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
     crossScalaVersions := Dependencies.SbtScalaVersions,
     scalaVersion := Dependencies.SbtScalaVersions.head,
     Dependencies.`sbt-plugin`,
-    addSbtPlugin(("com.typesafe.play" % "sbt-plugin" % Dependencies.PlayVersion).exclude("org.slf4j","slf4j-simple")),
+    addSbtPlugin(
+      ("com.typesafe.play" % "sbt-plugin" % Dependencies.PlayVersion)
+        .exclude("org.slf4j", "slf4j-simple")
+        .exclude("com.lightbend.play", "play-file-watch")),
+    libraryDependencies += "com.lightbend.play" %% "play-file-watch" % Dependencies.PlayFileWatchVersion,
     scriptedDependencies := {
       val () = scriptedDependencies.value
       val () = publishLocal.value

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
   val PlayVersion = "2.6.3" // if you update this, you probably need to update the following two
   val PlayJsonVersion = "2.6.3"
   val PlayStandaloneWsVersion = "1.0.4"
+  val PlayFileWatchVersion = "1.1.0"
 
   val AkkaVersion = "2.5.4"
   val AkkaHttpVersion = "10.0.9"
@@ -585,7 +586,7 @@ object Dependencies {
   )
 
   val `build-tool-support` = libraryDependencies ++= Seq(
-    "com.lightbend.play" %% "play-file-watch" % "1.0.1",
+    "com.lightbend.play" %% "play-file-watch" % PlayFileWatchVersion,
     playExceptions,
     playBuildLink,
     // This is used in the code to check if the embedded cassandra server is started


### PR DESCRIPTION
This uses the new version of play-file-watch with a custom WatchService for macOS instead of using JNotify.

We've decided not to update it on the Play stable version until it's been tested a bit. Though I do not expect any problems, I think it makes sense to test in the milestones for Lagom where it is less risky but will still see some actual users.