### PR TITLE
Service Router actions should use filtered request (1.3.x)

### DIFF
--- a/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
+++ b/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
@@ -160,10 +160,13 @@ class JavadslServiceRouter(override protected val descriptor: Descriptor, servic
   /**
    * Create the action.
    */
-  override protected def action[Request, Response](call: Call[Request, Response], descriptor: Descriptor,
-                                                   requestSerializer:  MessageSerializer[Request, ByteString],
-                                                   responseSerializer: MessageSerializer[Response, ByteString], requestHeader: RequestHeader,
-                                                   serviceCall: ServiceCall[Request, Response]): EssentialAction = {
+  override protected def action[Request, Response](
+    call:               Call[Request, Response],
+    descriptor:         Descriptor,
+    serviceCall:        ServiceCall[Request, Response],
+    requestSerializer:  MessageSerializer[Request, ByteString],
+    responseSerializer: MessageSerializer[Response, ByteString]
+  ): EssentialAction = {
 
     serviceCall match {
       // If it's a Play service call, then rather than creating the action directly, we let it create the action, and
@@ -172,12 +175,12 @@ class JavadslServiceRouter(override protected val descriptor: Descriptor, servic
         playServiceCall.invoke(
           new java.util.function.Function[ServiceCall[Request, Response], play.mvc.EssentialAction] {
             override def apply(serviceCall: ServiceCall[Request, Response]): play.mvc.EssentialAction = {
-              createAction(serviceCall, call, descriptor, requestSerializer, responseSerializer, requestHeader).asJava
+              createAction(call, descriptor, serviceCall, requestSerializer, responseSerializer).asJava
             }
           }
         )
       case _ =>
-        createAction(serviceCall, call, descriptor, requestSerializer, responseSerializer, requestHeader)
+        createAction(call, descriptor, serviceCall, requestSerializer, responseSerializer)
     }
   }
 

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
@@ -35,8 +35,10 @@ class ScaladslServiceRouter(override protected val descriptor: Descriptor, servi
         Method.GET
       }
     }
-    override val isWebSocket: Boolean = call.requestSerializer.isInstanceOf[StreamedMessageSerializer[_]] ||
-      call.responseSerializer.isInstanceOf[StreamedMessageSerializer[_]]
+    override val isWebSocket: Boolean =
+
+      messageSerializerIsStreamed(call.requestSerializer) ||
+        messageSerializerIsStreamed(call.responseSerializer)
 
     private val holder: ScalaMethodServiceCall[Any, Any] = call.serviceCallHolder match {
       case holder: ScalaMethodServiceCall[Any, Any] => holder
@@ -57,18 +59,21 @@ class ScaladslServiceRouter(override protected val descriptor: Descriptor, servi
   /**
    * Create the action.
    */
-  override protected def action[Request, Response](call: Call[Request, Response], descriptor: Descriptor,
-                                                   requestSerializer:  MessageSerializer[Request, ByteString],
-                                                   responseSerializer: MessageSerializer[Response, ByteString], requestHeader: RequestHeader,
-                                                   serviceCall: ServiceCall[Request, Response]): EssentialAction = {
+  override protected def action[Request, Response](
+    call:               Call[Request, Response],
+    descriptor:         Descriptor,
+    serviceCall:        ServiceCall[Request, Response],
+    requestSerializer:  MessageSerializer[Request, ByteString],
+    responseSerializer: MessageSerializer[Response, ByteString]
+  ): EssentialAction = {
 
     serviceCall match {
       // If it's a Play service call, then rather than creating the action directly, we let it create the action, and
       // pass it a callback that allows it to convert a service call into an action.
       case playServiceCall: PlayServiceCall[Request, Response] =>
-        playServiceCall.invoke(serviceCall => createAction(serviceCall, call, descriptor, requestSerializer, responseSerializer, requestHeader))
+        playServiceCall.invoke(serviceCall => createAction(call, descriptor, serviceCall, requestSerializer, responseSerializer))
       case _ =>
-        createAction(serviceCall, call, descriptor, requestSerializer, responseSerializer, requestHeader)
+        createAction(call, descriptor, serviceCall, requestSerializer, responseSerializer)
     }
   }
 

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStreamedServiceRouterSpec.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStreamedServiceRouterSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.server
+
+import java.util.concurrent.atomic.{ AtomicBoolean, AtomicInteger }
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.lightbend.lagom.internal.scaladsl.server.ScaladslServiceRouter
+import com.lightbend.lagom.scaladsl.api.transport._
+import com.lightbend.lagom.scaladsl.api.{ Service, ServiceCall }
+import com.lightbend.lagom.scaladsl.server.mocks._
+import com.lightbend.lagom.scaladsl.server.testkit.FakeRequest
+import org.scalatest.{ Assertion, AsyncFlatSpec, BeforeAndAfterAll, Matchers }
+import play.api.http.HttpConfiguration
+import play.api.http.websocket.{ Message, TextMessage }
+import play.api.mvc
+import play.api.mvc.Handler
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+ * This test relies on DefaultExceptionSerializer so in case of failure some information is lost on de/ser. Check the
+ * status code of the response (won't be 200) and locate the suspect line of code where that status code is launched.
+ */
+class ScaladslStreamedServiceRouterSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val system = ActorSystem("ScaladslServiceRouterSpec")
+  private implicit val ec: ExecutionContext = system.dispatcher
+  private implicit val mat: Materializer = ActorMaterializer.create(system)
+
+  override protected def afterAll(): Unit = {
+    system.terminate()
+    super.afterAll()
+  }
+
+  behavior of "ScaladslServiceRouter"
+
+  it should "serve a non-filtered Streamed request" in {
+    val atomicBoolean = new AtomicBoolean(false)
+    // this test is canary
+    val service = new SimpleStreamedService {
+      override def streamed(): ServerServiceCall[Source[String, NotUsed], Source[String, NotUsed]] = ServerServiceCall { (headers, _) =>
+        atomicBoolean.compareAndSet(false, true)
+        Future.successful((ResponseHeader.Ok, Source.single("unused")))
+      }
+    }
+
+    val x: mvc.WebSocket => mvc.RequestHeader => Future[WSFlow] =
+      (websocket) => (rh) => websocket(rh).map(_.right.get)
+
+    runRequest(service)(x) {
+      atomicBoolean.get() should be(true)
+    }
+  }
+
+  // this test can only assert that play filters and lagom filters were invoked and request headers made its way into
+  // the service implementation layer but since this test is not running a fully fledged HTTP server
+  // we can't run assertions over the response headers. The expected behavior is that both play and lagom filters
+  // are invoked while processing the response but Play doesn't support adding custom headers on a websocket handshake.
+  ignore should "propagate headers added by a Play Filter down to the ServiceImpl. [Streamed message]"
+
+  // this test can only assert that play filters and lagom filters were invoked and request headers made its way into
+  // the service implementation layer but since this test is not running a fully fledged HTTP server
+  // we can't run assertions over the response headers. The expected behavior is that both play and lagom filters
+  // are invoked while processing the response but Play doesn't support adding custom headers on a websocket handshake.
+  ignore should "propagate headers added by a Play Filter and a Lagom HeaderFilter down to the ServiceImpl (invoking Play Filter first). [String message]"
+
+  type WSFlow = Flow[Message, Message, _]
+
+  // ---------------------------------------------------------------------------------------------------
+
+  private def runRequest(service: Service)(x: mvc.WebSocket => mvc.RequestHeader => Future[WSFlow])(block: => Assertion): Future[Assertion] = {
+    val httpConfig = HttpConfiguration()
+    val router = new ScaladslServiceRouter(service.descriptor, service, httpConfig)
+    val req: mvc.Request[NotUsed] = new FakeRequest(method = "GET", path = PathProvider.PATH)
+    val reqHeader: mvc.RequestHeader = req
+    val handler = router.routes(reqHeader)
+    val futureResult: Future[WSFlow] = handler match {
+      case action: mvc.WebSocket => x(action)(reqHeader)
+      case _                     => Future.failed(PayloadTooLarge("Not a WebSocket."))
+    }
+    futureResult flatMap {
+      _.runWith(Source.single(TextMessage("41")), Sink.ignore)._2.map {
+        _ => block
+      }
+    }
+  }
+}
+

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStrictServiceRouterSpec.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStrictServiceRouterSpec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.server
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
+import akka.stream.{ ActorMaterializer, Materializer }
+import com.lightbend.lagom.internal.scaladsl.server.ScaladslServiceRouter
+import com.lightbend.lagom.scaladsl.api.transport._
+import com.lightbend.lagom.scaladsl.api.{ Service, ServiceCall }
+import com.lightbend.lagom.scaladsl.server.mocks._
+import com.lightbend.lagom.scaladsl.server.testkit.FakeRequest
+import org.scalatest.{ AsyncFlatSpec, BeforeAndAfterAll, Matchers }
+import play.api.http.HttpConfiguration
+import play.api.mvc
+import play.api.mvc.{ EssentialAction, Handler, Results }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+ * This test relies on DefaultExceptionSerializer so in case of failure some information is lost on de/ser. Check the
+ * status code of the response (won't be 200) and locate the suspect line of code where that status code is launched.
+ */
+class ScaladslStrictServiceRouterSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val system = ActorSystem("ScaladslServiceRouterSpec")
+  private implicit val ec: ExecutionContext = system.dispatcher
+  private implicit val mat: Materializer = ActorMaterializer.create(system)
+
+  override protected def afterAll(): Unit = {
+    system.terminate()
+    super.afterAll()
+  }
+
+  behavior of "ScaladslServiceRouter"
+
+  it should "serve a non-filtered Strict request" in {
+    // this test is canary
+    val hardcodedResponse = "a response"
+    val service = new SimpleStrictService {
+      override def simpleGet(): ServiceCall[NotUsed, String] = ServiceCall { _ =>
+        Future.successful(hardcodedResponse)
+      }
+    }
+
+    val x: mvc.EssentialAction => mvc.RequestHeader => Future[mvc.Result] = { (action) => (rh) => action(rh).run() }
+
+    runRequest(service)(x) {
+      _ should be(mvc.Results.Ok(hardcodedResponse))
+    }
+  }
+
+  it should "propagate headers altered by a Play Filter down to the ServiceImpl. [String message]" in {
+    // this test makes sure headers in request and response are added and they are added in the appropriate order.
+    // This test only uses Play filters.
+    val atomicInt = new AtomicInteger(0)
+    val hardcodedResponse = "a response"
+    val service = new SimpleStrictService {
+      override def simpleGet(): ServerServiceCall[NotUsed, String] = ServerServiceCall { (reqHeader, _) =>
+        Future {
+          reqHeader.getHeader(VerboseHeaderPlayFilter.addedOnRequest) should be(Some("1"))
+        }.recoverWith {
+          case t => Future.failed(BadRequest(s"Assertion failed: ${t.getMessage}"))
+        }.map { _ =>
+          (ResponseHeader.Ok.withHeader("in-service", atomicInt.incrementAndGet().toString), hardcodedResponse)
+        }
+      }
+    }
+
+    val x: mvc.EssentialAction => mvc.RequestHeader => Future[mvc.Result] = {
+      (action) => new VerboseHeaderPlayFilter(atomicInt, mat).apply(rh => action(rh).run())
+    }
+
+    runRequest(service)(x) {
+      _ should be(
+        mvc.Results.Ok(hardcodedResponse)
+          .withHeaders(
+            ("in-service", "2"),
+            (VerboseHeaderPlayFilter.addedOnResponse, "3")
+          )
+      )
+    }
+  }
+
+  it should "propagate headers altered by a Play Filter and a Lagom HeaderFilter down to the ServiceImpl (invoking Play Filter first). [String message]" in {
+    // this test makes sure headers in request and response are added and they are added in the appropriate order.
+    val atomicInt = new AtomicInteger(0)
+    val hardcodedResponse = "a response"
+    val service = new FilteredStrictService(atomicInt) {
+      override def simpleGet(): ServerServiceCall[NotUsed, String] = ServerServiceCall {
+        (reqHeader, _) =>
+          Future {
+            (
+              reqHeader.getHeader(VerboseHeaderPlayFilter.addedOnRequest), reqHeader.getHeader(VerboseHeaderLagomFilter.addedOnRequest)
+            ) should be(
+                (Some("1"), Some("2"))
+              )
+            // When this assertion fails, the AssertionException is mapped to a BadRequest but the
+            // exception serializer looses the exception message. Use the status code to locate the
+            // cause of failure.
+            // "1" and "2" are set on play filter and lagom filter respectively
+          }.recoverWith {
+            case t => Future.failed(BadRequest(s"Assertion failed: ${
+              t.getMessage
+            }"))
+          }.map {
+            _ =>
+              // if both headers are present, OK is returned with a new header from the service.
+              // the filters will add two more headers.
+              (ResponseHeader.Ok.withHeader("in-service", atomicInt.incrementAndGet().toString), hardcodedResponse)
+          }
+      }
+    }
+
+    val x: mvc.EssentialAction => mvc.RequestHeader => Future[mvc.Result] = {
+      (action) => new VerboseHeaderPlayFilter(atomicInt, mat).apply(rh => action(rh).run())
+    }
+
+    runRequest(service)(x) {
+      _ should be(
+        // when everything works as expected, the service receives 2 headers with values '1' and '2' and responds
+        // with three headers '3', '4' and '5'. In case of failure, some headers may still be added on the way out
+        // so make sure to check the status code on the response for more details on the cause of the error.
+        mvc.Results.Ok(hardcodedResponse)
+          .withHeaders(
+            ("in-service", "3"), // when this is missing it means the ServiceImpl code failed == missing request headers
+            (VerboseHeaderLagomFilter.addedOnResponse, "4"),
+            (VerboseHeaderPlayFilter.addedOnResponse, "5")
+          )
+      )
+    }
+  }
+  // ---------------------------------------------------------------------------------------------------
+
+  private def runRequest[T](service: Service)(x: mvc.EssentialAction => mvc.RequestHeader => Future[mvc.Result])(block: mvc.Result => T): Future[T] = {
+    val httpConfig = HttpConfiguration()
+    val router = new ScaladslServiceRouter(service.descriptor, service, httpConfig)
+    val req: mvc.Request[NotUsed] = new FakeRequest(method = "GET", path = PathProvider.PATH)
+    val reqHeader: mvc.RequestHeader = req
+    val handler = router.routes(reqHeader)
+    val futureResult: Future[mvc.Result] = handler match {
+      case action: mvc.EssentialAction => x(action)(reqHeader)
+      case _                           => Future.failed(PayloadTooLarge("Not an EssentialAction."))
+    }
+    futureResult map block
+  }
+}
+

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/mocks/MockFilters.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/mocks/MockFilters.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.server.mocks
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.stream.Materializer
+import com.lightbend.lagom.scaladsl.api.transport.{ Forbidden, HeaderFilter, RequestHeader, ResponseHeader }
+import play.api.mvc.{ Filter, Result, RequestHeader => PlayRequestHeader, ResponseHeader => PlayResponseHeader }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+// ------------------------------------------------------------------------------------------------------------
+// This is a play filter that adds a header on the request and the adds a header on the response. Headers may only
+// be added once so invoking this Filter twice breaks the test.
+class VerboseHeaderPlayFilter(atomicInt: AtomicInteger, mt: Materializer)(implicit ctx: ExecutionContext) extends Filter {
+
+  import VerboseHeaderPlayFilter._
+
+  override implicit def mat: Materializer = mt
+
+  override def apply(f: (PlayRequestHeader) => Future[Result])(rh: PlayRequestHeader): Future[Result] = {
+    ensureMissing(rh.headers.toSimpleMap, addedOnRequest)
+    val richerHeaders = rh.headers.add(addedOnRequest -> atomicInt.incrementAndGet().toString)
+    val richerRequest = rh.copy(headers = richerHeaders)
+    f(richerRequest).map {
+      case result =>
+        ensureMissing(result.header.headers, addedOnResponse)
+        result.withHeaders(addedOnResponse -> atomicInt.incrementAndGet().toString)
+    }
+  }
+
+  private def ensureMissing(headers: Map[String, String], key: String) =
+    if (headers.get(key).isDefined) throw Forbidden(s"Header $key already exists.")
+}
+
+object VerboseHeaderPlayFilter {
+  val addedOnRequest = "addedOnRequest-play"
+  val addedOnResponse = "addedOnResponse-play"
+}
+
+// ------------------------------------------------------------------------------------------------------------
+// This is a Lagom HeaderFilter that adds a header on the request and the adds a header on the response.
+class VerboseHeaderLagomFilter(atomicInteger: AtomicInteger) extends HeaderFilter {
+  override def transformServerRequest(request: RequestHeader): RequestHeader =
+    request.addHeader(VerboseHeaderLagomFilter.addedOnRequest, atomicInteger.incrementAndGet().toString)
+
+  override def transformServerResponse(response: ResponseHeader, request: RequestHeader): ResponseHeader =
+    response.addHeader(VerboseHeaderLagomFilter.addedOnResponse, atomicInteger.incrementAndGet().toString)
+
+  override def transformClientResponse(response: ResponseHeader, request: RequestHeader): ResponseHeader = ???
+
+  override def transformClientRequest(request: RequestHeader): RequestHeader = ???
+}
+
+object VerboseHeaderLagomFilter {
+  val addedOnRequest = "addedOnRequest-Lagom"
+  val addedOnResponse = "addedOnResponse-Lagom"
+}

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/mocks/MockServices.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/mocks/MockServices.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.server.mocks
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import com.lightbend.lagom.scaladsl.api.Service.{ pathCall, named, restCall }
+import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceCall }
+import com.lightbend.lagom.scaladsl.api.deser.DefaultExceptionSerializer
+import com.lightbend.lagom.scaladsl.api.transport.Method
+import play.api.{ Environment, Mode }
+
+object PathProvider {
+  val PATH = "/some-path"
+}
+
+/**
+ * A simple service tests may implement to provide their needed behavior.
+ */
+trait SimpleStrictService extends Service {
+  override def descriptor: Descriptor =
+    named("simple-strict")
+      .withCalls(restCall(Method.GET, PathProvider.PATH, simpleGet _))
+      .withExceptionSerializer(new DefaultExceptionSerializer(Environment.simple(mode = Mode.Dev)))
+
+  def simpleGet(): ServiceCall[NotUsed, String]
+}
+
+/**
+ * A simple service that uses Lagom's HeaderFilters. Tests may implement this to provide their needed behavior.
+ */
+abstract class FilteredStrictService(atomicInteger: AtomicInteger) extends SimpleStrictService {
+  override def descriptor: Descriptor =
+    super.descriptor.withHeaderFilter(new VerboseHeaderLagomFilter(atomicInteger))
+
+}
+
+/**
+ * A simple service tests may implement to provide their needed behavior.
+ */
+trait SimpleStreamedService extends Service {
+  override def descriptor: Descriptor =
+    named("simple-streamed")
+      .withCalls(pathCall(PathProvider.PATH, streamed _))
+      .withExceptionSerializer(new DefaultExceptionSerializer(Environment.simple(mode = Mode.Dev)))
+
+  def streamed(): ServiceCall[Source[String, NotUsed], Source[String, NotUsed]]
+}

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/testkit/FakeRequest.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/testkit/FakeRequest.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.server.testkit
+
+import java.net.URI
+import java.security.cert.X509Certificate
+
+import akka.NotUsed
+import play.api.mvc.{ Headers, Request }
+
+/**
+ * This is a simplified FakeRequest inspired on Play-Test's FakeRequest. Creating this simple copy here
+ * avoids adding a dependency to play-test that brings in too much transitive baggage
+ */
+class FakeRequest(override val method: String, override val path: String) extends Request[NotUsed] {
+  override def body: NotUsed = NotUsed
+
+  override def id: Long = 42L
+
+  override def tags: Map[String, String] = Map.empty[String, String]
+
+  override def uri: String = new URI(path).toString
+
+  override def version: String = "HTTP/1.1"
+
+  override def queryString: Map[String, Seq[String]] = Map.empty[String, Seq[String]]
+
+  override def headers: Headers = new Headers(Seq("Host" -> "localhost"))
+
+  override def remoteAddress: String = ""
+
+  override def secure: Boolean = false
+
+  override def clientCertificateChain: Option[Seq[X509Certificate]] = None
+}


### PR DESCRIPTION
This is a backport of #1030.

When a new request arrives, the ServiceRouter in Lagom builds a Play Action on the fly. That Action closes over the request.headers as received over the wire before the request is filtered.

The side-effect of that is that when using Play filters in a Lagom service, if the play filter modifies the headers then the modifications are not available on the Lagom code. Other modifications on the request are available on the Lagom code because the Action build on the fly by the ServiceRouter distinguishes between request and headers.

This PR ignores the headers received in favour of parsing the headers only when they are needed.

