### PR TITLE
Upgraded akka persistence cassandra version to 0.57

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,11 +10,11 @@ object Dependencies {
   val PlayStandaloneWsVersion = "1.1.0"
   val PlayFileWatchVersion = "1.1.0"
 
-  val AkkaVersion = "2.5.4"
+  val AkkaVersion = "2.5.6"
   val AkkaHttpVersion = "10.0.9"
   val ScalaVersions = Seq("2.11.11", "2.12.3")
   val SbtScalaVersions = Seq("2.10.6")
-  val AkkaPersistenceCassandraVersion = "0.54"
+  val AkkaPersistenceCassandraVersion = "0.57"
   val AkkaPersistenceJdbcVersion = "3.0.0"
   val ScalaTestVersion = "3.0.3"
   val JacksonVersion = "2.8.10"
@@ -115,9 +115,9 @@ object Dependencies {
       cassandraDriverCore,
       "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
       akkaPersistenceJdbc,
-      "com.github.jnr" % "jffi" % "1.2.14",
-      "com.github.jnr" % "jnr-constants" % "0.9.6",
-      "com.github.jnr" % "jnr-ffi" % "2.1.2",
+      "com.github.jnr" % "jffi" % "1.2.16",
+      "com.github.jnr" % "jnr-constants" % "0.9.9",
+      "com.github.jnr" % "jnr-ffi" % "2.1.6",
       "com.github.jnr" % "jnr-posix" % "3.0.27",
       "com.github.jnr" % "jnr-x86asm" % "1.0.2",
       "com.google.code.findbugs" % "jsr305" % "1.3.9",
@@ -158,8 +158,8 @@ object Dependencies {
       "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
       "com.zaxxer" % "HikariCP" % "2.7.1",
       "commons-codec" % "commons-codec" % "1.10",
-      "io.aeron" % "aeron-client" % "1.2.5",
-      "io.aeron" % "aeron-driver" % "1.2.5",
+      "io.aeron" % "aeron-client" % "1.3.0",
+      "io.aeron" % "aeron-driver" % "1.3.0",
       dropwizardMetricsCore,
       "io.jsonwebtoken" % "jjwt" % "0.7.0",
       // Netty 3 uses a different package to Netty 4, and a different artifact ID, so can safely coexist
@@ -171,7 +171,7 @@ object Dependencies {
       "junit" % "junit" % JUnitVersion,
       "net.jodah" % "typetools" % "0.5.0",
       "net.jpountz.lz4" % "lz4" % "1.3.0",
-      "org.agrona" % "agrona" % "0.9.5",
+      "org.agrona" % "agrona" % "0.9.6",
       "org.apache.commons" % "commons-lang3" % "3.6",
       "org.apache.kafka" % "kafka-clients" % KafkaVersion,
       "org.codehaus.mojo" % "animal-sniffer-annotations" % "1.14",
@@ -181,7 +181,7 @@ object Dependencies {
       javassist,
       "org.joda" % "joda-convert" % "1.7",
       "org.hamcrest" % "hamcrest-core" % "1.3",
-      "org.lmdbjava" % "lmdbjava" % "0.0.5",
+      "org.lmdbjava" % "lmdbjava" % "0.6.0",
       "org.pcollections" % "pcollections" % "2.1.2",
       reactiveStreams,
       "org.reflections" % "reflections" % "0.9.11",


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

This upgrade fixes the following issue in the cassandra persistence library: https://github.com/akka/akka-persistence-cassandra/issues/237

There is only one problem with the upgrade of the library: https://github.com/akka/akka-persistence-cassandra/issues/230

So an upgrade from the previous version to this one in a production system can go wrong and unless auto-create tables is off.

## Purpose

Upgrades the persistence cassandra to the latest bugfix release

## Background Context


## References

https://github.com/akka/akka-persistence-cassandra/issues/237
