### PR TITLE
Added child persistent entity

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntityAdvanced.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityAdvanced.md
@@ -45,7 +45,7 @@ Similar to `tell`, `forward` can also be used to send a message, the difference 
 
 Finally `ask` can be used to get a future of the reply sent to the message:
 
-@[child-persistent-entity-forward](code/docs/home/persistence/ChildActors.java)
+@[child-persistent-entity-ask](code/docs/home/persistence/ChildActors.java)
 
 ### Shutting a child entity down
 

--- a/docs/manual/java/guide/cluster/PersistentEntityAdvanced.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityAdvanced.md
@@ -1,0 +1,58 @@
+# Advanced Persistent Entity Usage
+
+Below are some advanced usages of persistent entities.
+
+## Child actors
+
+Lagom's `PersistentEntityRegistry` creates and distributes persistent entities by running them in actors, distributed across a Lagom cluster using [Akka cluster sharding](https://doc.akka.io/docs/akka/current/cluster-sharding.html?language=java). In some use cases, it may make sense to run persistent entities as a child actor of a user managed actor, which itself may be distributed using cluster sharding. Some examples of such use cases include:
+
+* Persistent process managers. When you have a long running operation that involves multiple interactions with other systems or entities, it is often necessary to store the state of the process, so that it can be continued by an asynchronous signal (such as a message arriving through a message queue). Lagom's persistent entity API can be a good fit for this persistence, since it provides an audit log of the process, and it allows read side processors to do reconciliation on the process.
+* Hybrid persistence solutions. Persistent entities are not suited to some persistence requirements, such as the need to store large blobs of data. In such cases it may make sense to store parts of the data that fit an event model in a persistent entity, while storing the blob data directly in a database designed for that. Updates would need to be idempotent with a durable retry mechanism if either failed.
+
+Lagom provides a [`ChildPersistentEntityFactory`](api/index.html?com/lightbend/lagom/javadsl/persistence/ChildPersistentEntityFactory.html) for instantiating persistent entities as a child of a user managed actor. This allows you to implement your process or other management logic in an actor, with the persistent entity being a direct child so that all communication with it is local, rather than needing to go through Akka cluster sharding to communicate with it.
+
+### Uniqueness of persistent entities
+
+It is of utmost importance that each persistent entity is only represented by one actor across the cluster at any time. `ChildPersistentEntityFactory` does not and cannot ensure the uniqueness of entities, it is up to the application code to use a cluster mechanism for doing this. The most straight forward way to do this is to have the parent actors distributed using Akka cluster sharding, and ensuring a 1:1 relationship of parent actors to persistent entities (based on, for example, the parent actors entity id). How to shard actors across a cluster is beyond the scope of this documentation, the [Akka cluster sharding documentation](https://doc.akka.io/docs/akka/current/cluster-sharding.html?language=java) can be consulted for this.
+
+### Creating a child persistent entity factory
+
+The [`ChildPersistentEntityFactory`](api/index.html?com/lightbend/lagom/javadsl/persistence/ChildPersistentEntityFactory.html) can be created by supplying a class for the entity, and a Play `Injector`. This is typically created by the code that starts the parent actor and the cluster sharding instance that distributes it. Once created, the factory can then be passed to created actors via their constructors, through an Akka `Props`:
+
+@[create-child-persistent-entity-factory](code/docs/home/persistence/ChildActors.java)
+
+The reason the factory gets created outside of the actor is that this allows mocked factories to be injected, which can be backed by Actor probes rather than an actual database backed entity.
+
+### Creating a child persistent entity
+
+Inside an actor that has a `ChildPersistentEntityFactory`, you can create entities. This is often done in the constructor or `preStart` function of the entity:
+
+@[create-child-persistent-entity](code/docs/home/persistence/ChildActors.java)
+
+The `processId` parameter will be the ID of the entity, it must be unique across the entire cluster. The name, `entity`, is the name of the child actor, and does not have to be unique.
+
+### Using a child persistent entity
+
+`ChildPersistentEntityFactory.create` returns a [`ChildPersistentEntity`](api/index.html?com/lightbend/lagom/javadsl/persistence/ChildPersistentEntity.html). This provides a number of methods, mirroring the methods available for communicating with actors.
+
+The `tell` method can be used to send a message from the current actor:
+
+@[child-persistent-entity-tell](code/docs/home/persistence/ChildActors.java)
+
+Similar to `tell`, `forward` can also be used to send a message, the difference being that the sender of the message will be the sender of the current message being processed in the parent actor:
+
+@[child-persistent-entity-forward](code/docs/home/persistence/ChildActors.java)
+
+Finally `ask` can be used to get a future of the reply sent to the message:
+
+@[child-persistent-entity-forward](code/docs/home/persistence/ChildActors.java)
+
+### Shutting a child entity down
+
+When rebalancing a cluster, it's important that graceful shutdown of entity actors is used to ensure all persistence operations have complete before the entity is started up on another cluster. To gracefully shut a child persistent entity down, the `stop` method can be used to tell it to shut down. The `getActorRef` method can then be used to obtain a reference to the actor, which can then be watched, and when it does shut down, the parent actor can shut itself down.
+
+### Testing actors that use child persistent entities
+
+The `ChildPersistentEntityFactory` conveniently allows child persistent entity actors to be mocked, by supplying an `ActorRef` to `ChildPersistentEntityFactory.mocked`. This `ActorRef` can be an Akka TestKit probe, which allows you to run assertions about what messages were sent to the entity, and simulate responses back. Here's an example of how to use it:
+
+@[mock-child-persistent-entity](code/docs/home/persistence/ChildActors.java)

--- a/docs/manual/java/guide/cluster/code/docs/home/persistence/ChildActors.java
+++ b/docs/manual/java/guide/cluster/code/docs/home/persistence/ChildActors.java
@@ -7,8 +7,7 @@ import akka.actor.Props;
 import akka.cluster.sharding.ClusterSharding;
 import akka.cluster.sharding.ClusterShardingSettings;
 import akka.cluster.sharding.ShardRegion;
-import akka.testkit.TestKit;
-import akka.testkit.TestProbe;
+import akka.testkit.javadsl.TestKit;
 import akka.util.Timeout;
 import com.lightbend.lagom.javadsl.persistence.ChildPersistentEntity;
 import com.lightbend.lagom.javadsl.persistence.ChildPersistentEntityFactory;
@@ -147,17 +146,17 @@ public interface ChildActors {
                         // our test probe.
                         ChildPersistentEntityFactory.mocked(
                             MyProcessManagerEntity.class,
-                            probe.testActor()
+                            probe.getRef()
                         )
                     ))
                 );
 
                 // Send the process manager a start message
-                processManager.tell("start", testActor());
+                processManager.tell("start", getRef());
                 // Expect the entity to receive a start process message
                 probe.expectMsg(new StartProcess());
                 // Simulate the entity to reply with a started message
-                probe.lastSender().tell("started", probe.testActor());
+                probe.reply("started");
                 // Expect that message to be mapped forward back to us
                 expectMsg(new MappedReply("started"));
             }};

--- a/docs/manual/java/guide/cluster/code/docs/home/persistence/ChildActors.java
+++ b/docs/manual/java/guide/cluster/code/docs/home/persistence/ChildActors.java
@@ -1,0 +1,168 @@
+package docs.home.persistence;
+
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.cluster.sharding.ClusterSharding;
+import akka.cluster.sharding.ClusterShardingSettings;
+import akka.cluster.sharding.ShardRegion;
+import akka.testkit.TestKit;
+import akka.testkit.TestProbe;
+import akka.util.Timeout;
+import com.lightbend.lagom.javadsl.persistence.ChildPersistentEntity;
+import com.lightbend.lagom.javadsl.persistence.ChildPersistentEntityFactory;
+import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import play.inject.Injector;
+
+import javax.inject.Inject;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+public interface ChildActors {
+
+    //#create-child-persistent-entity-factory
+    public class MyProcessManagerRouter {
+
+        private final ActorRef processManager;
+
+        @Inject
+        public MyProcessManagerRouter(ActorSystem system, Injector injector) {
+            ChildPersistentEntityFactory<MyCommand> factory =
+                ChildPersistentEntityFactory.forEntity(
+                    MyProcessManagerEntity.class, injector);
+
+            processManager = ClusterSharding.get(system).start(
+                "MyProcessManager",
+                Props.create(() -> new MyProcessManager(factory)),
+                ClusterShardingSettings.create(system),
+                messageExtractor
+            );
+        }
+
+        // ...
+        //#create-child-persistent-entity-factory
+
+        private ShardRegion.MessageExtractor messageExtractor;
+    }
+
+    public interface MyCommand {}
+
+    public class StartProcess implements MyCommand, PersistentEntity.ReplyType<String> {
+
+    }
+
+    public class MyProcessManagerEntity extends PersistentEntity<MyCommand, String, String> {
+        @Override
+        public Behavior initialBehavior(Optional<String> snapshotState) {
+            return newBehaviorBuilder("").build();
+        }
+    }
+
+    //#create-child-persistent-entity
+    public class MyProcessManager extends AbstractActor {
+
+        private final ChildPersistentEntityFactory<MyCommand> factory;
+        private ChildPersistentEntity<MyCommand> entity;
+
+        public MyProcessManager(ChildPersistentEntityFactory<MyCommand> factory) {
+            this.factory = factory;
+        }
+
+        @Override
+        public void preStart() throws Exception {
+            entity = factory.create(
+                context().self().path().name(), // The entity id
+                "entity",             // Name of the child actor
+                context()                       // Actor context
+            );
+        }
+
+        // ...
+        //#create-child-persistent-entity
+
+        @Override
+        public Receive createReceive() {
+            return receiveBuilder().build();
+        }
+
+        private void demonstrateTell() {
+            //#child-persistent-entity-tell
+            entity.tell(new StartProcess(), self());
+            //#child-persistent-entity-tell
+        }
+
+        private void demonstrateForward() {
+            //#child-persistent-entity-forward
+            entity.forward(new StartProcess(), context());
+            //#child-persistent-entity-forward
+        }
+
+        private void demonstrateAsk() {
+            //#child-persistent-entity-ask
+            CompletionStage<MappedReply> result =
+                entity.ask(new StartProcess(),
+                    Timeout.apply(3, TimeUnit.SECONDS)
+                ).thenApply(MappedReply::new);
+
+            akka.pattern.PatternsCS.pipe(result, context().dispatcher())
+                .to(self());
+            //#child-persistent-entity-ask
+        }
+    }
+
+    public class MappedReply {
+        public MappedReply(String reply) {}
+    }
+
+    // Because we don't want junit actually picking this up
+    public @interface Test {}
+
+    //#mock-child-persistent-entity
+    public class MyProcessManagerTest {
+
+        static ActorSystem system;
+
+        @BeforeClass
+        public void setup() {
+            system = ActorSystem.create();
+        }
+
+        @AfterClass
+        public void tearDown() {
+            system.terminate();
+        }
+
+        @Test
+        public void testStartProcess() {
+            new TestKit(system) {{
+                TestKit probe = new TestKit(system);
+
+                ActorRef processManager = system.actorOf(
+                    Props.create(() -> new MyProcessManager(
+                        // Mock the child persistent entity factory to use
+                        // our test probe.
+                        ChildPersistentEntityFactory.mocked(
+                            MyProcessManagerEntity.class,
+                            probe.testActor()
+                        )
+                    ))
+                );
+
+                // Send the process manager a start message
+                processManager.tell("start", testActor());
+                // Expect the entity to receive a start process message
+                probe.expectMsg(new StartProcess());
+                // Simulate the entity to reply with a started message
+                probe.lastSender().tell("started", probe.testActor());
+                // Expect that message to be mapped forward back to us
+                expectMsg(new MappedReply("started"));
+            }};
+        }
+    }
+    //#mock-child-persistent-entity
+
+}

--- a/docs/manual/java/guide/cluster/index.toc
+++ b/docs/manual/java/guide/cluster/index.toc
@@ -1,6 +1,7 @@
 PersistentEntity:Persistent Entity
 PersistentEntityCassandra:Cassandra Persistent Entities
 PersistentEntityRDBMS:Relational Database Persistent Entities
+PersistentEntityAdvanced:Advanced Persistent Entity Topics
 ReadSide:Persistent Read-Side
 ReadSideCassandra:Cassandra Read-Side Support
 ReadSideRDBMS:Relational Database Read-Side Support;next=ReadSideJDBC,ReadSideJPA

--- a/docs/manual/java/guide/cluster/index.toc
+++ b/docs/manual/java/guide/cluster/index.toc
@@ -1,7 +1,7 @@
 PersistentEntity:Persistent Entity
 PersistentEntityCassandra:Cassandra Persistent Entities
 PersistentEntityRDBMS:Relational Database Persistent Entities
-PersistentEntityAdvanced:Advanced Persistent Entity Topics
+PersistentEntityAdvanced:Advanced Persistent Entity Usage
 ReadSide:Persistent Read-Side
 ReadSideCassandra:Cassandra Read-Side Support
 ReadSideRDBMS:Relational Database Read-Side Support;next=ReadSideJDBC,ReadSideJPA

--- a/docs/manual/scala/guide/cluster/PersistentEntityAdvanced.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityAdvanced.md
@@ -1,0 +1,58 @@
+# Advanced Persistent Entity Usage
+
+Below are some advanced usages of persistent entities.
+
+## Child actors
+
+Lagom's `PersistentEntityRegistry` creates and distributes persistent entities by running them in actors, distributed across a Lagom cluster using [Akka cluster sharding](https://doc.akka.io/docs/akka/current/cluster-sharding.html?language=scala). In some use cases, it may make sense to run persistent entities as a child actor of a user managed actor, which itself may be distributed using cluster sharding. Some examples of such use cases include:
+
+* Persistent process managers. When you have a long running operation that involves multiple interactions with other systems or entities, it is often necessary to store the state of the process, so that it can be continued by an asynchronous signal (such as a message arriving through a message queue). Lagom's persistent entity API can be a good fit for this persistence, since it provides an audit log of the process, and it allows read side processors to do reconciliation on the process.
+* Hybrid persistence solutions. Persistent entities are not suited to some persistence requirements, such as the need to store large blobs of data. In such cases it may make sense to store parts of the data that fit an event model in a persistent entity, while storing the blob data directly in a database designed for that. Updates would need to be idempotent with a durable retry mechanism if either failed.
+
+Lagom provides a [`ChildPersistentEntityFactory`](api/com/lightbend/lagom/scaladsl/persistence/ChildPersistentEntityFactory.html) for instantiating persistent entities as a child of a user managed actor. This allows you to implement your process or other management logic in an actor, with the persistent entity being a direct child so that all communication with it is local, rather than needing to go through Akka cluster sharding to communicate with it.
+
+### Uniqueness of persistent entities
+
+It is of utmost importance that each persistent entity is only represented by one actor across the cluster at any time. `ChildPersistentEntityFactory` does not and cannot ensure the uniqueness of entities, it is up to the application code to use a cluster mechanism for doing this. The most straight forward way to do this is to have the parent actors distributed using Akka cluster sharding, and ensuring a 1:1 relationship of parent actors to persistent entities (based on, for example, the parent actors entity id). How to shard actors across a cluster is beyond the scope of this documentation, the [Akka cluster sharding documentation](https://doc.akka.io/docs/akka/current/cluster-sharding.html?language=scala) can be consulted for this.
+
+### Creating a child persistent entity factory
+
+The [`ChildPersistentEntityFactory`](api/com/lightbend/lagom/scaladsl/persistence/ChildPersistentEntityFactory.html) can be created by supplying the factory for creating the entity instance. This is typically created by the code that starts the parent actor and the cluster sharding instance that distributes it. Once created, the factory can then be passed to created actors via their constructors, through an Akka `Props`:
+
+@[create-child-persistent-entity-factory](code/ChildActors.scala)
+
+The reason the factory gets created outside of the actor is that this allows mocked factories to be injected, which can be backed by Actor probes rather than an actual database backed entity.
+
+### Creating a child persistent entity
+
+Inside an actor that has a `ChildPersistentEntityFactory`, you can create entities. This is often done in the constructor or `preStart` function of the entity:
+
+@[create-child-persistent-entity](code/ChildActors.scala)
+
+The first parameter is the ID of the entity, it must be unique across the entire cluster. The name, `entity`, is the name of the child actor, and only has to be unique to that actor.
+
+### Using a child persistent entity
+
+`ChildPersistentEntityFactory.apply` returns a [`ChildPersistentEntity`](api/com/lightbend/lagom/scaladsl/persistence/ChildPersistentEntity.html). This provides a number of methods, mirroring the methods available for communicating with actors.
+
+The `!` method can be used to send a message from the current actor:
+
+@[child-persistent-entity-tell](code/ChildActors.scala)
+
+Similar to `!`, `forward` can also be used to send a message, the difference being that the sender of the message will be the sender of the current message being processed in the parent actor:
+
+@[child-persistent-entity-forward](code/ChildActors.scala)
+
+Finally `?` can be used to get a future of the reply sent to the message:
+
+@[child-persistent-entity-ask](code/ChildActors.scala)
+
+### Shutting a child entity down
+
+When rebalancing a cluster, it's important that graceful shutdown of entity actors is used to ensure all persistence operations have complete before the entity is started up on another cluster. To gracefully shut a child persistent entity down, the `stop` method can be used to tell it to shut down. The `actor` method can then be used to obtain a reference to the actor, which can then be watched, and when it does shut down, the parent actor can shut itself down.
+
+### Testing actors that use child persistent entities
+
+The `ChildPersistentEntityFactory` conveniently allows child persistent entity actors to be mocked, by supplying an `ActorRef` to `ChildPersistentEntityFactory.mocked`. This `ActorRef` can be an Akka TestKit probe, which allows you to run assertions about what messages were sent to the entity, and simulate responses back. Here's an example of how to use it:
+
+@[mock-child-persistent-entity](code/ChildActors.scala)

--- a/docs/manual/scala/guide/cluster/code/ChildActors.scala
+++ b/docs/manual/scala/guide/cluster/code/ChildActors.scala
@@ -1,0 +1,124 @@
+package docs.scaladsl.cluster.childactors
+
+import akka.actor.{Actor, ActorSystem, Props}
+import akka.cluster.sharding.{ClusterSharding, ClusterShardingSettings, ShardRegion}
+import akka.testkit.{TestKit, TestProbe}
+import akka.util.Timeout
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
+import com.lightbend.lagom.scaladsl.persistence.{ChildPersistentEntity, ChildPersistentEntityFactory, PersistentEntity}
+import org.scalatest.{BeforeAndAfterAll, WordSpecLike}
+
+//#create-child-persistent-entity-factory
+class MyProcessManagerRouter(system: ActorSystem, entityFactory: () => MyProcessManagerEntity) {
+  private val processManager = {
+    val factory = ChildPersistentEntityFactory.forEntity(entityFactory)
+    ClusterSharding(system).start(
+      "MyProcessManager",
+      Props(new MyProcessManager(factory)),
+      ClusterShardingSettings(system),
+      extractEntityId,
+      extractShardId
+    )
+  }
+  //#create-child-persistent-entity-factory
+
+  private def extractEntityId: ShardRegion.ExtractEntityId = PartialFunction.empty
+  private def extractShardId: ShardRegion.ExtractShardId = _ => ""
+}
+
+trait MyCommand
+
+case object StartProcess extends MyCommand with ReplyType[String]
+
+class MyProcessManagerEntity extends PersistentEntity {
+  override type Command = MyCommand
+  override type Event = String
+  override type State = String
+  override def initialState = ""
+  override def behavior = {
+    case "" => Actions()
+  }
+}
+
+//#create-child-persistent-entity
+class MyProcessManager(
+    factory: ChildPersistentEntityFactory[MyProcessManagerEntity]
+  ) extends Actor {
+
+  private var entity: ChildPersistentEntity[MyCommand] = _
+
+  override def preStart(): Unit = {
+    entity = factory(
+      context.self.path.name, // The entity id
+      "entity"                // Name of the child actor
+    )
+  }
+  //#create-child-persistent-entity
+
+
+  override def receive = PartialFunction.empty
+
+  private def demonstrateTell(): Unit = {
+    //#child-persistent-entity-tell
+    entity ! StartProcess
+    //#child-persistent-entity-tell
+  }
+
+  private def demonstrateForward(): Unit = {
+    //#child-persistent-entity-forward
+    entity forward StartProcess
+    //#child-persistent-entity-forward
+  }
+
+  private def demonstrateAsk(): Unit = {
+    //#child-persistent-entity-ask
+    import scala.concurrent.duration._
+    implicit val timeout = Timeout(3.seconds)
+
+    import context.dispatcher
+    import akka.pattern.pipe
+
+    val result = (entity ? StartProcess)
+      .map(MappedReply.apply)
+
+    result pipeTo self
+    //#child-persistent-entity-ask
+  }
+}
+
+case class MappedReply(reply: String)
+
+// Ensures scalatest can't find the contained test
+private abstract class Ignore {
+  //#mock-child-persistent-entity
+  class MyProcessManagerTest extends TestKit(ActorSystem())
+    with WordSpecLike with BeforeAndAfterAll {
+
+    override protected def afterAll(): Unit = {
+      system.terminate()
+    }
+
+    "My process manager" should {
+      "allow starting a process" in {
+        val probe = TestProbe()
+
+        val processManager = system.actorOf(Props(new MyProcessManager(
+          // Mock the child persistent entity factory to use
+          // our test probe.
+          ChildPersistentEntityFactory.mocked[MyProcessManagerEntity](probe.testActor)
+        )))
+
+        // Send the process manager a start message
+        processManager ! "start"
+        // Expect the entity to receive a start process message
+        probe.expectMsg(StartProcess)
+        // Simulate the entity to reply with a started message
+        probe reply "started"
+        // Expect that message to be mapped forward back to us
+        expectMsg(MappedReply("started"))
+
+      }
+    }
+  }
+  //#mock-child-persistent-entity
+}

--- a/docs/manual/scala/guide/cluster/index.toc
+++ b/docs/manual/scala/guide/cluster/index.toc
@@ -1,6 +1,7 @@
 PersistentEntity:Persistent Entity
 PersistentEntityCassandra:Cassandra Persistent Entities
 PersistentEntityRDBMS:Relational Database Persistent Entities
+PersistentEntityAdvanced:Advanced Persistent Entity Usage
 ReadSide:Persistent Read-Side
 ReadSideCassandra:Cassandra Read-Side Support
 ReadSideRDBMS:Relational Database Read-Side Support;next=ReadSideJDBC,ReadSideSlick

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraChildPersistentEntitySpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraChildPersistentEntitySpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence.cassandra
+
+import akka.actor.{ Actor, Props, Terminated }
+import akka.util.Timeout
+import com.google.common.collect.ImmutableList
+import com.lightbend.lagom.javadsl.persistence.PersistentEntity.ReplyType
+import com.lightbend.lagom.javadsl.persistence.{ ChildPersistentEntityFactory, TestEntity }
+import play.api.inject.{ NewInstanceInjector, SimpleInjector }
+
+import scala.concurrent.duration._
+import scala.collection.JavaConverters._
+import scala.compat.java8.FutureConverters
+
+class CassandraChildPersistentEntitySpec extends CassandraPersistenceSpec() {
+
+  val add = new TestEntity.Add("foo", 1)
+  def appended(entityId: String) = new TestEntity.Appended(entityId, "FOO")
+  val state = new TestEntity.State(TestEntity.Mode.APPEND, ImmutableList.copyOf(List("FOO").toIterable.asJava))
+  val get = TestEntity.Get.instance()
+
+  "The child persistent entity factory" should {
+    "allow tells" in {
+      val actor = createActor("child-entity-tell")
+      actor ! Tell(add)
+      expectMsg(appended("child-entity-tell"))
+      actor ! Tell(get)
+      expectMsg(state)
+    }
+    "allow asks" in {
+      val actor = createActor("child-entity-ask")
+      actor ! Ask(add)
+      expectMsg(appended("child-entity-ask"))
+      actor ! Ask(get)
+      expectMsg(state)
+    }
+    "allow forwards" in {
+      val actor = createActor("child-entity-forward")
+      actor ! Forward(add)
+      expectMsg(appended("child-entity-forward"))
+      actor ! Forward(get)
+      expectMsg(state)
+    }
+    "allow stopping entity" in {
+      val actor = createActor("child-entity-stop")
+      watch(actor)
+      actor ! Stop
+      expectTerminated(actor)
+    }
+  }
+
+  private def createActor(entityId: String) = {
+    val factory = ChildPersistentEntityFactory.forEntity(
+      classOf[TestEntity],
+      (new SimpleInjector(NewInstanceInjector) + new TestEntity(system)).asJava
+    )
+    system.actorOf(Props(new MyActor(factory, entityId)))
+  }
+
+  case class Ask(cmd: TestEntity.Cmd with ReplyType[_])
+  case class Tell(cmd: TestEntity.Cmd)
+  case object Stop
+  case class Forward(cmd: TestEntity.Cmd)
+
+  private class MyActor(factory: ChildPersistentEntityFactory[TestEntity.Cmd], entityId: String) extends Actor {
+
+    import akka.pattern.pipe
+    import context.dispatcher
+
+    private val timeout = Timeout(10.seconds)
+    private val entity = factory.create(entityId, "entity", context)
+    context.watch(entity.getActor)
+
+    override def receive: Receive = {
+      case Ask(cmd: TestEntity.Cmd with ReplyType[Unit]) =>
+        FutureConverters.toScala(entity.ask[Unit, TestEntity.Cmd with ReplyType[Unit]](cmd, timeout)) pipeTo sender()
+      case Tell(cmd)     => entity.tell(cmd, sender())
+      case Forward(cmd)  => entity.forward(cmd, context)
+      case Stop          => entity.stop()
+      case Terminated(_) => context.stop(self)
+    }
+  }
+
+}

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraChildPersistentEntitySpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraChildPersistentEntitySpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.persistence.cassandra
+
+import akka.actor.{ Actor, Props, Terminated }
+import akka.util.Timeout
+import com.lightbend.lagom.scaladsl.persistence.{ ChildPersistentEntityFactory, TestEntity, TestEntitySerializerRegistry }
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
+
+import scala.concurrent.duration._
+
+class CassandraChildPersistentEntitySpec extends CassandraPersistenceSpec(TestEntitySerializerRegistry) {
+
+  val add = TestEntity.Add("foo")
+  val appended = TestEntity.Appended("FOO")
+  val state = TestEntity.State(TestEntity.Mode.Append, List("FOO"))
+  val get = TestEntity.Get
+
+  "The child persistent entity factory" should {
+    "allow tells" in {
+      val actor = createActor("child-entity-tell")
+      actor ! Tell(add)
+      expectMsg(appended)
+      actor ! Tell(get)
+      expectMsg(state)
+    }
+    "allow asks" in {
+      val actor = createActor("child-entity-ask")
+      actor ! Ask(add)
+      expectMsg(appended)
+      actor ! Ask(get)
+      expectMsg(state)
+    }
+    "allow forwards" in {
+      val actor = createActor("child-entity-forward")
+      actor ! Forward(add)
+      expectMsg(appended)
+      actor ! Forward(get)
+      expectMsg(state)
+    }
+    "allow stopping entity" in {
+      val actor = createActor("child-entity-stop")
+      watch(actor)
+      actor ! Stop
+      expectTerminated(actor)
+    }
+  }
+
+  private def createActor(entityId: String) = {
+    val factory = ChildPersistentEntityFactory.forEntity(() => new TestEntity(system))
+    system.actorOf(Props(new MyActor(factory, entityId)))
+  }
+
+  case class Ask(cmd: TestEntity.Cmd with ReplyType[_])
+  case class Tell(cmd: TestEntity.Cmd)
+  case object Stop
+  case class Forward(cmd: TestEntity.Cmd)
+
+  private class MyActor(factory: ChildPersistentEntityFactory[TestEntity], entityId: String) extends Actor {
+
+    import akka.pattern.pipe
+    import context.dispatcher
+
+    implicit val timeout = Timeout(10.seconds)
+    val entity = factory(entityId, "entity")
+    context.watch(entity.actor)
+
+    override def receive: Receive = {
+      case Ask(cmd)      => (entity ? cmd) pipeTo sender()
+      case Tell(cmd)     => entity.!(cmd)(sender())
+      case Forward(cmd)  => entity forward cmd
+      case Stop          => entity.stop()
+      case Terminated(_) => context.stop(self)
+    }
+  }
+
+}

--- a/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/ChildPersistentEntity.java
+++ b/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/ChildPersistentEntity.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence;
+
+import akka.actor.ActorContext;
+import akka.actor.ActorRef;
+import akka.pattern.Patterns;
+import akka.util.Timeout;
+import com.lightbend.lagom.internal.javadsl.persistence.PersistentEntityActor;
+import com.typesafe.config.Config;
+import play.inject.Injector;
+import scala.compat.java8.FutureConverters;
+import scala.compat.java8.OptionConverters;
+import scala.concurrent.Future;
+import scala.concurrent.duration.Duration;
+import scala.runtime.AbstractFunction0;
+
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A persistent entity that runs as a child actor of the current actor context.
+ */
+public class ChildPersistentEntity<Command> {
+
+  private final ActorRef actor;
+
+  ChildPersistentEntity(ActorRef actor) {
+    this.actor = actor;
+  }
+
+  /**
+   * Get the actual actor for the entity.
+   * <p>
+   * This may be useful in order to watch the actors termination.
+   */
+  public ActorRef getActor() {
+    return actor;
+  }
+
+  /**
+   * Send a message to the actor.
+   */
+  public void tell(Command msg, ActorRef sender) {
+    actor.tell(msg, sender);
+  }
+
+  /**
+   * Ask the actor with a command.
+   */
+  @SuppressWarnings("unchecked")
+  public <Reply, Cmd extends PersistentEntity.ReplyType<Reply>> CompletionStage<Reply> ask(Cmd msg, Timeout timeout) {
+    return FutureConverters.toJava((Future<Reply>) Patterns.ask(actor, msg, timeout));
+  }
+
+  /**
+   * Forward a message to the actor.
+   */
+  public void forward(Command msg, ActorContext ctx) {
+    actor.forward(msg, ctx);
+  }
+
+  /**
+   * Stop the persistent entity.
+   */
+  public void stop() {
+    actor.tell(PersistentEntityActor.Stop$.MODULE$, ActorRef.noSender());
+  }
+
+  /**
+   * Instantiate a persistent entity as a child of the current actor context.
+   * <p>
+   * Note that since this is a direct child, this provides no guarantee that this is the only entity with the given id
+   * running in the cluster, or even in the actor system. It is up to the actor that instantiates this to ensure that
+   * only one instance of the entity across the cluster is instantiated (by using cluster sharding to distribute
+   * itself, for example), or to deal with inconsistencies that may arise due to having multiple entities instantiated
+   * in the cluster.
+   *
+   * @param entityClass The class of the persistent entity.
+   * @param injector    The injector to use to create the persistent entity.
+   * @param entityId    The entity ID.
+   * @param actorName   The actor name.
+   * @param ctx         The actor context.
+   */
+  @SuppressWarnings("unchecked")
+  public static <Command> ChildPersistentEntity<Command> create(Class<? extends PersistentEntity<Command, ?, ?>> entityClass,
+      Injector injector, String entityId, String actorName, ActorContext ctx) {
+
+    Optional<ActorRef> maybeEntity = OptionConverters.toJava(ctx.child(actorName));
+
+    ActorRef actorRef = maybeEntity.orElseGet(() -> {
+      Config conf = ctx.system().settings().config().getConfig("lagom.persistence");
+      Optional<Object> snapshotAfter = Optional.of(conf.getString("snapshot-after"))
+          .filter(str -> !str.equals("off"))
+          .map(str -> conf.getInt("snapshot-after"));
+
+      PersistentEntity<Command, ?, ?> entity = injector.instanceOf(entityClass);
+
+      return ctx.actorOf(PersistentEntityActor.props(
+          entity.entityTypeName(),
+          Optional.of(entityId),
+          new AbstractFunction0() {
+            public Object apply() {
+              return entity;
+            }
+          },
+          snapshotAfter,
+          Duration.Undefined()
+      ), actorName);
+    });
+
+    return new ChildPersistentEntity(actorRef);
+  }
+}

--- a/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/ChildPersistentEntityFactory.java
+++ b/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/ChildPersistentEntityFactory.java
@@ -8,7 +8,15 @@ import akka.actor.ActorRef;
 import akka.actor.PoisonPill;
 import play.inject.Injector;
 
+/**
+ * Factory abstraction for creating child persistent entities.
+ *
+ * This can be used instead of directly invoking
+ * {@link ChildPersistentEntity#create(Class, Injector, String, String, ActorContext)} as a method of indirection to
+ * allow you to inject a mocked actor (eg an Akka TestKit probe) when testing.
+ */
 public interface ChildPersistentEntityFactory<Command> {
+
   /**
    * Create an entity.
    *
@@ -37,9 +45,9 @@ public interface ChildPersistentEntityFactory<Command> {
    * This is intended to be used with an Akka TestKit TestProbe, for example:
    *
    * <pre>
-   * TestProbe entityProbe = TestProbe.apply("persistent-entity");
+   * TestKit entityProbe = new TestKit(system, "persistent-entity");
    * ChildPersistentEntityFactory&lt;MyCommand&gt; childEntityFactory =
-   *   ChildPersistentEntityFactory.mocked(MyEntity.class, entityProbe.ref());
+   *   ChildPersistentEntityFactory.mocked(MyEntity.class, entityProbe.getRef());
    *
    * // Create actor and cause it to send a command to the entity
    * ...

--- a/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/ChildPersistentEntityFactory.java
+++ b/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/ChildPersistentEntityFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence;
+
+import akka.actor.ActorContext;
+import akka.actor.ActorRef;
+import akka.actor.PoisonPill;
+import play.inject.Injector;
+
+public interface ChildPersistentEntityFactory<Command> {
+  /**
+   * Create an entity.
+   *
+   * @param entityId  The id of the entity.
+   * @param actorName The name of the actor.
+   */
+  ChildPersistentEntity<Command> create(String entityId, String actorName, ActorContext ctx);
+
+  /**
+   * Create a {@link ChildPersistentEntityFactory} for entities of the given type.
+   *
+   * @param entityClass The class of the entity.
+   * @param injector The injector to create entities with.
+   * @return The persistent entity factory.
+   */
+  static <Command> ChildPersistentEntityFactory<Command> forEntity(Class<? extends PersistentEntity<Command, ?, ?>> entityClass, Injector injector) {
+    return (entityId, actorName, ctx) -> ChildPersistentEntity.create(entityClass, injector, entityId, actorName, ctx);
+  }
+
+  /**
+   * Create a mocked {@link ChildPersistentEntityFactory}.
+   *
+   * All commands sent to any entities created will be passed as is to the <code>testProbe</code> actor. When
+   * <code>stop</code> is invoked, the actor will be sent a <code>PoisonPill</code>.
+   *
+   * This is intended to be used with an Akka TestKit TestProbe, for example:
+   *
+   * <pre>
+   * TestProbe entityProbe = TestProbe.apply("persistent-entity");
+   * ChildPersistentEntityFactory&lt;MyCommand&gt; childEntityFactory =
+   *   ChildPersistentEntityFactory.mocked(MyEntity.class, entityProbe.ref());
+   *
+   * // Create actor and cause it to send a command to the entity
+   * ...
+   *
+   * entityProbe.expectMsg(new Duration(5, TimeUnit.SECONDS), new MyCommand());
+   * entityProbe.reply(new SomeReply());
+   * </pre>
+   *
+   * @param entityClass The entity class. This is used to infer the Command type.
+   * @param testProbe The test probe ActorRef.
+   */
+  static <Command> ChildPersistentEntityFactory<Command> mocked(Class<? extends PersistentEntity<Command, ?, ?>> entityClass, ActorRef testProbe) {
+    return (entityId, actorName, ctx) -> new ChildPersistentEntity<Command>(testProbe) {
+      @Override
+      public void stop() {
+        testProbe.tell(PoisonPill.getInstance(), ActorRef.noSender());
+      }
+    };
+  }
+}

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/MockChildPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/MockChildPersistentEntitySpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence
+
+import java.util.Optional
+
+import akka.actor.{ Actor, ActorRef, Props }
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import com.lightbend.lagom.javadsl.persistence.PersistentEntity.ReplyType
+import com.lightbend.lagom.persistence.ActorSystemSpec
+
+import scala.concurrent.duration._
+import scala.compat.java8.FutureConverters
+
+class MockChildPersistentEntitySpec extends ActorSystemSpec {
+
+  "The mock child persistent entity factory" should {
+    "allow mock tells" in {
+      val probe = TestProbe()
+      val actor = createActor(probe.ref)
+      actor ! Tell
+      probe.expectMsg(MockCommand)
+      probe.reply("reply")
+      expectMsg("reply")
+    }
+    "allow mock asks" in {
+      val probe = TestProbe()
+      val actor = createActor(probe.ref)
+      actor ! Ask
+      probe.expectMsg(MockCommand)
+      probe.reply("reply")
+      expectMsg("reply")
+    }
+    "allow mock forwards" in {
+      val probe = TestProbe()
+      val actor = createActor(probe.ref)
+      actor ! Forward
+      probe.expectMsg(MockCommand)
+      probe.reply("reply")
+      expectMsg("reply")
+    }
+    "allow stopping the entity" in {
+      val probe = TestProbe()
+      val actor = createActor(probe.ref)
+      watch(probe.ref)
+      actor ! Stop
+      expectTerminated(probe.ref)
+    }
+  }
+
+  private def createActor(testProbe: ActorRef): ActorRef = {
+    system.actorOf(Props(new MyActor(ChildPersistentEntityFactory.mocked(classOf[MyEntity], testProbe))))
+  }
+
+  case object MockCommand extends ReplyType[String]
+
+  case object Ask
+  case object Tell
+  case object Stop
+  case object Forward
+
+  private class MyActor(factory: ChildPersistentEntityFactory[MockCommand.type]) extends Actor {
+
+    import akka.pattern.pipe
+    import context.dispatcher
+
+    private val timeout = Timeout(10.seconds)
+    private val entity = factory.create("entity-id", "entity", context)
+    context.watch(entity.getActor)
+
+    override def receive: Receive = {
+      case Ask     => FutureConverters.toScala(entity.ask[String, MockCommand.type](MockCommand, timeout)) pipeTo sender()
+      case Tell    => entity.tell(MockCommand, sender())
+      case Forward => entity.forward(MockCommand, context)
+      case Stop    => entity.stop()
+    }
+  }
+
+  private class MyEntity extends PersistentEntity[MockCommand.type, Any, Any] {
+    override def initialBehavior(snapshotState: Optional[Any]): Behavior = newBehavior(())
+  }
+}
+

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/ChildPersistentEntity.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/ChildPersistentEntity.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.persistence
+
+import akka.actor.{ ActorContext, ActorRef, PoisonPill }
+import akka.util.Timeout
+import com.lightbend.lagom.internal.scaladsl.persistence.PersistentEntityActor
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.reflect.ClassTag
+
+/**
+ * A persistent entity that runs as a child actor of the current actor context.
+ *
+ * @param actor The actor for direct access if necessary.
+ */
+sealed class ChildPersistentEntity[Command](val actor: ActorRef) {
+  /**
+   * Send a message to the actor.
+   */
+  def !(msg: Command)(implicit sender: ActorRef): Unit = actor ! msg
+
+  /**
+   * Ask the actor with a command.
+   */
+  def ?[Cmd <: Command with PersistentEntity.ReplyType[_]](command: Cmd)(implicit timeout: Timeout): Future[command.ReplyType] = {
+    import akka.pattern.ask
+
+    (actor ? command).asInstanceOf[Future[command.ReplyType]]
+  }
+
+  /**
+   * Forward the command to the entity.
+   */
+  def forward(msg: Command)(implicit ctx: ActorContext): Unit = actor forward msg
+
+  /**
+   * Stop the persistent entity.
+   */
+  def stop(): Unit = {
+    actor ! PersistentEntityActor.Stop
+  }
+}
+
+object ChildPersistentEntity {
+
+  /**
+   * Instantiate a persistent entity as a child of the current actor context.
+   *
+   * Note that since this is a direct child, this provides no guarantee that this is the only entity with the given id
+   * running in the cluster, or even in the actor system. It is up to the actor that instantiates this to ensure that
+   * only one instance of the entity across the cluster is instantiated (by using cluster sharding to distribute
+   * itself, for example), or to deal with inconsistencies that may arise due to having multiple entities instantiated
+   * in the cluster.
+   *
+   * @param factory   The entity factory.
+   * @param entityId  The entity ID.
+   * @param actorName The actor name.
+   */
+  def apply[P <: PersistentEntity: ClassTag](factory: () => P, entityId: String, actorName: String)(implicit ctx: ActorContext): ChildPersistentEntity[P#Command] = {
+
+    ctx.child(actorName) match {
+
+      case Some(actorRef) => new ChildPersistentEntity(actorRef)
+      case None =>
+
+        val conf = ctx.system.settings.config.getConfig("lagom.persistence")
+        val snapshotAfter: Option[Int] = conf.getString("snapshot-after") match {
+          case "off" => None
+          case _     => Some(conf.getInt("snapshot-after"))
+        }
+
+        val entity = factory()
+
+        val actorRef = ctx.actorOf(PersistentEntityActor.props(
+          persistenceIdPrefix = entity.entityTypeName,
+          entityId = Some(entityId),
+          entityFactory = () => entity,
+          snapshotAfter = snapshotAfter,
+          passivateAfterIdleTimeout = Duration.Undefined
+        ), actorName)
+
+        new ChildPersistentEntity(actorRef)
+    }
+  }
+}
+
+/**
+ * Factory for creating child persistent entities.
+ *
+ * This can be used instead of directly invoking [[ChildPersistentEntity.apply()]] as a method of indirection to
+ * allow you to inject a mocked actor (eg an Akka TestKit probe) when testing.
+ */
+trait ChildPersistentEntityFactory[P <: PersistentEntity] {
+
+  /**
+   * Create an entity.
+   *
+   * @param entityId  The id of the entity.
+   * @param actorName The name of the actor.
+   */
+  def apply(entityId: String, actorName: String)(implicit ctx: ActorContext): ChildPersistentEntity[P#Command]
+}
+
+object ChildPersistentEntityFactory {
+
+  /**
+   * Create a [[ChildPersistentEntityFactory]] for the given entity.
+   *
+   * @param factory The factory to create the entity.
+   */
+  def forEntity[P <: PersistentEntity: ClassTag](factory: () => P): ChildPersistentEntityFactory[P] = {
+    new ChildPersistentEntityFactory[P] {
+      override def apply(entityId: String, actorName: String)(implicit ctx: ActorContext): ChildPersistentEntity[P#Command] = {
+        ChildPersistentEntity(factory, entityId, actorName)
+      }
+    }
+  }
+
+  /**
+   * Create a mocked [[ChildPersistentEntityFactory]].
+   *
+   * All commands sent to any entities created will be passed as is to the `testProbe` actor. When `stop` is invoked,
+   * the actor will be sent a `PoisonPill`.
+   *
+   * This is intended to be used with an Akka TestKit TestProbe, for example:
+   *
+   * {{{
+   * val entityProbe = TestProbe("persistent-entity")
+   * val childEntityFactory = ChildPersistentEntityFactory.mocked[MyEntity](entityProbe.ref)
+   *
+   * // Create actor and cause it to send a command to the entity
+   * ...
+   *
+   * entityProbe.expectMsg(5.seconds, MyCommand)
+   * entityProbe.reply(SomeReply)
+   * }}}
+   *
+   * @param testProbe The test probe ActorRef.
+   */
+  def mocked[P <: PersistentEntity](testProbe: ActorRef): ChildPersistentEntityFactory[P] = {
+    new ChildPersistentEntityFactory[P] {
+      override def apply(entityId: String, actorName: String)(implicit ctx: ActorContext): ChildPersistentEntity[P#Command] = {
+        new ChildPersistentEntity[P#Command](testProbe) {
+          override def stop(): Unit = {
+            actor ! PoisonPill
+          }
+        }
+      }
+    }
+  }
+}

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/MockChildPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/MockChildPersistentEntitySpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.scaladsl.persistence
+
+import akka.actor.{ Actor, Props }
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import com.lightbend.lagom.persistence.ActorSystemSpec
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
+
+import scala.concurrent.duration._
+
+class MockChildPersistentEntitySpec extends ActorSystemSpec {
+
+  "The mock child persistent entity factory" should {
+    "allow mock tells" in {
+      val probe = TestProbe()
+      val actor = system.actorOf(Props(new MyActor(ChildPersistentEntityFactory.mocked(probe.ref))))
+      actor ! Tell
+      probe.expectMsg(MockCommand)
+      probe.reply("reply")
+      expectMsg("reply")
+    }
+    "allow mock asks" in {
+      val probe = TestProbe()
+      val actor = system.actorOf(Props(new MyActor(ChildPersistentEntityFactory.mocked(probe.ref))))
+      actor ! Ask
+      probe.expectMsg(MockCommand)
+      probe.reply("reply")
+      expectMsg("reply")
+    }
+    "allow mock forwards" in {
+      val probe = TestProbe()
+      val actor = system.actorOf(Props(new MyActor(ChildPersistentEntityFactory.mocked(probe.ref))))
+      actor ! Forward
+      probe.expectMsg(MockCommand)
+      probe.reply("reply")
+      expectMsg("reply")
+    }
+    "allow stopping the entity" in {
+      val probe = TestProbe()
+      val actor = system.actorOf(Props(new MyActor(ChildPersistentEntityFactory.mocked(probe.ref))))
+      watch(probe.ref)
+      actor ! Stop
+      expectTerminated(probe.ref)
+    }
+  }
+
+  case object MockCommand extends ReplyType[String]
+  case object Ask
+  case object Tell
+  case object Stop
+  case object Forward
+
+  private class MyActor(factory: ChildPersistentEntityFactory[MyEntity]) extends Actor {
+    import akka.pattern.pipe
+    import context.dispatcher
+    implicit val timeout = Timeout(10.seconds)
+    val entity = factory("foo", "foo")
+    override def receive: Receive = {
+      case Ask     => (entity ? MockCommand) pipeTo sender()
+      case Tell    => entity.!(MockCommand)(sender())
+      case Forward => entity forward MockCommand
+      case Stop    => entity.stop()
+    }
+  }
+
+  private class MyEntity extends PersistentEntity {
+    override type Command = MockCommand.type
+    override type Event = Any
+    override type State = Any
+
+    override def initialState = ()
+    override def behavior = PartialFunction.empty
+  }
+
+}


### PR DESCRIPTION
This allows a persistent entity to run as a companion to another actor. This allows the following use cases:

* An actor running as a persistent process manager can use the entity to store its state without having to communicate with another node in the Akka cluster.
* When you have a use case where you need to do something that is far beyond the scope of a persistent entity (such as managing some non event sourced data store), and the entities for that datasource can only be acted on one at a time, so you're using cluster sharding to distribute that processing, and you do want to emit persistent events as well for these entities.

By running the entity as a child entity, you can cut down on network communication and decrease your surface area for failure to impact you.

Documentation to come.