### PR TITLE
Allow subscribers to access message metadata

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -73,9 +73,8 @@ lazy val docs = project
     persistenceJdbcScaladsl,
     testkitJavadsl,
     testkitScaladsl,
-    brokerScaladsl,
+    kafkaBrokerScaladsl,
     playJson,
-    kafkaBroker,
     pubsubScaladsl,
     immutables % "test->compile",
     theme % "run-markdown",
@@ -94,8 +93,7 @@ lazy val persistenceCassandraScaladsl = ProjectRef(parentDir, "persistence-cassa
 lazy val testkitJavadsl = ProjectRef(parentDir, "testkit-javadsl")
 lazy val testkitScaladsl = ProjectRef(parentDir, "testkit-scaladsl")
 lazy val playJson = ProjectRef(parentDir, "play-json")
-lazy val kafkaBroker = ProjectRef(parentDir, "kafka-broker")
-lazy val brokerScaladsl = ProjectRef(parentDir, "broker-scaladsl")
+lazy val kafkaBrokerScaladsl = ProjectRef(parentDir, "kafka-broker-scaladsl")
 lazy val devmodeScaladsl = ProjectRef(parentDir, "devmode-scaladsl")
 lazy val pubsubScaladsl = ProjectRef(parentDir, "pubsub-scaladsl")
 

--- a/docs/manual/java/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/java/guide/broker/MessageBrokerApi.md
@@ -52,6 +52,15 @@ When calling [`Topic.subscribe()`](api/index.html?com/lightbend/lagom/javadsl/ap
 
 Finally, subscribers are grouped together via [`Subscriber.withGroupId`](api/index.html?com/lightbend/lagom/javadsl/api/broker/Subscriber.html#withGroupId-java.lang.String-). A subscriber group allows many nodes in your cluster to consume a message stream while ensuring that each message is only handled once by each node in your cluster.  Without subscriber groups, all of your nodes for a particular service would get every message in the stream, leading to their processing being duplicated.  By default, Lagom will use a group id that has the same name as the service consuming the topic.
 
+### Consuming message metadata
+
+Your broker implementation may provide additional metadata with messages which you can consume. This can be accessed by invoking the [`Subscriber.withMetadata()`](api/index.html?com/lightbend/lagom/javadsl/api/broker/Subscriber.html#withMetadata--) method, which returns a subscriber that wraps the messages in a [`Message`](api/index.html?com/lightbend/lagom/javadsl/api/broker/Message.html).
+
+@[subscribe-to-topic-with-metadata](code/docs/javadsl/mb/AnotherServiceImpl.java)
+
+The [`messageKeyAsString`](api/index.html?com/lightbend/lagom/javadsl/api/broker/Message.html#messageKeyAsString--) method is provided as a convenience for accessing the message key. Other properties can be accessed using the [`get`](api/index.html?com/lightbend/lagom/javadsl/api/broker/Message.html#get-com.lightbend.lagom.javadsl.api.broker.MetadataKey-) method. A full list of the metadata keys available for Kafka can be found [here](api/index.html?com/lightbend/lagom/javadsl/broker/kafka/KafkaMetadataKeys.html).
+
+
 ## Polymorphic event streams
 
 Typically you will want to publish more than one type of event to a particular topic. This can be done by creating an interface that each event implements. In order to successfully serialize these events to and from JSON, a few extra annotations are needed to instruct Jackson to describe and consume the type of the event in the produced JSON.

--- a/docs/manual/java/guide/broker/code/docs/javadsl/mb/AnotherServiceImpl.java
+++ b/docs/manual/java/guide/broker/code/docs/javadsl/mb/AnotherServiceImpl.java
@@ -4,6 +4,10 @@ import akka.Done;
 import akka.NotUsed;
 import akka.stream.javadsl.Flow;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.broker.Message;
+import com.lightbend.lagom.javadsl.broker.kafka.KafkaMetadataKeys;
+import org.apache.kafka.common.header.Headers;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -33,5 +37,22 @@ public class AnotherServiceImpl implements AnotherService {
 
     private Done doSomethingWithTheMessage(GreetingMessage message) {
         throw new UnsupportedOperationException("Missing implementation");
+    }
+
+    private void subscribeWithMetadata() {
+        //#subscribe-to-topic-with-metadata
+        helloService.greetingsTopic()
+            .subscribe().withMetadata()
+            .atLeastOnce(Flow.fromFunction((Message<GreetingMessage> msg) -> {
+                GreetingMessage payload = msg.getPayload();
+                String messageKey = msg.messageKeyAsString();
+                Optional<Headers> kafkaHeaders = msg.get(KafkaMetadataKeys.HEADERS);
+                System.out.println("Message: " + payload +
+                    " Key: " + messageKey +
+                    " Headers: " + kafkaHeaders);
+                return Done.getInstance();
+            }));
+        //#subscribe-to-topic-with-metadata
+
     }
 }

--- a/docs/manual/scala/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/scala/guide/broker/MessageBrokerApi.md
@@ -48,6 +48,14 @@ When calling [`Topic.subscribe`](api/com/lightbend/lagom/scaladsl/api/broker/Top
 
 Finally, subscribers are grouped together via [`Subscriber.withGroupId`](api/com/lightbend/lagom/scaladsl/api/broker/Subscriber.html#withGroupId\(groupId:String\):com.lightbend.lagom.scaladsl.api.broker.Subscriber[Message]). A subscriber group allows many nodes in your cluster to consume a message stream while ensuring that each message is only handled once by each node in your cluster.  Without subscriber groups, all of your nodes for a particular service would get every message in the stream, leading to their processing being duplicated.  By default, Lagom will use a group id that has the same name as the service consuming the topic.
 
+### Consuming message metadata
+
+Your broker implementation may provide additional metadata with messages which you can consume. This can be accessed by invoking the [`Subscriber.withMetadata`](api/com/lightbend/lagom/scaladsl/api/broker/Subscriber.html#withMetadata:com.lightbend.lagom.scaladsl.api.broker.Subscriber[com.lightbend.lagom.scaladsl.api.broker.Message[Payload]]) method, which returns a subscriber that wraps the messages in a [`Message`](api/com/lightbend/lagom/scaladsl/api/broker/Message.html).
+
+@[subscribe-to-topic-with-metadata](code/docs/scaladsl/mb/AnotherServiceImpl.scala)
+
+The [`messageKeyAsString`](api/com/lightbend/lagom/scaladsl/api/broker/Message.html#messageKeyAsString:String) method is provided as a convenience for accessing the message key. Other properties can be accessed using the [`get`](api/com/lightbend/lagom/scaladsl/api/broker/Message.html#get\(com.lightbend.lagom.scaladsl.api.broker.MetadataKey[Metadata]\):Metadata) method. A full list of the metadata keys available for Kafka can be found [here](api/com/lightbend/lagom/scaladsl/broker/kafka/KafkaMetadataKeys$.html).
+
 ## Polymorphic event streams
 
 Typically you will want to publish more than one type of event to a particular topic. This can be done by creating an interface that each event implements. In order to successfully serialize these events to and from JSON, you will have to include some extra information on your JSON representation of the data.

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/Message.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/Message.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.api.broker;
+
+import org.pcollections.HashTreePMap;
+import org.pcollections.PMap;
+
+import java.util.Optional;
+
+/**
+ * A message broker message.
+ *
+ * This provides access to both the message payload, and the metadata.
+ */
+public final class Message<Payload> {
+
+  private final Payload payload;
+  private final PMap<MetadataKey<?>, Object> metadataMap;
+
+  private Message(Payload payload, PMap<MetadataKey<?>, Object> metadataMap) {
+    this.payload = payload;
+    this.metadataMap = metadataMap;
+  }
+
+  /**
+   * The payload of the message.
+   */
+  public Payload getPayload() {
+    return payload;
+  }
+
+  /**
+   * Get the metadata for the given metadata key.
+   *
+   * @param key The key of the metadata.
+   * @return The metadata, if found for that key.
+   */
+  @SuppressWarnings("unchecked")
+  public <Metadata> Optional<Metadata> get(MetadataKey<Metadata> key) {
+    return Optional.ofNullable((Metadata) metadataMap.get(key));
+  }
+
+  /**
+   * Add a metadata key and value to this message.
+   *
+   * @param key The key to add.
+   * @param metadata The metadata to add.
+   * @return A copy of this message with the key and value added.
+   */
+  public <Metadata> Message<Payload> add(MetadataKey<Metadata> key, Metadata metadata) {
+    return new Message<>(payload, metadataMap.plus(key, metadata));
+  }
+
+  /**
+   * Return a copy of this message with the given payload.
+   *
+   * @param payload The payload.
+   * @return A copy of this message with the given payload.
+   */
+  public <P2> Message<P2> withPayload(P2 payload) {
+    return new Message<>(payload, metadataMap);
+  }
+
+  /**
+   * Get the message key as a String.
+   * <p>
+   * If the key is not a String, it will be converted to a String using <code>toString</code>.
+   * <p>
+   * If the underlying message broker doesn't support keys, the empty string will be returned.
+   *
+   * @return A string representation of the message key.
+   */
+  public String messageKeyAsString() {
+    return get(MetadataKey.messageKey()).map(Object::toString).orElse("");
+  }
+
+  /**
+   * Create a message with the given payload.
+   */
+  public static <Payload> Message<Payload> create(Payload payload) {
+    return new Message<>(payload, HashTreePMap.empty());
+  }
+
+}

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/MetadataKey.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/MetadataKey.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.api.broker;
+
+/**
+ * A metadata key.
+ */
+public final class MetadataKey<Metadata> {
+  private final String name;
+
+  private MetadataKey(String name) {
+    this.name = name;
+  }
+
+  /**
+   * The name of the metadata key.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Create a metadata key with the given name.
+   */
+  public static <Metadata> MetadataKey<Metadata> named(String name) {
+    return new MetadataKey<>(name);
+  }
+
+  /**
+   * The message key metadata key.
+   */
+  @SuppressWarnings("unchecked")
+  public static <Key> MetadataKey<Key> messageKey() {
+    return (MetadataKey) MESSAGE_KEY;
+  }
+
+  private static MetadataKey<Object> MESSAGE_KEY = named("messageKey");
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MetadataKey<?> that = (MetadataKey<?>) o;
+
+    return name.equals(that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataKey{" +
+        "name='" + name + '\'' +
+        '}';
+  }
+}
+

--- a/service/javadsl/kafka/client/src/main/java/com/lightbend/lagom/javadsl/broker/kafka/KafkaMetadataKeys.java
+++ b/service/javadsl/kafka/client/src/main/java/com/lightbend/lagom/javadsl/broker/kafka/KafkaMetadataKeys.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
-package com.lightbend.lagom.internal.javadsl.broker.kafka;
+package com.lightbend.lagom.javadsl.broker.kafka;
 
 import com.lightbend.lagom.javadsl.api.broker.MetadataKey;
 import org.apache.kafka.common.header.Headers;

--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
@@ -19,6 +19,7 @@ import com.lightbend.lagom.internal.broker.kafka.{ ConsumerConfig, KafkaConfig, 
 import com.lightbend.lagom.javadsl.api.Descriptor.TopicCall
 import com.lightbend.lagom.javadsl.api.{ ServiceInfo, ServiceLocator }
 import com.lightbend.lagom.javadsl.api.broker.{ Message, MetadataKey, Subscriber }
+import com.lightbend.lagom.javadsl.broker.kafka.KafkaMetadataKeys
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.slf4j.LoggerFactory

--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaTopic.scala
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaTopic.scala
@@ -16,11 +16,11 @@ import scala.concurrent.ExecutionContext
 /**
  * Represents a Kafka topic and allows publishing/consuming messages to/from the topic.
  */
-private[lagom] class JavadslKafkaTopic[Message](kafkaConfig: KafkaConfig, topicCall: TopicCall[Message],
-                                                info: ServiceInfo, system: ActorSystem, serviceLocator: ServiceLocator)(implicit mat: Materializer, ec: ExecutionContext) extends Topic[Message] {
+private[lagom] class JavadslKafkaTopic[Payload](kafkaConfig: KafkaConfig, topicCall: TopicCall[Payload],
+                                                info: ServiceInfo, system: ActorSystem, serviceLocator: ServiceLocator)(implicit mat: Materializer, ec: ExecutionContext) extends Topic[Payload] {
 
   override def topicId: TopicId = topicCall.topicId
 
-  override def subscribe(): Subscriber[Message] = new JavadslKafkaSubscriber(kafkaConfig, topicCall,
-    JavadslKafkaSubscriber.GroupId.default(info), info, system, serviceLocator)
+  override def subscribe(): Subscriber[Payload] = new JavadslKafkaSubscriber[Payload, Payload](kafkaConfig, topicCall,
+    JavadslKafkaSubscriber.GroupId.default(info), info, system, serviceLocator, _.value())
 }

--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/KafkaMetadataKeys.java
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/KafkaMetadataKeys.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.javadsl.broker.kafka;
+
+import com.lightbend.lagom.javadsl.api.broker.MetadataKey;
+import org.apache.kafka.common.header.Headers;
+
+/**
+ * Metadata keys specific to the Kafka broker implementation.
+ */
+public final class KafkaMetadataKeys {
+
+  private KafkaMetadataKeys() {
+  }
+
+  /**
+   * The partition the message is published to.
+   */
+  public static final MetadataKey<Integer> PARTITION = MetadataKey.named("kafkaPartition");
+
+  /**
+   * The offset of the message in its partition.
+   */
+  public static final MetadataKey<Long> OFFSET = MetadataKey.named("kafkaOffset");
+
+  /**
+   * The topic the message is published to.
+   */
+  public static final MetadataKey<String> TOPIC = MetadataKey.named("kafkaTopic");
+
+  /**
+   * The Kafka message headers.
+   */
+  public static final MetadataKey<Headers> HEADERS = MetadataKey.named("kafkaHeaders");
+}

--- a/service/javadsl/kafka/client/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriberSpec.scala
+++ b/service/javadsl/kafka/client/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriberSpec.scala
@@ -13,7 +13,7 @@ class JavadslKafkaSubscriberSpec extends FlatSpec with Matchers {
   behavior of "JavadslKafkaSubscriber"
 
   it should "create a new subscriber with updated groupId" in {
-    val subscriber = new JavadslKafkaSubscriber(null, null, JavadslKafkaSubscriber.GroupId("old"), null, null, null)(null, null)
+    val subscriber = new JavadslKafkaSubscriber(null, null, JavadslKafkaSubscriber.GroupId("old"), null, null, null, null)(null, null)
     subscriber.withGroupId("newGID") should not be subscriber
   }
 }

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -20,26 +20,29 @@ import com.lightbend.lagom.internal.javadsl.persistence.OffsetAdapter.{ dslOffse
 import com.lightbend.lagom.internal.kafka.KafkaLocalServer
 import com.lightbend.lagom.javadsl.api.ScalaService._
 import com.lightbend.lagom.javadsl.api._
-import com.lightbend.lagom.javadsl.api.broker.Topic
+import com.lightbend.lagom.javadsl.api.broker.kafka.{ KafkaProperties, PartitionKeyStrategy }
+import com.lightbend.lagom.javadsl.api.broker.{ Message, Topic }
 import com.lightbend.lagom.javadsl.broker.TopicProducer
 import com.lightbend.lagom.javadsl.persistence.{ AggregateEvent, AggregateEventTag, PersistentEntityRef, PersistentEntityRegistry, Offset => JOffset }
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport
 import com.lightbend.lagom.spi.persistence.{ InMemoryOffsetStore, OffsetStore }
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, Matchers, WordSpecLike }
+import org.scalatest._
 import play.api.inject._
 import play.api.inject.guice.GuiceApplicationBuilder
 
 import scala.collection.mutable
 import scala.compat.java8.FunctionConverters._
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, Promise }
+import scala.concurrent.{ Await, ExecutionContext, Promise }
 
 class JavadslKafkaApiSpec extends WordSpecLike
   with Matchers
   with BeforeAndAfter
   with BeforeAndAfterAll
-  with ScalaFutures {
+  with ScalaFutures
+  with OptionValues {
 
   private lazy val offsetStore = new InMemoryOffsetStore
 
@@ -85,6 +88,7 @@ class JavadslKafkaApiSpec extends WordSpecLike
   }
 
   override implicit val patienceConfig = PatienceConfig(30.seconds, 150.millis)
+  import application.materializer
 
   "The Kafka message broker api" should {
 
@@ -237,7 +241,6 @@ class JavadslKafkaApiSpec extends WordSpecLike
     }
 
     "self-heal at-most-once consumer stream if a failure occurs" in {
-      implicit val mat = application.injector.instanceOf(classOf[Materializer])
       case object SimulateFailure extends RuntimeException
 
       // Let's publish a message to the topic
@@ -279,6 +282,34 @@ class JavadslKafkaApiSpec extends WordSpecLike
       for (i <- 1 to batchSize) test6EventJournal.append(i.toString)
       assert(latch.await(10, TimeUnit.SECONDS))
     }
+
+    "attach metadata to the message" in {
+      test7EventJournal.append("A1")
+      test7EventJournal.append("A2")
+      test7EventJournal.append("A3")
+
+      val messages = Await.result(
+        testService.test7Topic().subscribe.withMetadata.atMostOnceSource.asScala.take(3).runWith(Sink.seq),
+        10.seconds
+      )
+
+      messages.size shouldBe 3
+      def runAssertions(msg: Message[String]): Unit = {
+        msg.messageKeyAsString shouldBe "A"
+        msg.get(KafkaMetadataKeys.TOPIC).asScala.value shouldBe "test7"
+        msg.get(KafkaMetadataKeys.HEADERS) should not be None
+        msg.get(KafkaMetadataKeys.PARTITION).asScala.value shouldBe
+          messages.head.get(KafkaMetadataKeys.PARTITION).asScala.value
+      }
+      messages.foreach(runAssertions)
+      messages.head.getPayload shouldBe "A1"
+      val offset = messages.head.get(KafkaMetadataKeys.OFFSET).asScala.value
+      messages(1).getPayload shouldBe "A2"
+      messages(1).get(KafkaMetadataKeys.OFFSET).asScala.value shouldBe (offset + 1)
+      messages(2).getPayload shouldBe "A3"
+      messages(2).get(KafkaMetadataKeys.OFFSET).asScala.value shouldBe (offset + 2)
+    }
+
   }
 
 }
@@ -291,6 +322,7 @@ object JavadslKafkaApiSpec {
   private val test4EventJournal = new EventJournal[String]
   private val test5EventJournal = new EventJournal[String]
   private val test6EventJournal = new EventJournal[String]
+  private val test7EventJournal = new EventJournal[String]
 
   // Allows tests to insert logic into the producer stream
   @volatile var messageTransformer: String => String = identity
@@ -302,6 +334,7 @@ object JavadslKafkaApiSpec {
     def test4Topic(): Topic[String]
     def test5Topic(): Topic[String]
     def test6Topic(): Topic[String]
+    def test7Topic(): Topic[String]
 
     override def descriptor(): Descriptor =
       named("testservice")
@@ -311,7 +344,11 @@ object JavadslKafkaApiSpec {
           topic("test3", test3Topic _),
           topic("test4", test4Topic _),
           topic("test5", test5Topic _),
-          topic("test6", test6Topic _)
+          topic("test6", test6Topic _),
+          topic("test7", test7Topic _)
+            .withProperty(KafkaProperties.partitionKeyStrategy(), new PartitionKeyStrategy[String] {
+              override def computePartitionKey(message: String) = message.take(1)
+            })
         )
   }
 
@@ -324,6 +361,7 @@ object JavadslKafkaApiSpec {
     override def test4Topic(): Topic[String] = createTopicProducer(test4EventJournal)
     override def test5Topic(): Topic[String] = createTopicProducer(test5EventJournal)
     override def test6Topic(): Topic[String] = createTopicProducer(test6EventJournal)
+    override def test7Topic(): Topic[String] = createTopicProducer(test7EventJournal)
 
     private def createTopicProducer(eventJournal: EventJournal[String]): Topic[String] =
       TopicProducer.singleStreamWithOffset[String]({ fromOffset: JOffset =>

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -23,6 +23,7 @@ import com.lightbend.lagom.javadsl.api._
 import com.lightbend.lagom.javadsl.api.broker.kafka.{ KafkaProperties, PartitionKeyStrategy }
 import com.lightbend.lagom.javadsl.api.broker.{ Message, Topic }
 import com.lightbend.lagom.javadsl.broker.TopicProducer
+import com.lightbend.lagom.javadsl.broker.kafka.KafkaMetadataKeys
 import com.lightbend.lagom.javadsl.persistence.{ AggregateEvent, AggregateEventTag, PersistentEntityRef, PersistentEntityRegistry, Offset => JOffset }
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport
 import com.lightbend.lagom.spi.persistence.{ InMemoryOffsetStore, OffsetStore }

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/MessageMetadata.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/MessageMetadata.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.api.broker
+
+/**
+ * A message broker message.
+ *
+ * This provides access to both the message payload, and the metadata.
+ */
+sealed trait Message[Payload] {
+  /**
+   * The payload of the message.
+   */
+  def payload: Payload
+
+  /**
+   * Get the metadata for the given metadata key.
+   *
+   * @param key The key of the metadata.
+   * @return The metadata, if found for that key.
+   */
+  def get[Metadata](key: MetadataKey[Metadata]): Option[Metadata]
+
+  /**
+   * Add a metadata key and value to this message.
+   *
+   * @param keyValue The key and value to add.
+   * @return A copy of this message with the key and value added.
+   */
+  def +[Metadata](keyValue: (MetadataKey[Metadata], Metadata)): Message[Payload]
+
+  /**
+   * Return a copy of this message with the given payload.
+   *
+   * @param payload The payload.
+   * @return A copy of this message with the given payload.
+   */
+  def withPayload[P2](payload: P2): Message[P2]
+
+  /**
+   * Get the message key as a String.
+   *
+   * If the key is not a String, it will be converted to a String using `toString`.
+   *
+   * If the underlying message broker doesn't support keys, the empty string will be returned.
+   *
+   * @return A string representation of the message key.
+   */
+  def messageKeyAsString: String = get(MetadataKey.MessageKey[Any]).fold("")(_.toString)
+}
+
+object Message {
+  /**
+   * Create a message with the given payload.
+   */
+  def apply[Payload](payload: Payload): Message[Payload] = {
+    MessageImpl(payload, Map.empty)
+  }
+
+  private case class MessageImpl[Payload](payload: Payload, metadataMap: Map[MetadataKey[_], _]) extends Message[Payload] {
+    override def get[Metadata](key: MetadataKey[Metadata]): Option[Metadata] = {
+      metadataMap.get(key).asInstanceOf[Option[Metadata]]
+    }
+    override def +[Metadata](keyValue: (MetadataKey[Metadata], Metadata)): Message[Payload] = {
+      MessageImpl(payload, metadataMap + keyValue)
+    }
+
+    override def withPayload[P2](payload: P2): Message[P2] = MessageImpl(payload, metadataMap)
+  }
+}
+
+/**
+ * A metadata key.
+ */
+sealed trait MetadataKey[Metadata] {
+  /**
+   * The name of the metadata key.
+   */
+  def name: String
+}
+
+object MetadataKey {
+
+  /**
+   * Create a metadata key with the given name.
+   */
+  def apply[Metadata](name: String): MetadataKey[Metadata] = {
+    MetadataKeyImpl(name)
+  }
+
+  private case class MetadataKeyImpl[Metadata](name: String) extends MetadataKey[Metadata]
+
+  /**
+   * The message key metadata key.
+   */
+  def MessageKey[Key]: MetadataKey[Key] = MessageKeyObj.asInstanceOf[MetadataKey[Key]]
+
+  private val MessageKeyObj = MetadataKey[Any]("messageKey")
+}

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Subscriber.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Subscriber.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Future
 /**
  * A Subscriber for consuming messages from a message broker.
  */
-trait Subscriber[Message] {
+trait Subscriber[Payload] {
 
   /**
    * Returns a copy of this subscriber with the passed group id.
@@ -19,7 +19,16 @@ trait Subscriber[Message] {
    * @param groupId The group id to assign to this subscriber.
    * @return A copy of this subscriber with the passed group id.
    */
-  def withGroupId(groupId: String): Subscriber[Message]
+  def withGroupId(groupId: String): Subscriber[Payload]
+
+  /**
+   * Returns this subscriber, but message payloads are wrapped
+   * in [[Message]] instances to allow accessing any metadata
+   * associated with the message.
+   *
+   * @return A copy of this subscriber.
+   */
+  def withMetadata: Subscriber[Message[Payload]]
 
   /**
    * Returns a stream of messages with at most once delivery semantic.
@@ -27,7 +36,7 @@ trait Subscriber[Message] {
    * If a failure occurs (e.g., an exception is thrown), the user is responsible
    * of deciding how to recover from it (e.g., restarting the stream, aborting, ...).
    */
-  def atMostOnceSource: Source[Message, _]
+  def atMostOnceSource: Source[Payload, _]
 
   /**
    * Applies the passed `flow` to the messages processed by this subscriber. Messages are delivered to the passed
@@ -43,7 +52,7 @@ trait Subscriber[Message] {
    * @param flow The flow to apply to each received message.
    * @return A `Future` that will be completed if the `flow` completes.
    */
-  def atLeastOnce(flow: Flow[Message, Done, _]): Future[Done]
+  def atLeastOnce(flow: Flow[Payload, Done, _]): Future[Done]
 }
 
 object Subscriber {

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Topic.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Topic.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.scaladsl.api.broker
 /**
  * A topic can be used to publish/subscribe messages to/from a message broker.
  */
-trait Topic[Message] {
+trait Topic[Payload] {
   /**
    * The topic identifier.
    *
@@ -19,7 +19,7 @@ trait Topic[Message] {
    *
    * @return A Subscriber to this topic.
    */
-  def subscribe: Subscriber[Message]
+  def subscribe: Subscriber[Payload]
 
 }
 

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaTopic.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaTopic.scala
@@ -18,6 +18,6 @@ private[lagom] class ScaladslKafkaTopic[Message](kafkaConfig: KafkaConfig, topic
 
   override def topicId: TopicId = topicCall.topicId
 
-  override def subscribe: Subscriber[Message] = new ScaladslKafkaSubscriber(kafkaConfig, topicCall,
-    ScaladslKafkaSubscriber.GroupId.default(info), info, system, serviceLocator)
+  override def subscribe: Subscriber[Message] = new ScaladslKafkaSubscriber[Message, Message](kafkaConfig, topicCall,
+    ScaladslKafkaSubscriber.GroupId.default(info), info, system, serviceLocator, _.value)
 }

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/KafkaMetadataKeys.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/scaladsl/broker/kafka/KafkaMetadataKeys.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.broker.kafka
+
+import com.lightbend.lagom.scaladsl.api.broker.MetadataKey
+import org.apache.kafka.common.header.Headers
+
+/**
+ * Metadata keys specific to the Kafka broker implementation.
+ */
+object KafkaMetadataKeys {
+
+  /**
+   * The partition the message is published to.
+   */
+  val Partition: MetadataKey[Int] = MetadataKey("kafkaPartition")
+
+  /**
+   * The offset of the message in its partition.
+   */
+  val Offset: MetadataKey[Long] = MetadataKey("kafkaOffset")
+
+  /**
+   * The topic the message is published to.
+   */
+  val Topic: MetadataKey[String] = MetadataKey("kafkaTopic")
+
+  /**
+   * The Kafka message headers.
+   */
+  val Headers: MetadataKey[Headers] = MetadataKey("kafkaHeaders")
+}

--- a/service/scaladsl/kafka/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaSubscriberSpec.scala
+++ b/service/scaladsl/kafka/client/src/test/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaSubscriberSpec.scala
@@ -13,7 +13,7 @@ class ScaladslKafkaSubscriberSpec extends FlatSpec with Matchers {
   behavior of "ScaladslKafkaSubscriber"
 
   it should "create a new subscriber with updated groupId" in {
-    val subscriber = new ScaladslKafkaSubscriber(null, null, ScaladslKafkaSubscriber.GroupId("old"), null, null, null)(null, null)
+    val subscriber = new ScaladslKafkaSubscriber(null, null, ScaladslKafkaSubscriber.GroupId("old"), null, null, null, null)(null, null)
     subscriber.withGroupId("newGID") should not be subscriber
   }
 }

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/testkit/TopicStub.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/testkit/TopicStub.scala
@@ -9,21 +9,30 @@ import akka.Done
 import akka.actor.ActorRef
 import akka.stream.Materializer
 import akka.stream.javadsl.{ Flow, Source }
+import akka.stream.scaladsl.{ Flow => ScalaFlow }
 import com.lightbend.lagom.internal.testkit.InternalSubscriberStub
-import com.lightbend.lagom.javadsl.api.broker.{ Subscriber, Topic }
+import com.lightbend.lagom.javadsl.api.broker.{ Message, Subscriber, Topic }
 
 import scala.compat.java8.FutureConverters.toJava
 
 private[lagom] class TopicStub[T](val topicId: Topic.TopicId, topicBuffer: ActorRef)(implicit materializer: Materializer) extends Topic[T] {
 
   // TODO: use ServiceInfo's name as a default value.
-  def subscribe = new SubscriberStub("default", topicBuffer)
+  def subscribe = new SubscriberStub("default", topicBuffer, _.getPayload)
 
-  class SubscriberStub(groupId: String, topicBuffer: ActorRef)(implicit materializer: Materializer)
-    extends InternalSubscriberStub[T](groupId, topicBuffer)(materializer) with Subscriber[T] {
+  class SubscriberStub[SubscriberPayload](groupId: String, topicBuffer: ActorRef, transform: Message[T] => SubscriberPayload)(implicit materializer: Materializer)
+    extends InternalSubscriberStub[T, Message](groupId, topicBuffer)(materializer) with Subscriber[SubscriberPayload] {
 
-    override def withGroupId(groupId: String): Subscriber[T] = new SubscriberStub(groupId, topicBuffer)
-    override def atMostOnceSource(): Source[T, _] = super.mostOnceSource.asJava
-    override def atLeastOnce(flow: Flow[T, Done, _]): CompletionStage[Done] = toJava(super.leastOnce(flow.asScala))
+    override def withGroupId(groupId: String): Subscriber[SubscriberPayload] =
+      new SubscriberStub(groupId, topicBuffer, transform)
+
+    override def withMetadata(): Subscriber[Message[SubscriberPayload]] =
+      new SubscriberStub[Message[SubscriberPayload]](groupId, topicBuffer, msg => msg.withPayload(transform(msg)))
+
+    override def atMostOnceSource(): Source[SubscriberPayload, _] =
+      super.mostOnceSource.map(transform).asJava
+
+    override def atLeastOnce(flow: Flow[SubscriberPayload, Done, _]): CompletionStage[Done] =
+      toJava(super.leastOnce(ScalaFlow[Message[T]].map(transform).via(flow.asScala)))
   }
 }

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ProducerStubFactory.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ProducerStubFactory.scala
@@ -11,7 +11,7 @@ import akka.actor.{ ActorRef, ActorSystem, Props }
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.javadsl.testkit.TopicStub
 import com.lightbend.lagom.internal.testkit.TopicBufferActor
-import com.lightbend.lagom.javadsl.api.broker.Topic
+import com.lightbend.lagom.javadsl.api.broker.{ Message, Topic }
 
 /**
  * Factors [[com.lightbend.lagom.javadsl.testkit.ProducerStub]]'s. This is a singleton that should be [[javax.inject.Inject]]ed
@@ -50,6 +50,12 @@ final class ProducerStub[T] private[lagom] (topicName: String, actorSystem: Acto
    *
    * @param message
    */
-  def send(message: T): Unit = bufferActor.tell(message, ActorRef.noSender)
+  def send(message: T): Unit = send(Message.create(message))
 
+  /**
+   * Send a message wrapped with metadata to the topic.
+   *
+   * @param message The message to send.
+   */
+  def send(message: Message[T]): Unit = bufferActor.tell(message, ActorRef.noSender)
 }


### PR DESCRIPTION
Supersedes #930.

This provides an abstraction for accessing message metadata. Metadata keys are strongly typed (like topic properties). The message key is considered a generic key rather than being Kafka specific, so is defined in the Lagom api project. It has been designed such that we can support message keys other than String in future (though String is still only supported by Lagom, that's a separate thing to this).

Other Kafka specific properties that have been added are offset, partition, topic, and headers - the headers use the immutable Headers type from the Kafka consumer API.

While this change only supports accessing metadata from the consumer side, a similar approach could be added in future to produce custom metadata on the producer side.

Documentation to come.