### PR TITLE
Document ReadSide.register in the Cassandra/RDBMS read-side documentation

### DIFF
--- a/docs/manual/java/guide/cluster/ReadSideCassandra.md
+++ b/docs/manual/java/guide/cluster/ReadSideCassandra.md
@@ -76,6 +76,12 @@ And then to register them:
 
 @[register-prepare](code/docs/home/persistence/CassandraBlogEventProcessor.java)
 
+### Registering your read-side processor
+
+Once you've created your read-side processor, you need to register it with Lagom. This is done using the [`ReadSide`](api/index.html?com/lightbend/lagom/javadsl/persistence/ReadSide.html) component:
+
+@[register-event-processor](code/docs/home/persistence/BlogServiceImpl3.java)
+
 ### Event handlers
 
 The event handlers take an event, and return a list of bound statements.  Rather than executing updates in the handler itself, it is recommended that you return the statements that you want to execute to Lagom.  This allows Lagom to batch those statements with the offset table update statement, which Lagom will then executed as a logged batch, which Cassandra executes atomically.  By doing this you can ensure exactly once processing of all events, otherwise processing may be at least once.

--- a/docs/manual/java/guide/cluster/ReadSideJDBC.md
+++ b/docs/manual/java/guide/cluster/ReadSideJDBC.md
@@ -68,6 +68,12 @@ If you read the [[Cassandra read-side support|ReadSideCassandra]] guide, you may
 
 Again this callback is optional, and in our example we have no need for a prepare callback, so none is specified.
 
+### Registering your read-side processor
+
+Once you've created your read-side processor, you need to register it with Lagom. This is done using the [`ReadSide`](api/index.html?com/lightbend/lagom/javadsl/persistence/ReadSide.html) component:
+
+@[register-event-processor](code/docs/home/persistence/BlogServiceImpl3.java)
+
 ### Event handlers
 
 The event handlers take an event and a connection, and update the read-side accordingly.

--- a/docs/manual/java/guide/cluster/ReadSideJPA.md
+++ b/docs/manual/java/guide/cluster/ReadSideJPA.md
@@ -119,6 +119,12 @@ If you read the [[Cassandra read-side support|ReadSideCassandra]] guide, you may
 
 Again this callback is optional, and in our example we have no need for a prepare callback, so none is specified.
 
+### Registering your read-side processor
+
+Once you've created your read-side processor, you need to register it with Lagom. This is done using the [`ReadSide`](api/index.html?com/lightbend/lagom/javadsl/persistence/ReadSide.html) component:
+
+@[register-event-processor](code/docs/home/persistence/BlogServiceImpl3.java)
+
 ### Event handlers
 
 The event handlers take an event and a JPA `EntityManger`, and update the read-side accordingly.

--- a/docs/manual/scala/guide/cluster/ReadSideCassandra.md
+++ b/docs/manual/scala/guide/cluster/ReadSideCassandra.md
@@ -76,6 +76,12 @@ And then to register them:
 
 @[register-prepare](code/docs/home/scaladsl/persistence/CassandraBlogEventProcessor.scala)
 
+### Registering your read-side processor
+
+Once you've created your read-side processor, you need to register it with Lagom. This is done using the [`ReadSide`](api/index.html#com/lightbend/lagom/scaladsl/persistence/ReadSide) component:
+
+@[register-event-processor](code/docs/home/scaladsl/persistence/BlogServiceImpl3.scala)
+
 ### Event handlers
 
 The event handlers take an event, and return a list of bound statements.  Rather than executing updates in the handler itself, it is recommended that you return the statements that you want to execute to Lagom.  This allows Lagom to batch those statements with the offset table update statement, which Lagom will then executed as a logged batch, which Cassandra executes atomically.  By doing this you can ensure exactly once processing of all events, otherwise processing may be at least once.

--- a/docs/manual/scala/guide/cluster/ReadSideJDBC.md
+++ b/docs/manual/scala/guide/cluster/ReadSideJDBC.md
@@ -68,6 +68,12 @@ If you read the [[Cassandra read-side support|ReadSideCassandra]] guide, you may
 
 Again this callback is optional, and in our example we have no need for a prepare callback, so none is specified.
 
+### Registering your read-side processor
+
+Once you've created your read-side processor, you need to register it with Lagom. This is done using the [`ReadSide`](api/index.html#com/lightbend/lagom/scaladsl/persistence/ReadSide) component:
+
+@[register-event-processor](code/docs/home/scaladsl/persistence/BlogServiceImpl3.scala)
+
 ### Event handlers
 
 The event handlers take an event and a connection, and update the read-side accordingly.

--- a/docs/manual/scala/guide/cluster/ReadSideSlick.md
+++ b/docs/manual/scala/guide/cluster/ReadSideSlick.md
@@ -80,6 +80,12 @@ If you read the [[Cassandra read-side support|ReadSideCassandra]] guide, you may
 
 Again this callback is optional, and in our example we have no need for a prepare callback, so none is specified.
 
+### Registering your read-side processor
+
+Once you've created your read-side processor, you need to register it with Lagom. This is done using the [`ReadSide`](api/index.html#com/lightbend/lagom/scaladsl/persistence/ReadSide) component:
+
+@[register-event-processor](code/docs/home/scaladsl/persistence/BlogServiceImpl3.scala)
+
 ### Event handlers
 
 The event handlers take an event and returns a Slick `DBIOAction`.


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #996 

## Purpose

Added to the persistent read-sides documentation for CassandraReadSide, JdbcReadSide, etc the missing section about registering read-side processors

## Background Context

It seemed pretty straight forward

## References

no
