### PR TITLE
Adds .gitignore on maven archetype

### DIFF
--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/.gitignore
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/.gitignore
@@ -1,0 +1,15 @@
+target
+ideatarget
+.target
+bin
+.cache
+.cache-main
+.cache-tests
+.classpath
+.project
+.tmpBin
+.factorypath
+.settings
+logs
+.idea
+*.iml


### PR DESCRIPTION
Solves #1013

This `.gitignore` is copied from lagom-scala.g8 but includes also `*.iml` which seems to be created on IntelliJ.