### PR TITLE
ReadSide should honour BackoffSupervision.

### DIFF
--- a/persistence-jdbc/javadsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-jdbc/javadsl/src/multi-jvm/resources/reference.conf
@@ -9,7 +9,4 @@ lagom.persistence {
     max = 2 s
     random-factor = 0.2
   }
-  cluster.distribution {
-    ensure-active-interval = 4s
-  }
 }

--- a/persistence-jdbc/scaladsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-jdbc/scaladsl/src/multi-jvm/resources/reference.conf
@@ -7,7 +7,4 @@ lagom.persistence {
     max = 2 s
     random-factor = 0.2
   }
-  cluster.distribution {
-    ensure-active-interval = 4s
-  }
 }

--- a/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterDistribution.scala
+++ b/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterDistribution.scala
@@ -91,14 +91,10 @@ class ClusterDistribution(system: ExtendedActorSystem) extends Extension {
     val extractEntityId: ShardRegion.ExtractEntityId = {
       case msg @ EnsureActive(entityId) => (entityId, msg)
     }
-    val extractShardId: ShardRegion.ExtractShardId = if (entityIds.size > MaxShards) {
-      {
-        case EnsureActive(entityId) => Math.abs(entityId.hashCode % 1000).toString
-      }
-    } else {
-      {
-        case EnsureActive(entityId) => entityId
-      }
+
+    val extractShardId: ShardRegion.ExtractShardId = {
+      case EnsureActive(entityId) if entityIds.size > MaxShards => Math.abs(entityId.hashCode % 1000).toString
+      case EnsureActive(entityId)                               => entityId
     }
 
     val sharding = ClusterSharding(system)

--- a/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterStartupTask.scala
+++ b/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterStartupTask.scala
@@ -86,7 +86,9 @@ class ClusterStartupTask(actorRef: ActorRef) {
 }
 
 private[lagom] object ClusterStartupTaskActor {
+
   case object Execute
+
 }
 
 private[lagom] class ClusterStartupTaskActor(task: () => Future[Done], timeout: FiniteDuration) extends Actor with ActorLogging {

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -103,7 +103,6 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
     case Done =>
       throw new IllegalStateException("Stream terminated when it shouldn't")
 
-
   }
 
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
@@ -10,10 +10,13 @@ import javax.inject.{ Inject, Provider, Singleton }
 import akka.actor.{ ActorSystem, SupervisorStrategy }
 import akka.cluster.Cluster
 import akka.cluster.sharding.ClusterShardingSettings
+import akka.cluster.sharding.ShardRegion.{ EntityId, StartEntity }
 import akka.pattern.BackoffSupervisor
 import akka.stream.Materializer
 import com.google.inject.Injector
+import com.lightbend.lagom.internal.javadsl.persistence.ReadSideTagHolderActor.{ GetTag, CachedTag }
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
+import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.{ ClusterDistribution, ClusterDistributionSettings, ClusterStartupTask }
 import com.lightbend.lagom.javadsl.persistence._
 import com.typesafe.config.Config
@@ -49,7 +52,8 @@ private[lagom] class ReadSideImpl @Inject() (
   }
 
   private[lagom] def registerFactory[Event <: AggregateEvent[Event]](
-    processorFactory: () => ReadSideProcessor[Event], clazz: Class[_]
+    processorFactory: () => ReadSideProcessor[Event],
+    clazz:            Class[_]
   ) = {
 
     // Only run if we're configured to run on this role
@@ -71,27 +75,116 @@ private[lagom] class ReadSideImpl @Inject() (
         case None      => throw new IllegalArgumentException(s"ReadSideProcessor ${clazz.getName} returned 0 tags")
       }
 
-      val globalPrepareTask = ClusterStartupTask(
-        system, s"readSideGlobalPrepare-$encodedReadSideName",
-        () => processorFactory().buildHandler().globalPrepare().toScala,
-        config.globalPrepareTimeout, config.role, config.minBackoff, config.maxBackoff, config.randomBackoffFactor
-      )
+      val globalPrepareTask: ClusterStartupTask =
+        ClusterStartupTask(
+          system,
+          s"readSideGlobalPrepare-$encodedReadSideName",
+          () => processorFactory().buildHandler().globalPrepare().toScala,
+          config.globalPrepareTimeout,
+          config.role,
+          config.minBackoff,
+          config.maxBackoff,
+          config.randomBackoffFactor
+        )
 
-      val processorProps = ReadSideActor.props(processorFactory, registry.eventStream[Event], eventClass, globalPrepareTask, config.globalPrepareTimeout)
-
-      val backoffProps = BackoffSupervisor.propsWithSupervisorStrategy(
-        processorProps, "processor", config.minBackoff, config.maxBackoff, config.randomBackoffFactor, SupervisorStrategy.stoppingStrategy
-      )
+      val readSideProps =
+        ReadSideTagHolderActor.props(
+          config,
+          globalPrepareTask,
+          processorFactory,
+          registry,
+          eventClass
+        )
 
       val shardingSettings = ClusterShardingSettings(system).withRole(config.role)
 
       ClusterDistribution(system).start(
         readSideName,
-        backoffProps,
+        readSideProps,
         entityIds.toSet,
         ClusterDistributionSettings(system).copy(clusterShardingSettings = shardingSettings)
       )
     }
 
   }
+}
+
+import akka.actor.{ Actor, Props }
+
+object ReadSideTagHolderActor {
+  def props[Event <: AggregateEvent[Event]](
+    config:            ReadSideConfig,
+    globalPrepareTask: ClusterStartupTask,
+    processorFactory:  () => ReadSideProcessor[Event],
+    registry:          PersistentEntityRegistry,
+    eventClass:        Class[Event]
+  )(implicit mat: Materializer): Props =
+    Props(
+      new ReadSideTagHolderActor(
+        config,
+        globalPrepareTask: ClusterStartupTask, processorFactory,
+        registry,
+        eventClass
+      )(
+        mat
+      )
+    )
+
+  // A ReadSideTagHolder is a 1:1 relation to a ReadSideActor. The difference is that
+  // the ReadSideActor may die and be respawned by a supervisor while the ReadSideTagHolderActor
+  // is a sharded actor that may only be respawned by EnsureActive.
+  // because those two respawn operations have different frequencies the TagHolder is provided
+  // as a cache for the ReadSideActor to retart faster when it crashes.
+  case object GetTag
+  case class CachedTag(tag: EntityId)
+
+}
+
+// A ReadSideActor consumes a shard of the whole event stream. That operation
+// happens inside a node of cluster. Akka Cluster Sharding is used to distribute
+// the tags across the cluster. The distribution of tags happens on a keep-alive
+// loop provided in ClusterDistribution.
+// So, each node start a ClusterDistribution and a ShardRegion. Then the
+// ClusterDistribution runs an infinite loop that constantly sends  all required
+// tags to the ShradRegion. The ShardRegion distributes the information to each
+// appropriate node where each local ShardRegion redirects each
+class ReadSideTagHolderActor[Event <: AggregateEvent[Event]](
+  config:            ReadSideConfig,
+  globalPrepareTask: ClusterStartupTask,
+  processorFactory:  () => ReadSideProcessor[Event],
+  registry:          PersistentEntityRegistry,
+  eventClass:        Class[Event]
+)(implicit mat: Materializer) extends Actor {
+  override def receive = {
+    case EnsureActive(tag) =>
+
+      val processorProps =
+        ReadSideActor.props(
+          processorFactory,
+          registry.eventStream[Event],
+          eventClass,
+          globalPrepareTask,
+          config.globalPrepareTimeout,
+          self
+        )
+
+      val backoffProps =
+        BackoffSupervisor.propsWithSupervisorStrategy(
+          processorProps,
+          "processor",
+          config.minBackoff,
+          config.maxBackoff,
+          config.randomBackoffFactor,
+          SupervisorStrategy.stoppingStrategy
+        )
+      context.actorOf(backoffProps)
+      context.become(started(tag))
+  }
+
+  def started(tag: EntityId): Receive = {
+    case GetTag         => sender() ! CachedTag(tag)
+    case StartEntity(_) =>
+    // already started, nothing to do here
+  }
+
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
@@ -4,28 +4,21 @@
 package com.lightbend.lagom.internal.javadsl.persistence
 
 import java.net.URLEncoder
-import java.util.concurrent.TimeUnit
 import javax.inject.{ Inject, Provider, Singleton }
 
-import akka.actor.{ ActorSystem, SupervisorStrategy }
+import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.cluster.sharding.ClusterShardingSettings
-import akka.cluster.sharding.ShardRegion.{ EntityId, StartEntity }
-import akka.pattern.BackoffSupervisor
 import akka.stream.Materializer
 import com.google.inject.Injector
-import com.lightbend.lagom.internal.javadsl.persistence.ReadSideTagHolderActor.{ GetTag, CachedTag }
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.{ ClusterDistribution, ClusterDistributionSettings, ClusterStartupTask }
 import com.lightbend.lagom.javadsl.persistence._
 import com.typesafe.config.Config
-import play.api.Configuration
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 @Singleton
@@ -88,12 +81,12 @@ private[lagom] class ReadSideImpl @Inject() (
         )
 
       val readSideProps =
-        ReadSideTagHolderActor.props(
+        ReadSideActor.props(
           config,
+          eventClass,
           globalPrepareTask,
-          processorFactory,
-          registry,
-          eventClass
+          registry.eventStream[Event],
+          processorFactory
         )
 
       val shardingSettings = ClusterShardingSettings(system).withRole(config.role)
@@ -107,84 +100,4 @@ private[lagom] class ReadSideImpl @Inject() (
     }
 
   }
-}
-
-import akka.actor.{ Actor, Props }
-
-object ReadSideTagHolderActor {
-  def props[Event <: AggregateEvent[Event]](
-    config:            ReadSideConfig,
-    globalPrepareTask: ClusterStartupTask,
-    processorFactory:  () => ReadSideProcessor[Event],
-    registry:          PersistentEntityRegistry,
-    eventClass:        Class[Event]
-  )(implicit mat: Materializer): Props =
-    Props(
-      new ReadSideTagHolderActor(
-        config,
-        globalPrepareTask: ClusterStartupTask, processorFactory,
-        registry,
-        eventClass
-      )(
-        mat
-      )
-    )
-
-  // A ReadSideTagHolder is a 1:1 relation to a ReadSideActor. The difference is that
-  // the ReadSideActor may die and be respawned by a supervisor while the ReadSideTagHolderActor
-  // is a sharded actor that may only be respawned by EnsureActive.
-  // because those two respawn operations have different frequencies the TagHolder is provided
-  // as a cache for the ReadSideActor to retart faster when it crashes.
-  case object GetTag
-  case class CachedTag(tag: EntityId)
-
-}
-
-// A ReadSideActor consumes a shard of the whole event stream. That operation
-// happens inside a node of cluster. Akka Cluster Sharding is used to distribute
-// the tags across the cluster. The distribution of tags happens on a keep-alive
-// loop provided in ClusterDistribution.
-// So, each node start a ClusterDistribution and a ShardRegion. Then the
-// ClusterDistribution runs an infinite loop that constantly sends  all required
-// tags to the ShradRegion. The ShardRegion distributes the information to each
-// appropriate node where each local ShardRegion redirects each
-class ReadSideTagHolderActor[Event <: AggregateEvent[Event]](
-  config:            ReadSideConfig,
-  globalPrepareTask: ClusterStartupTask,
-  processorFactory:  () => ReadSideProcessor[Event],
-  registry:          PersistentEntityRegistry,
-  eventClass:        Class[Event]
-)(implicit mat: Materializer) extends Actor {
-  override def receive = {
-    case EnsureActive(tag) =>
-
-      val processorProps =
-        ReadSideActor.props(
-          processorFactory,
-          registry.eventStream[Event],
-          eventClass,
-          globalPrepareTask,
-          config.globalPrepareTimeout,
-          self
-        )
-
-      val backoffProps =
-        BackoffSupervisor.propsWithSupervisorStrategy(
-          processorProps,
-          "processor",
-          config.minBackoff,
-          config.maxBackoff,
-          config.randomBackoffFactor,
-          SupervisorStrategy.stoppingStrategy
-        )
-      context.actorOf(backoffProps)
-      context.become(started(tag))
-  }
-
-  def started(tag: EntityId): Receive = {
-    case GetTag         => sender() ! CachedTag(tag)
-    case StartEntity(_) =>
-    // already started, nothing to do here
-  }
-
 }

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
@@ -6,26 +6,27 @@ package com.lightbend.lagom.javadsl.persistence
 import java.util.Optional
 import java.util.concurrent.CompletionStage
 
-import akka.actor.ActorRef
+import akka.actor.{ Actor, ActorRef, Props, SupervisorStrategy }
+import akka.cluster.sharding.ShardRegion.EntityId
+import akka.pattern.{ BackoffSupervisor, pipe }
 import akka.stream.ActorMaterializer
 import akka.stream.javadsl.Source
 import akka.testkit.ImplicitSender
 import akka.{ Done, NotUsed }
+import com.lightbend.lagom.internal.javadsl.persistence.ReadSideTagHolderActor.{ CachedTag, GetTag }
 import com.lightbend.lagom.internal.javadsl.persistence.{ PersistentEntityActor, ReadSideActor }
-import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
-import com.lightbend.lagom.javadsl.persistence.Offset.{ Sequence, TimeBasedUUID }
 import com.lightbend.lagom.javadsl.persistence.TestEntity.Mode
 import com.lightbend.lagom.persistence.ActorSystemSpec
-import com.lightbend.lagom.spi.persistence.OffsetStore
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
+
 import scala.compat.java8.FutureConverters._
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
-trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventually with BeforeAndAfter { spec: ActorSystemSpec =>
+trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventually with BeforeAndAfter {
+  spec: ActorSystemSpec =>
 
   import system.dispatcher
 
@@ -62,28 +63,37 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
     )
   }
 
+  class Mock(tagName: EntityId) extends Actor {
+    def receive = {
+      case Execute =>
+        processorFactory()
+          .buildHandler
+          .globalPrepare()
+          .toScala
+          .map { _ => Done } pipeTo sender()
+
+      case GetTag =>
+        sender() ! CachedTag(tagName)
+    }
+  }
+
   private def createReadSideProcessor() = {
-    /* read side and injector only needed for deprecated register method */
-    val readSide = system.actorOf(
-      ReadSideActor.props[TestEntity.Evt](
-        processorFactory,
-        eventStream,
-        classOf[TestEntity.Evt],
-        new ClusterStartupTask(testActor),
-        20.seconds
-      )
+    val mockRef = system.actorOf(Props(new Mock(tag.tag)))
+    val processorProps = ReadSideActor.props[TestEntity.Evt](
+      processorFactory,
+      eventStream,
+      classOf[TestEntity.Evt],
+      new ClusterStartupTask(mockRef),
+      5.seconds,
+      mockRef
     )
 
-    readSide ! EnsureActive(tag.tag)
-
-    expectMsg(Execute)
-
-    processorFactory()
-      .buildHandler()
-      .globalPrepare().toScala
-      .foreach { _ =>
-        readSide ! Done
-      }
+    val readSide: ActorRef =
+      system.actorOf(
+        BackoffSupervisor.propsWithSupervisorStrategy(
+          processorProps, "processor", 500.milliseconds, 1.second, 0.2, SupervisorStrategy.stoppingStrategy
+        )
+      )
 
     readSideActor = Some(readSide)
   }

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
@@ -4,7 +4,7 @@
 package com.lightbend.lagom.internal.scaladsl.persistence
 
 import akka.{ Done, NotUsed }
-import akka.actor.{ Actor, ActorLogging, Props, Status }
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props, Status }
 import akka.persistence.query.Offset
 import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.{ Keep, Sink }
@@ -12,9 +12,10 @@ import akka.stream.{ KillSwitch, KillSwitches, Materializer }
 import akka.util.Timeout
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
+import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideTagHolderActor.{ CachedTag, GetTag }
 import com.lightbend.lagom.scaladsl.persistence._
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 private[lagom] object ReadSideActor {
 
@@ -23,9 +24,10 @@ private[lagom] object ReadSideActor {
     eventStreamFactory:   (AggregateEventTag[Event], Offset) => Source[EventStreamElement[Event], NotUsed],
     clazz:                Class[Event],
     globalPrepareTask:    ClusterStartupTask,
-    globalPrepareTimeout: FiniteDuration
+    globalPrepareTimeout: FiniteDuration,
+    tagHolder:            ActorRef
   )(implicit mat: Materializer) = {
-    Props(classOf[ReadSideActor[Event]], processor, eventStreamFactory, clazz, globalPrepareTask, globalPrepareTimeout, mat)
+    Props(classOf[ReadSideActor[Event]], processor, eventStreamFactory, clazz, globalPrepareTask, globalPrepareTimeout, tagHolder, mat)
   }
 
   /**
@@ -42,7 +44,8 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
   eventStreamFactory:   (AggregateEventTag[Event], Offset) => Source[EventStreamElement[Event], NotUsed],
   clazz:                Class[Event],
   globalPrepareTask:    ClusterStartupTask,
-  globalPrepareTimeout: FiniteDuration
+  globalPrepareTimeout: FiniteDuration,
+  tagHolder:            ActorRef
 )(implicit mat: Materializer) extends Actor with ActorLogging {
   import ReadSideActor._
   import akka.pattern.pipe
@@ -51,12 +54,18 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
 
   private var shutdown: Option[KillSwitch] = None
 
+  override def preStart(): Unit = {
+    super.preStart()
+    implicit val timeout = Timeout(Duration(100, "millis"))
+    (tagHolder ? GetTag) pipeTo self
+  }
+
   override def postStop: Unit = {
     shutdown.foreach(_.shutdown())
   }
 
   def receive = {
-    case EnsureActive(tagName) =>
+    case CachedTag(tagName) =>
 
       val tag = new AggregateEventTag(clazz, tagName)
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
@@ -3,97 +3,91 @@
  */
 package com.lightbend.lagom.internal.scaladsl.persistence
 
-import akka.{ Done, NotUsed }
-import akka.actor.{ Actor, ActorLogging, ActorRef, Props, Status }
+import akka.actor.{ Actor, ActorLogging, Props, Status }
+import akka.cluster.sharding.ShardRegion.EntityId
 import akka.persistence.query.Offset
-import akka.stream.scaladsl.Source
-import akka.stream.scaladsl.{ Keep, Sink }
+import akka.stream.scaladsl.{ Keep, RestartSource, Sink, Source }
 import akka.stream.{ KillSwitch, KillSwitches, Materializer }
 import akka.util.Timeout
+import akka.{ Done, NotUsed }
+import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
-import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideTagHolderActor.{ CachedTag, GetTag }
 import com.lightbend.lagom.scaladsl.persistence._
-
-import scala.concurrent.duration.{ Duration, FiniteDuration }
 
 private[lagom] object ReadSideActor {
 
   def props[Event <: AggregateEvent[Event]](
-    processor:            () => ReadSideProcessor[Event],
-    eventStreamFactory:   (AggregateEventTag[Event], Offset) => Source[EventStreamElement[Event], NotUsed],
-    clazz:                Class[Event],
-    globalPrepareTask:    ClusterStartupTask,
-    globalPrepareTimeout: FiniteDuration,
-    tagHolder:            ActorRef
+    config:             ReadSideConfig,
+    clazz:              Class[Event],
+    globalPrepareTask:  ClusterStartupTask,
+    eventStreamFactory: (AggregateEventTag[Event], Offset) => Source[EventStreamElement[Event], NotUsed],
+    processor:          () => ReadSideProcessor[Event]
   )(implicit mat: Materializer) = {
-    Props(classOf[ReadSideActor[Event]], processor, eventStreamFactory, clazz, globalPrepareTask, globalPrepareTimeout, tagHolder, mat)
+    Props(
+      classOf[ReadSideActor[Event]],
+      config,
+      clazz,
+      globalPrepareTask,
+      eventStreamFactory,
+      processor,
+      mat
+    )
   }
 
-  /**
-   * Start processing from the given offset
-   */
-  case class Start(offset: Offset)
+  case object Start
+
 }
 
 /**
  * Read side actor
  */
 private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
-  processorFactory:     () => ReadSideProcessor[Event],
-  eventStreamFactory:   (AggregateEventTag[Event], Offset) => Source[EventStreamElement[Event], NotUsed],
-  clazz:                Class[Event],
-  globalPrepareTask:    ClusterStartupTask,
-  globalPrepareTimeout: FiniteDuration,
-  tagHolder:            ActorRef
+  config:             ReadSideConfig,
+  clazz:              Class[Event],
+  globalPrepareTask:  ClusterStartupTask,
+  eventStreamFactory: (AggregateEventTag[Event], Offset) => Source[EventStreamElement[Event], NotUsed],
+  processor:          () => ReadSideProcessor[Event]
 )(implicit mat: Materializer) extends Actor with ActorLogging {
+
   import ReadSideActor._
   import akka.pattern.pipe
-  import akka.pattern.ask
   import context.dispatcher
 
   private var shutdown: Option[KillSwitch] = None
-
-  override def preStart(): Unit = {
-    super.preStart()
-    implicit val timeout = Timeout(Duration(100, "millis"))
-    (tagHolder ? GetTag) pipeTo self
-  }
 
   override def postStop: Unit = {
     shutdown.foreach(_.shutdown())
   }
 
   def receive = {
-    case CachedTag(tagName) =>
+    case EnsureActive(tagName) =>
+      implicit val timeout = Timeout(config.globalPrepareTimeout)
+      globalPrepareTask.askExecute().map { _ => Start } pipeTo self
+      context.become(start(tagName))
+  }
+
+  def start(tagName: EntityId): Receive = {
+    case Start =>
 
       val tag = new AggregateEventTag(clazz, tagName)
+      val backoffSource = RestartSource.withBackoff(
+        config.minBackoff,
+        config.maxBackoff,
+        config.randomBackoffFactor
+      ) { () =>
+        val handler = processor().buildHandler
+        val futureOffset = handler.prepare(tag)
+        Source.fromFuture(futureOffset).flatMapConcat {
+          offset =>
+            val eventStreamSource = eventStreamFactory(tag, offset)
+            val userlandFlow = handler.handle()
+            eventStreamSource.via(userlandFlow)
+        }
+      }
 
-      implicit val timeout = Timeout(globalPrepareTimeout)
-
-      globalPrepareTask.askExecute() pipeTo self
-      context become preparing(tag)
-  }
-
-  def preparing(tag: AggregateEventTag[Event]): Receive = {
-
-    case Done =>
-      val handler = processorFactory().buildHandler
-      handler.prepare(tag).map(Start(_)) pipeTo self
-      context become active(handler, tag)
-
-    case Status.Failure(e) =>
-      throw e
-
-  }
-
-  def active(handler: ReadSideProcessor.ReadSideHandler[Event], tag: AggregateEventTag[Event]): Receive = {
-
-    case Start(offset) =>
-
-      val (killSwitch, streamDone) = eventStreamFactory(tag, offset)
+      val (killSwitch, streamDone) = backoffSource
         .viaMat(KillSwitches.single)(Keep.right)
-        .via(handler.handle())
         .toMat(Sink.ignore)(Keep.both)
         .run()
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
@@ -5,16 +5,12 @@ package com.lightbend.lagom.internal.scaladsl.persistence
 
 import java.net.URLEncoder
 
-import akka.actor.{ ActorSystem, SupervisorStrategy }
+import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.cluster.sharding.ClusterShardingSettings
-import akka.cluster.sharding.ShardRegion.{ EntityId, StartEntity }
-import akka.pattern.BackoffSupervisor
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
-import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.{ ClusterDistribution, ClusterDistributionSettings, ClusterStartupTask }
-import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideTagHolderActor.{ CachedTag, GetTag }
 import com.lightbend.lagom.scaladsl.persistence._
 
 import scala.concurrent.ExecutionContext
@@ -56,12 +52,12 @@ private[lagom] class ReadSideImpl(
         )
 
       val readSideProps =
-        ReadSideTagHolderActor.props(
+        ReadSideActor.props(
           config,
+          eventClass,
           globalPrepareTask,
-          processorFactory,
-          registry,
-          eventClass
+          registry.eventStream[Event],
+          processorFactory
         )
 
       val shardingSettings = ClusterShardingSettings(system).withRole(config.role)
@@ -75,84 +71,4 @@ private[lagom] class ReadSideImpl(
     }
 
   }
-}
-
-import akka.actor.{ Actor, Props }
-
-object ReadSideTagHolderActor {
-  def props[Event <: AggregateEvent[Event]](
-    config:            ReadSideConfig,
-    globalPrepareTask: ClusterStartupTask,
-    processorFactory:  () => ReadSideProcessor[Event],
-    registry:          PersistentEntityRegistry,
-    eventClass:        Class[Event]
-  )(implicit mat: Materializer): Props =
-    Props(
-      new ReadSideTagHolderActor(
-        config,
-        globalPrepareTask: ClusterStartupTask, processorFactory,
-        registry,
-        eventClass
-      )(
-        mat
-      )
-    )
-
-  // A ReadSideTagHolder is a 1:1 relation to a ReadSideActor. The difference is that
-  // the ReadSideActor may die and be respawned by a supervisor while the ReadSideTagHolderActor
-  // is a sharded actor that may only be respawned by EnsureActive.
-  // because those two respawn operations have different frequencies the TagHolder is provided
-  // as a cache for the ReadSideActor to retart faster when it crashes.
-  case object GetTag
-  case class CachedTag(tag: EntityId)
-
-}
-
-// A ReadSideActor consumes a shard of the whole event stream. That operation
-// happens inside a node of cluster. Akka Cluster Sharding is used to distribute
-// the tags across the cluster. The distribution of tags happens on a keep-alive
-// loop provided in ClusterDistribution.
-// So, each node start a ClusterDistribution and a ShardRegion. Then the
-// ClusterDistribution runs an infinite loop that constantly sends  all required
-// tags to the ShradRegion. The ShardRegion distributes the information to each
-// appropriate node where each local ShardRegion redirects each
-class ReadSideTagHolderActor[Event <: AggregateEvent[Event]](
-  config:            ReadSideConfig,
-  globalPrepareTask: ClusterStartupTask,
-  processorFactory:  () => ReadSideProcessor[Event],
-  registry:          PersistentEntityRegistry,
-  eventClass:        Class[Event]
-)(implicit mat: Materializer) extends Actor {
-  override def receive = {
-    case EnsureActive(tag) =>
-
-      val processorProps =
-        ReadSideActor.props(
-          processorFactory,
-          registry.eventStream[Event],
-          eventClass,
-          globalPrepareTask,
-          config.globalPrepareTimeout,
-          self
-        )
-
-      val backoffProps =
-        BackoffSupervisor.propsWithSupervisorStrategy(
-          processorProps,
-          "processor",
-          config.minBackoff,
-          config.maxBackoff,
-          config.randomBackoffFactor,
-          SupervisorStrategy.stoppingStrategy
-        )
-      context.actorOf(backoffProps)
-      context.become(started(tag))
-  }
-
-  def started(tag: EntityId): Receive = {
-    case GetTag         => sender() ! CachedTag(tag)
-    case StartEntity(_) =>
-    // already started, nothing to do here
-  }
-
 }

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
@@ -8,10 +8,13 @@ import java.net.URLEncoder
 import akka.actor.{ ActorSystem, SupervisorStrategy }
 import akka.cluster.Cluster
 import akka.cluster.sharding.ClusterShardingSettings
+import akka.cluster.sharding.ShardRegion.{ EntityId, StartEntity }
 import akka.pattern.BackoffSupervisor
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
+import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.{ ClusterDistribution, ClusterDistributionSettings, ClusterStartupTask }
+import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideTagHolderActor.{ CachedTag, GetTag }
 import com.lightbend.lagom.scaladsl.persistence._
 
 import scala.concurrent.ExecutionContext
@@ -40,27 +43,116 @@ private[lagom] class ReadSideImpl(
         case None      => throw new IllegalArgumentException(s"ReadSideProcessor ${proto.getClass.getName} returned 0 tags")
       }
 
-      val globalPrepareTask = ClusterStartupTask(
-        system, s"readSideGlobalPrepare-$encodedReadSideName",
-        () => processorFactory().buildHandler.globalPrepare(),
-        config.globalPrepareTimeout, config.role, config.minBackoff, config.maxBackoff, config.randomBackoffFactor
-      )
+      val globalPrepareTask: ClusterStartupTask =
+        ClusterStartupTask(
+          system,
+          s"readSideGlobalPrepare-$encodedReadSideName",
+          () => processorFactory().buildHandler().globalPrepare(),
+          config.globalPrepareTimeout,
+          config.role,
+          config.minBackoff,
+          config.maxBackoff,
+          config.randomBackoffFactor
+        )
 
-      val processorProps = ReadSideActor.props(processorFactory, registry.eventStream[Event], eventClass, globalPrepareTask, config.globalPrepareTimeout)
-
-      val backoffProps = BackoffSupervisor.propsWithSupervisorStrategy(
-        processorProps, "processor", config.minBackoff, config.maxBackoff, config.randomBackoffFactor, SupervisorStrategy.stoppingStrategy
-      )
+      val readSideProps =
+        ReadSideTagHolderActor.props(
+          config,
+          globalPrepareTask,
+          processorFactory,
+          registry,
+          eventClass
+        )
 
       val shardingSettings = ClusterShardingSettings(system).withRole(config.role)
 
       ClusterDistribution(system).start(
         readSideName,
-        backoffProps,
-        entityIds.toSet,
+        readSideProps,
+        entityIds,
         ClusterDistributionSettings(system).copy(clusterShardingSettings = shardingSettings)
       )
     }
 
   }
+}
+
+import akka.actor.{ Actor, Props }
+
+object ReadSideTagHolderActor {
+  def props[Event <: AggregateEvent[Event]](
+    config:            ReadSideConfig,
+    globalPrepareTask: ClusterStartupTask,
+    processorFactory:  () => ReadSideProcessor[Event],
+    registry:          PersistentEntityRegistry,
+    eventClass:        Class[Event]
+  )(implicit mat: Materializer): Props =
+    Props(
+      new ReadSideTagHolderActor(
+        config,
+        globalPrepareTask: ClusterStartupTask, processorFactory,
+        registry,
+        eventClass
+      )(
+        mat
+      )
+    )
+
+  // A ReadSideTagHolder is a 1:1 relation to a ReadSideActor. The difference is that
+  // the ReadSideActor may die and be respawned by a supervisor while the ReadSideTagHolderActor
+  // is a sharded actor that may only be respawned by EnsureActive.
+  // because those two respawn operations have different frequencies the TagHolder is provided
+  // as a cache for the ReadSideActor to retart faster when it crashes.
+  case object GetTag
+  case class CachedTag(tag: EntityId)
+
+}
+
+// A ReadSideActor consumes a shard of the whole event stream. That operation
+// happens inside a node of cluster. Akka Cluster Sharding is used to distribute
+// the tags across the cluster. The distribution of tags happens on a keep-alive
+// loop provided in ClusterDistribution.
+// So, each node start a ClusterDistribution and a ShardRegion. Then the
+// ClusterDistribution runs an infinite loop that constantly sends  all required
+// tags to the ShradRegion. The ShardRegion distributes the information to each
+// appropriate node where each local ShardRegion redirects each
+class ReadSideTagHolderActor[Event <: AggregateEvent[Event]](
+  config:            ReadSideConfig,
+  globalPrepareTask: ClusterStartupTask,
+  processorFactory:  () => ReadSideProcessor[Event],
+  registry:          PersistentEntityRegistry,
+  eventClass:        Class[Event]
+)(implicit mat: Materializer) extends Actor {
+  override def receive = {
+    case EnsureActive(tag) =>
+
+      val processorProps =
+        ReadSideActor.props(
+          processorFactory,
+          registry.eventStream[Event],
+          eventClass,
+          globalPrepareTask,
+          config.globalPrepareTimeout,
+          self
+        )
+
+      val backoffProps =
+        BackoffSupervisor.propsWithSupervisorStrategy(
+          processorProps,
+          "processor",
+          config.minBackoff,
+          config.maxBackoff,
+          config.randomBackoffFactor,
+          SupervisorStrategy.stoppingStrategy
+        )
+      context.actorOf(backoffProps)
+      context.become(started(tag))
+  }
+
+  def started(tag: EntityId): Receive = {
+    case GetTag         => sender() ! CachedTag(tag)
+    case StartEntity(_) =>
+    // already started, nothing to do here
+  }
+
 }

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -3,18 +3,17 @@
  */
 package com.lightbend.lagom.scaladsl.persistence
 
-import akka.actor.{ Actor, ActorRef, Props, SupervisorStrategy }
-import akka.cluster.sharding.ShardRegion.EntityId
-import akka.pattern.{ BackoffSupervisor, pipe }
+import akka.actor.{ Actor, ActorRef, Props }
+import akka.pattern.pipe
 import akka.persistence.query.Offset
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.testkit.ImplicitSender
 import akka.{ Done, NotUsed }
+import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
-import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideTagHolderActor.{ CachedTag, GetTag }
 import com.lightbend.lagom.internal.scaladsl.persistence.{ PersistentEntityActor, ReadSideActor }
 import com.lightbend.lagom.persistence.ActorSystemSpec
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Mode
@@ -62,39 +61,32 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
     )
   }
 
-  class Mock(tagName: EntityId) extends Actor {
+  class Mock() extends Actor {
     def receive = {
       case Execute =>
         processorFactory()
           .buildHandler
           .globalPrepare()
           .map { _ => Done } pipeTo sender()
-      case GetTag =>
-        sender() ! CachedTag(tagName)
     }
   }
 
   private def createReadSideProcessor() = {
-    /* read side and injector only needed for deprecated register method */
-
-    val mockRef = system.actorOf(Props(new Mock(tag.tag)))
+    val mockRef = system.actorOf(Props(new Mock()))
     val processorProps = ReadSideActor.props[TestEntity.Evt](
-      processorFactory,
-      eventStream,
+      ReadSideConfig(),
       classOf[TestEntity.Evt],
       new ClusterStartupTask(mockRef),
-      5.seconds,
-      mockRef
+      eventStream,
+      processorFactory
     )
 
-    val readSide: ActorRef =
-      system.actorOf(
-        BackoffSupervisor.propsWithSupervisorStrategy(
-          processorProps, "processor", 500.milliseconds, 1.second, 0.2, SupervisorStrategy.stoppingStrategy
-        )
-      )
+    val readSide: ActorRef = system.actorOf(processorProps)
+
+    readSide ! EnsureActive(tag.tag)
 
     readSideActor = Some(readSide)
+
   }
 
   after {

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -4,6 +4,7 @@
 package com.lightbend.lagom.scaladsl.persistence
 
 import akka.actor.{ Actor, ActorRef, Props, SupervisorStrategy }
+import akka.cluster.sharding.ShardRegion.EntityId
 import akka.pattern.{ BackoffSupervisor, pipe }
 import akka.persistence.query.Offset
 import akka.stream.ActorMaterializer
@@ -13,6 +14,7 @@ import akka.{ Done, NotUsed }
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
+import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideTagHolderActor.{ CachedTag, GetTag }
 import com.lightbend.lagom.internal.scaladsl.persistence.{ PersistentEntityActor, ReadSideActor }
 import com.lightbend.lagom.persistence.ActorSystemSpec
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Mode
@@ -60,27 +62,29 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
     )
   }
 
-  class AlwaysReplyDone extends Actor {
+  class Mock(tagName: EntityId) extends Actor {
     def receive = {
       case Execute =>
-
         processorFactory()
           .buildHandler
           .globalPrepare()
           .map { _ => Done } pipeTo sender()
-
+      case GetTag =>
+        sender() ! CachedTag(tagName)
     }
   }
 
   private def createReadSideProcessor() = {
     /* read side and injector only needed for deprecated register method */
 
+    val mockRef = system.actorOf(Props(new Mock(tag.tag)))
     val processorProps = ReadSideActor.props[TestEntity.Evt](
       processorFactory,
       eventStream,
       classOf[TestEntity.Evt],
-      new ClusterStartupTask(system.actorOf(Props(new AlwaysReplyDone))),
-      3.seconds
+      new ClusterStartupTask(mockRef),
+      5.seconds,
+      mockRef
     )
 
     val readSide: ActorRef =
@@ -89,8 +93,6 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
           processorProps, "processor", 500.milliseconds, 1.second, 0.2, SupervisorStrategy.stoppingStrategy
         )
       )
-
-    system.scheduler.schedule(Duration.Zero, 1.second, readSide, EnsureActive(tag.tag))
 
     readSideActor = Some(readSide)
   }


### PR DESCRIPTION
Fixes part of  #1006. 

This PR addresses the problem where a `ReadSideActor` that was just restarted by the BackoffSupervisor would not start consuming from the eventStream because it doesn't know the tag it was assigned. The tag assignment comes from `ClusterDistribution` every 30 seconds.

This PR wraps the stream inside `ReadSideActor` in a `RestartSource`.
