### PR TITLE
Added serializer for ClusterStartupTaskActor.Execute

### DIFF
--- a/persistence/core/src/main/resources/reference.conf
+++ b/persistence/core/src/main/resources/reference.conf
@@ -79,3 +79,18 @@ lagom.persistence.cluster.distribution {
   # Each entity is pinged at this interval. Each node will ping this often, so this interval can be quite long.
   ensure-active-interval = 30s
 }
+
+akka.actor {
+  serializers {
+    lagom-persistence-core = "com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskSerializer"
+  }
+  serialization-bindings {
+    // Disabled, will be enabled in Lagom 1.4
+    // "com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor$Execute$" = lagom-persistence-core
+  }
+  serialization-identifiers {
+    // "lagom-persistence-core".hashCode
+    "com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskSerializer" = -1543173302
+  }
+}
+

--- a/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterStartupTaskSerializer.scala
+++ b/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterStartupTaskSerializer.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cluster
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.{ BaseSerializer, SerializerWithStringManifest }
+import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
+
+private[lagom] class ClusterStartupTaskSerializer(val system: ExtendedActorSystem)
+  extends SerializerWithStringManifest with BaseSerializer {
+
+  val ExecuteManifest = "E"
+
+  override def manifest(obj: AnyRef) = obj match {
+    case Execute => ExecuteManifest
+    case _       => throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass} in [${getClass.getName}]")
+  }
+
+  override def toBinary(obj: AnyRef) = obj match {
+    case Execute => Array.emptyByteArray
+    case _       => throw new IllegalArgumentException(s"Can't serialize object of type ${obj.getClass} in [${getClass.getName}]")
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String) = manifest match {
+    case `ExecuteManifest` => Execute
+    case _ => throw new IllegalArgumentException(
+      s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]"
+    )
+  }
+}

--- a/persistence/core/src/test/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterStartupTaskSerializerSpec.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/internal/persistence/cluster/ClusterStartupTaskSerializerSpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.cluster
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.SerializationExtension
+import com.lightbend.lagom.persistence.ActorSystemSpec
+
+class ClusterStartupTaskSerializerSpec extends ActorSystemSpec {
+  val serializer = new ClusterStartupTaskSerializer(system.asInstanceOf[ExtendedActorSystem])
+
+  def checkSerialization(obj: AnyRef): Unit = {
+    // check that it is *not* configured for Lagom 1.3
+    SerializationExtension(system).serializerFor(obj.getClass).getClass should not be classOf[ClusterStartupTaskSerializer]
+
+    // verify serialization-deserialization round trip
+    val blob = serializer.toBinary(obj)
+    val obj2 = serializer.fromBinary(blob, serializer.manifest(obj))
+    obj2 should be(obj)
+  }
+
+  "ClusterStartupTaskSerializerSpec" must {
+    "serialize Execute" in {
+      checkSerialization(ClusterStartupTaskActor.Execute)
+    }
+  }
+}


### PR DESCRIPTION
Fixes #933.

This is a backport of #1043, with the modification that the serializer is not enabled (so that rolling upgrades can be done safely on the 1.3.x branch without any config changes from the user).