### PR TITLE
FF issue with websocket binary frames

### DIFF
--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/MessageProtocol.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/MessageProtocol.java
@@ -127,7 +127,10 @@ public final class MessageProtocol {
      * @return true if this message protocol is text based.
      */
     public boolean isText() {
-        return charset.isPresent();
+        boolean isJson = contentType.map(contentType -> "application/json".equals(contentType)).orElse(false);
+        boolean isPlainText = contentType.map(contentType -> "text/plain".equals(contentType)).orElse(false);
+
+        return charset.isPresent() || isJson || isPlainText;
     }
 
     private static final Charset utf8Charset = Charset.forName("utf-8");

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/MessageProtocol.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/MessageProtocol.scala
@@ -51,7 +51,7 @@ sealed trait MessageProtocol {
    *
    * @return true if this message protocol is text based.
    */
-  def isText: Boolean = charset.isDefined || contentType.contains("application/json")
+  def isText: Boolean = charset.isDefined || contentType.contains("application/json") || contentType.contains("text/plain")
 
   /**
    * Whether the protocol uses UTF-8.


### PR DESCRIPTION
fixes #1018

`MessageProtocol.isText` now returns true also in the case if the
contentType is `"text/plain"`

Btw. better way would be deciding based on the "Opcode" of each message https://tools.ietf.org/html/rfc6455#page-29