### PR TITLE
Changing the default port for service locator 8000 -> 9008

### DIFF
--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/it/__service2ClassName__IT.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/it/__service2ClassName__IT.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertEquals;
 
 public class ${service2ClassName}IT {
 
-    private static final String SERVICE_LOCATOR_URI = "http://localhost:8000";
+    private static final String SERVICE_LOCATOR_URI = "http://localhost:9008";
 
     private static LagomClientFactory clientFactory;
     private static ${service1ClassName}Service ${service1Name}Service;

--- a/dev/maven-plugin/src/main/maven/plugin.xml
+++ b/dev/maven-plugin/src/main/maven/plugin.xml
@@ -171,7 +171,7 @@
             <editable>true</editable>
             <description>The port to run the service locator on.</description>
             <configuration>
-                <serviceLocatorPort implementation="int" default-value="8000">${service.locator.port}</serviceLocatorPort>
+                <serviceLocatorPort implementation="int" default-value="9008">${service.locator.port}</serviceLocatorPort>
             </configuration>
         </parameter>
         <parameter>

--- a/dev/maven-plugin/src/maven-test/external-project/integration-test/src/test/java/sample/integration/ExternalProjectIT.java
+++ b/dev/maven-plugin/src/maven-test/external-project/integration-test/src/test/java/sample/integration/ExternalProjectIT.java
@@ -20,7 +20,7 @@ public class ExternalProjectIT {
     @BeforeClass
     public static void setup() {
         clientFactory = LagomClientFactory.create("integration-test", ExternalProjectIT.class.getClassLoader());
-        helloService = clientFactory.createDevClient(HelloService.class, URI.create("http://localhost:8000"));
+        helloService = clientFactory.createDevClient(HelloService.class, URI.create("http://localhost:9008"));
     }
 
     @Test

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -405,7 +405,7 @@ object LagomPlugin extends AutoPlugin {
     lagomInfrastructureServices := lagomInfrastructureServicesTask.value,
     lagomServicesPortRange := defaultPortRange,
     lagomServiceLocatorEnabled := true,
-    lagomServiceLocatorPort := 8000,
+    lagomServiceLocatorPort := 9008,
     lagomServiceGatewayPort := 9000,
     lagomServiceGatewayImpl := "akka-http",
     lagomServiceLocatorUrl := s"http://localhost:${lagomServiceLocatorPort.value}",

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/test
@@ -5,7 +5,7 @@
 > runAll
 
 # Check that external service a is registered with the service locator
-> validateRequest retry-until-success http://localhost:8000/services/a status 200
+> validateRequest retry-until-success http://localhost:9008/services/a status 200
 
 # Check that external service a is accessible through the gateway
 > validateRequest retry-until-success http://localhost:9000/hello/World status 200 body-contains Hello body-contains World

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/test
@@ -5,7 +5,7 @@
 > runAll
 
 # Check that external service a is registered with the service locator
-> validateRequest retry-until-success http://localhost:8000/services/a status 200
+> validateRequest retry-until-success http://localhost:9008/services/a status 200
 
 # Check that external service a is accessible through the gateway
 > validateRequest retry-until-success http://localhost:9000/hello/World status 200 body-contains Hello body-contains World

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/test
@@ -8,22 +8,22 @@
 # --------------
 
 # Precondition
-> validateRequest http://localhost:8000 should-be-down
+> validateRequest http://localhost:9008 should-be-down
 
 > lagomServiceLocatorStart
-> validateRequest retry-until-success http://localhost:8000
-> validateRequest http://localhost:8000/services/fooservice status 404
+> validateRequest retry-until-success http://localhost:9008
+> validateRequest http://localhost:9008/services/fooservice status 404
 
 # Check that the external service is started
-> validateRequest http://localhost:8000/services/externalservice status 200
+> validateRequest http://localhost:9008/services/externalservice status 200
 
 # Run the service and check that it eventually gets registered
 > run
-> validateRequest retry-until-success http://localhost:8000/services/fooservice status 200
+> validateRequest retry-until-success http://localhost:9008/services/fooservice status 200
 
 # Stop the service locator and check that it does stop
 > lagomServiceLocatorStop
-> validateRequest retry-until-success http://localhost:8000 should-be-down
+> validateRequest retry-until-success http://localhost:9008 should-be-down
 
 # Stop the service
 > stop
@@ -35,7 +35,7 @@
 # Part 1
 > runAll
 $ sleep 1000
-> validateRequest http://localhost:8000/services should-be-down
+> validateRequest http://localhost:9008/services should-be-down
 > validateFile retry-until-success target/reload.log line-count 1
 
 # Cleanup
@@ -46,17 +46,17 @@ $ sleep 1000
 # ---------------
 
 # Preconditions - ensure everything is down
-> validateRequest http://localhost:8000 should-be-down
+> validateRequest http://localhost:9008 should-be-down
 > validateRequest http://localhost:9000 should-be-down
 
 > runAll
 
 # Ensure everything is up
-> validateRequest retry-until-success http://localhost:8000
+> validateRequest retry-until-success http://localhost:9008
 > validateRequest retry-until-success http://localhost:9000
 
 # Ensure the foo service is reachable
-> validateRequest retry-until-success http://localhost:8000/services/fooservice status 200
+> validateRequest retry-until-success http://localhost:9008/services/fooservice status 200
 > validateRequest http://localhost:9000/foo status 200
 
 # Ensure the foo service can access cassandra
@@ -69,18 +69,18 @@ $ sleep 1000
 > set lagomCassandraEnabled in ThisBuild := false
 
 # Preconditions - ensure everything is down
-> validateRequest http://localhost:8000 should-be-down
+> validateRequest http://localhost:9008 should-be-down
 > validateRequest http://localhost:9000 should-be-down
 > validateRequest http://localhost:9000/foo/cassandra should-be-down
 
 > runAll
 
 # Locator and gateway should be up
-> validateRequest retry-until-success http://localhost:8000
+> validateRequest retry-until-success http://localhost:9008
 > validateRequest retry-until-success http://localhost:9000
 
 # Ensure the foo service is reachable
-> validateRequest retry-until-success http://localhost:8000/services/fooservice status 200
+> validateRequest retry-until-success http://localhost:9008/services/fooservice status 200
 > validateRequest http://localhost:9000/foo status 200
 
 # Request to cassandra should have a status code of 500
@@ -88,4 +88,3 @@ $ sleep 1000
 
 # Cleanup
 > stop
-

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/project/Build.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/project/Build.scala
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 import sbt._
@@ -12,7 +12,7 @@ object DevModeBuild {
   val ConnectTimeout = 10000
   val ReadTimeout = 10000
 
-  def callFoo(): String = makeRequest("http://localhost:8000/services/%2Ffooservice") { conn =>
+  def callFoo(): String = makeRequest("http://localhost:9008/services/%2Ffooservice") { conn =>
     val br = new BufferedReader(new InputStreamReader((conn.getInputStream())))
     val fooAddress = Stream.continually(br.readLine()).takeWhile(_ != null).mkString("\n").trim()
     makeRequest(fooAddress+"/foo") { conn =>

--- a/docs/manual/common/guide/devmode/DevEnvironment.md
+++ b/docs/manual/common/guide/devmode/DevEnvironment.md
@@ -83,7 +83,7 @@ This all happens automatically without special code or additional configuration.
 
 <!--end copied section -->
 
-You can verify that your services are running by viewing `http://localhost:8000/services` in a web browser (or with a command line tool such as `curl`).  The Service Locator, running on port 8000, will return JSON such as:
+You can verify that your services are running by viewing `http://localhost:9008/services` in a web browser (or with a command line tool such as `curl`). The Service Locator, running on port `9008`, will return JSON such as:
 
 ```
 [{"name":"hello-stream","url":"http://0.0.0.0:26230"},

--- a/docs/manual/java/gettingstarted/GettingStartedMaven.md
+++ b/docs/manual/java/gettingstarted/GettingStartedMaven.md
@@ -23,12 +23,12 @@ To create your project, follow these steps:
     Choose archetype:
     1: remote -> com.lightbend.lagom:maven-archetype-lagom-java (maven-archetype-lagom-java)
     Choose a number or apply filter (format: [groupId:]artifactId, case sensitive contains): :
-    ``` 
-    
+    ```
+
 1. Enter the number that corresponds with `com.lightbend.lagom:maven-archetype-lagom-java` (at time of writing, the number `1`, and the only one available).
     Maven prompts you for the version.
 1. Enter the number corresponding with the version of Lagom you want to use. We recommend using the [current stable release](https://www.lagomframework.com/documentation/)).
-    The template prompts you for POM values. 
+    The template prompts you for POM values.
 1. Specify values for:
     * `groupId`  - Usually a reversed domain name, such as `com.example.hello`.
     * `artifactId` - Maven also uses this value as the name for the top-level project folder. You might want to use a value such as `my-first-system`
@@ -37,7 +37,7 @@ To create your project, follow these steps:
     Maven prompts you to confirm POM values.    
 1. Enter `Y` to accept the values.
    When finished, Maven creates the project, and completes with a message similar to the following:
-   
+
 ```
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
@@ -46,7 +46,7 @@ To create your project, follow these steps:
    [INFO] Finished at: 2017-02-24T11:58:08-06:00
    [INFO] Final Memory: 17M/252M
    [INFO] ------------------------------------------------------------------------
-   
+
 ```
 
 
@@ -55,18 +55,18 @@ To create your project, follow these steps:
 The structure for a project created with the Maven archetype generate command will look similar to the following (assuming `my-first-system` as an `artifactId`):
 
 ```
-my-first-system 
+my-first-system
  └ hello-api/             → hello world api project dir
- └ hello-impl/            → hello world implementation dir 
+ └ hello-impl/            → hello world implementation dir
  └ integration-tests/
  └ stream-api/            → stream api project dir
  └ stream-impl/           → stream implementation project dir
  └ pom.xml                → Project group build file
 ```
 
-Note that the `hello` and `stream` services each have: 
+Note that the `hello` and `stream` services each have:
 
-* An `api` project that contains a service interface through which consumers can interact with the service. 
+* An `api` project that contains a service interface through which consumers can interact with the service.
 * An `impl` project that contains the service implementation.
 
 ## Run Hello World
@@ -86,7 +86,7 @@ It will take a bit of time for the services to start. The `Services started` mes
 [info] Starting embedded Cassandra server
 ..........
 [info] Cassandra server running at 127.0.0.1:4000
-[info] Service locator is running at http://localhost:8000
+[info] Service locator is running at http://localhost:9008
 [info] Service gateway is running at http://localhost:9000
 ...
 [info] Service hello-impl listening for HTTP on 0:0:0:0:0:0:0:0:24266
@@ -94,11 +94,11 @@ It will take a bit of time for the services to start. The `Services started` mes
 (Services started, press enter to stop and go back to the console...)
 ```
 
-Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser: 
+Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser:
 
 ```
 http://localhost:9000/api/hello/World
 ```
 The request returns the message `Hello, World!`.
 
-Congratulations! You've created and run your first Lagom system. 
+Congratulations! You've created and run your first Lagom system.

--- a/docs/manual/java/gettingstarted/GettingStartedSbt.md
+++ b/docs/manual/java/gettingstarted/GettingStartedSbt.md
@@ -66,7 +66,7 @@ It will take a bit of time to build the project and start the services. Among ot
 [info] Starting embedded Cassandra server
 ..........
 [info] Cassandra server running at 127.0.0.1:4000
-[info] Service locator is running at http://localhost:8000
+[info] Service locator is running at http://localhost:9008
 [info] Service gateway is running at http://localhost:9000
 [info] Service helloworld-impl listening for HTTP on 0:0:0:0:0:0:0:0:24266
 [info] Service hellostream-impl listening for HTTP on 0:0:0:0:0:0:0:0:26230
@@ -80,6 +80,3 @@ http://localhost:9000/api/hello/World
 ```
 
 The service returns the message, `Hello, World!`. Congratulations! You've created and run your first Lagom system.
-
-
-

--- a/docs/manual/java/guide/advanced/code/docs/advanced/IntegratingNonLagom.java
+++ b/docs/manual/java/guide/advanced/code/docs/advanced/IntegratingNonLagom.java
@@ -36,7 +36,7 @@ public class IntegratingNonLagom {
 
     private void devMode(LagomClientFactory clientFactory) {
         boolean isDevelopment = false;
-        URI helloServiceUri = URI.create("http://localhost:8000");
+        URI helloServiceUri = URI.create("http://localhost:9008");
 
         //#dev-mode
         HelloService helloService;

--- a/docs/manual/java/guide/devmode/ServiceLocator.md
+++ b/docs/manual/java/guide/devmode/ServiceLocator.md
@@ -4,7 +4,7 @@ A Service Locator is embedded in Lagom's development environment, allowing servi
 
 ## Default port
 
-By default, the service locator runs on port `8000`, but it is possible to use a different port. For instance, you can tell the service locator to run on port 10000 by adding the following to your build.
+By default, the service locator runs on port `9008`, but it is possible to use a different port. For instance, you can tell the service locator to run on port `10000` by adding the following to your build.
 
 In the Maven root project pom:
 
@@ -55,7 +55,7 @@ Note that if the service you want to communicate with is actually a Lagom servic
 
 # Service Gateway
 
-Some clients that want to connect to your services will not have access to your Service Locator. External clients need a stable address to communicate to and here's where the Service Gateway comes in. The Service Gateway will expose and reverse proxy all public endpoints registered by your services. A Service Gateway is embedded in Lagom's development environment, allowing clients from the outside (e.g. a browser) to connect to your Lagom services. 
+Some clients that want to connect to your services will not have access to your Service Locator. External clients need a stable address to communicate to and here's where the Service Gateway comes in. The Service Gateway will expose and reverse proxy all public endpoints registered by your services. A Service Gateway is embedded in Lagom's development environment, allowing clients from the outside (e.g. a browser) to connect to your Lagom services.
 
 ## Default port
 
@@ -81,7 +81,7 @@ In sbt:
 
 ## Default gateway implementation
 
-The Lagom development environment provides an implementation of a Service Gateway based on [Akka HTTP](https://github.com/akka/akka-http) and the (now legacy) implementation based on [Netty](https://netty.io/). 
+The Lagom development environment provides an implementation of a Service Gateway based on [Akka HTTP](https://github.com/akka/akka-http) and the (now legacy) implementation based on [Netty](https://netty.io/).
 
 You may opt in to use the old `netty` implementation.
 

--- a/docs/manual/scala/gettingstarted/IntroGetStarted.md
+++ b/docs/manual/scala/gettingstarted/IntroGetStarted.md
@@ -64,7 +64,7 @@ It will take a bit of time to build the project and start the services. Among ot
 [info] Starting embedded Cassandra server
 ..........
 [info] Cassandra server running at 127.0.0.1:4000
-[info] Service locator is running at http://localhost:8000
+[info] Service locator is running at http://localhost:9008
 [info] Service gateway is running at http://localhost:9000
 [info] Service hello-impl listening for HTTP on 0:0:0:0:0:0:0:0:24266
 [info] Service hello-stream-impl listening for HTTP on 0:0:0:0:0:0:0:0:26230
@@ -78,5 +78,3 @@ http://localhost:9000/api/hello/World
 ```
 
 The service returns the message, `Hello, World!`. Congratulations, you've built your first Lagom project!
-
-

--- a/docs/manual/scala/guide/advanced/IntegratingNonLagom.md
+++ b/docs/manual/scala/guide/advanced/IntegratingNonLagom.md
@@ -45,9 +45,9 @@ Here we've created a client for the `HelloService` the same way we would in a re
 #### Working with dev mode
 
 When running your service in development, you can tell the service to use Lagom's dev mode service locator, by adding a dependency on Lagom's dev mode support:
- 
+
 @[dev-mode-dependency](code/integrating-non-lagom.sbt)
- 
+
 Then, when you instantiate your application, rather than mixing in your production service locator, you can mix in the [`LagomDevModeServiceLocatorComponents`](api/com/lightbend/lagom/scaladsl/devmode/LagomDevModeServiceLocatorComponents.html) trait to get the dev mode service locator:
 
 @[dev-mode](code/IntegratingNonLagom.scala)
@@ -55,7 +55,7 @@ Then, when you instantiate your application, rather than mixing in your producti
 You'll also need to configure your application to tell it where the service locator is running, this can be done by passing a system property to your application when it starts up, for example:
 
 ```
--Dlagom.service-locator-url=http://localhost:8000
+-Dlagom.service-locator-url=http://localhost:9008
 ```
 
 Alternatively, you can configure it programmatically by overriding the `devModeServiceLocatorUrl` value on the `LagomDevModeServiceLocatorComponents` trait:

--- a/docs/manual/scala/guide/devmode/ServiceLocator.md
+++ b/docs/manual/scala/guide/devmode/ServiceLocator.md
@@ -4,7 +4,7 @@ A Service Locator is embedded in Lagom's development environment, allowing servi
 
 ## Default port
 
-By default, the service locator runs on port `8000`, but it is possible to use a different port. For instance, you can tell the service locator to run on port 10000 by adding the following to your build.
+By default, the service locator runs on port `9008`, but it is possible to use a different port. For instance, you can tell the service locator to run on port `10000` by adding the following to your build.
 
 In the Maven root project pom:
 
@@ -56,7 +56,7 @@ Note that if the service you want to communicate with is actually a Lagom servic
 
 # Service Gateway
 
-Some clients that want to connect to your services will not have access to your Service Locator. External clients need a stable address to communicate to and here's where the Service Gateway comes in. The Service Gateway will expose and reverse proxy all public endpoints registered by your services. A Service Gateway is embedded in Lagom's development environment, allowing clients from the outside (e.g. a browser) to connect to your Lagom services. 
+Some clients that want to connect to your services will not have access to your Service Locator. External clients need a stable address to communicate to and here's where the Service Gateway comes in. The Service Gateway will expose and reverse proxy all public endpoints registered by your services. A Service Gateway is embedded in Lagom's development environment, allowing clients from the outside (e.g. a browser) to connect to your Lagom services.
 
 ## Default port
 
@@ -69,7 +69,7 @@ In sbt:
 
 ## Default gateway implementation
 
-The Lagom development environment provides an implementation of a Service Gateway based on [Akka HTTP](https://github.com/akka/akka-http) and the (now legacy) implementation based on [Netty](https://netty.io/). 
+The Lagom development environment provides an implementation of a Service Gateway based on [Akka HTTP](https://github.com/akka/akka-http) and the (now legacy) implementation based on [Netty](https://netty.io/).
 
 You may opt in to use the old `netty` implementation with this setting in sbt:
 

--- a/service/javadsl/integration-client/src/main/java/com/lightbend/lagom/javadsl/client/integration/LagomClientFactory.java
+++ b/service/javadsl/integration-client/src/main/java/com/lightbend/lagom/javadsl/client/integration/LagomClientFactory.java
@@ -131,20 +131,20 @@ public class LagomClientFactory implements Closeable {
     /**
      * Create a Lagom service client that uses the Lagom dev mode service locator to locate the service.
      *
-     * This uses the default Lagom service locator port, that is, localhost:8000.
+     * This uses the default Lagom service locator port, that is, localhost:9008.
      *
      * @param clientInterface The client interface for the service.
      * @return An implementation of the client interface.
      */
     public <T> T createDevClient(Class<T> clientInterface) {
-        return createDevClient(clientInterface, URI.create("http://localhost:8000"));
+        return createDevClient(clientInterface, URI.create("http://localhost:9008"));
     }
 
     /**
      * Create a Lagom service client that uses the Lagom dev mode service locator to locate the service.
      *
      * @param clientInterface The client interface for the service.
-     * @param serviceLocatorUri The URI of the Lagom dev mode service locator - usually http://localhost:8000.
+     * @param serviceLocatorUri The URI of the Lagom dev mode service locator - usually http://localhost:9008.
      * @return An implementation of the client interface.
      */
     public <T> T createDevClient(Class<T> clientInterface, URI serviceLocatorUri) {


### PR DESCRIPTION
## Fixes
Issue #460

Changing the default value of port of the service locator from `8000` to `9008`, 

## Purpose
..because `8000` conflicts w/ the default value for JDWP debug mechanism.