### PR TITLE
Allow no passivation to be configured

### DIFF
--- a/persistence/core/src/main/resources/reference.conf
+++ b/persistence/core/src/main/resources/reference.conf
@@ -20,7 +20,10 @@ lagom.persistence {
   # any messages during this timeout. Passivation is performed to reduce
   # memory consumption. Objects referenced by the entity can be garbage
   # collected after passivation. Next message will activate the entity
-  # again, which will recover its state from persistent storage.  
+  # again, which will recover its state from persistent storage. Set to 0
+  # to disable passivation - this should only be done when the number of
+  # entities is bounded and their state, sharded across the cluster, will
+  # fit in memory.
   passivate-after-idle-timeout = 120s
   
   # Specifies that entities run on cluster nodes with a specific role.

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -52,8 +52,15 @@ abstract class AbstractPersistentEntityRegistry(system: ActorSystem, injector: I
     case "" => None
     case r  => Some(r)
   }
-  private val passivateAfterIdleTimeout: FiniteDuration =
-    conf.getDuration("passivate-after-idle-timeout", TimeUnit.MILLISECONDS).millis
+  private val passivateAfterIdleTimeout: Duration = {
+    val durationMs = conf.getDuration("passivate-after-idle-timeout", TimeUnit.MILLISECONDS)
+    if (durationMs == 0) {
+      // Scaladoc of setReceiveTimeout says "Pass in `Duration.Undefined` to switch off this feature."
+      Duration.Undefined
+    } else {
+      durationMs.millis
+    }
+  }
   private val askTimeout: FiniteDuration = conf.getDuration("ask-timeout", TimeUnit.MILLISECONDS).millis
   private val shardingSettings = ClusterShardingSettings(system).withRole(role)
 

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
@@ -14,7 +14,7 @@ import akka.persistence.RecoveryCompleted
 import akka.persistence.SnapshotOffer
 import akka.util.ByteString
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.Duration
 import akka.actor.ReceiveTimeout
 import akka.cluster.sharding.ShardRegion
 import akka.actor.actorRef2Scala
@@ -31,7 +31,7 @@ private[lagom] object PersistentEntityActor {
     entityId:                  Optional[String],
     entityFactory:             () => PersistentEntity[C, E, S],
     snapshotAfter:             Optional[Int],
-    passivateAfterIdleTimeout: FiniteDuration
+    passivateAfterIdleTimeout: Duration
   ): Props =
     Props(new PersistentEntityActor(persistenceIdPrefix, entityId, entityFactory(), snapshotAfter.orElse(0),
       passivateAfterIdleTimeout))
@@ -51,7 +51,7 @@ private[lagom] class PersistentEntityActor[C, E, S](
   id:                        Optional[String],
   entity:                    PersistentEntity[C, E, S],
   snapshotAfter:             Int,
-  passivateAfterIdleTimeout: FiniteDuration
+  passivateAfterIdleTimeout: Duration
 ) extends PersistentActor {
   private val log = Logger(this.getClass)
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -50,8 +50,16 @@ abstract class AbstractPersistentEntityRegistry(system: ActorSystem) extends Per
     case "" => None
     case r  => Some(r)
   }
-  private val passivateAfterIdleTimeout: FiniteDuration =
-    conf.getDuration("passivate-after-idle-timeout", TimeUnit.MILLISECONDS).millis
+  private val passivateAfterIdleTimeout: Duration = {
+    val durationMs = conf.getDuration("passivate-after-idle-timeout", TimeUnit.MILLISECONDS)
+    if (durationMs == 0) {
+      // Scaladoc of setReceiveTimeout says "Pass in `Duration.Undefined` to switch off this feature."
+      Duration.Undefined
+    } else {
+      durationMs.millis
+    }
+  }
+
   private val askTimeout: FiniteDuration = conf.getDuration("ask-timeout", TimeUnit.MILLISECONDS).millis
   private val shardingSettings = ClusterShardingSettings(system).withRole(role)
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
@@ -13,7 +13,7 @@ import akka.util.ByteString
 import com.lightbend.lagom.scaladsl.persistence.{ AggregateEvent, AggregateEventShards, AggregateEventTag, PersistentEntity }
 import play.api.Logger
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.Duration
 import scala.util.control.Exception.Catcher
 import scala.util.control.NonFatal
 
@@ -23,7 +23,7 @@ private[lagom] object PersistentEntityActor {
     entityId:                  Option[String],
     entityFactory:             () => PersistentEntity,
     snapshotAfter:             Option[Int],
-    passivateAfterIdleTimeout: FiniteDuration
+    passivateAfterIdleTimeout: Duration
   ): Props =
     Props(new PersistentEntityActor(persistenceIdPrefix, entityId,
       entityFactory(),
@@ -60,7 +60,7 @@ private[lagom] class PersistentEntityActor(
   id:                        Option[String],
   entity:                    PersistentEntity,
   snapshotAfter:             Int,
-  passivateAfterIdleTimeout: FiniteDuration
+  passivateAfterIdleTimeout: Duration
 ) extends PersistentActor {
 
   import PersistentEntityActor.EntityIdSeparator


### PR DESCRIPTION
My primary motivation for implementing this is that I have a use case with a very custom sharding distribution setup (the cluster is divided into multiple failure groups, with fast failover between them when timeouts occur), and so I'm instantiating persistent entity actors as direct children of my own sharded actors, rather than letting Lagom manage them. Because of this, I want/need my own actors to handle passivation, and so need to disable passivation of the persistent entity actors.