### PR TITLE
Fix unhandled event issue message in PersistentEntityTestDriver

### DIFF
--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
@@ -40,6 +40,7 @@ object TestEntity {
       JsonSerializer(Json.format[ChangeMode]),
       JsonSerializer(emptySingletonFormat(Get)),
       JsonSerializer(emptySingletonFormat(UndefinedCmd)),
+      JsonSerializer(emptySingletonFormat(UnhandledEvtCmd)),
       JsonSerializer(emptySingletonFormat(GetAddress)),
       JsonSerializer(emptySingletonFormat(Clear))
     )
@@ -62,6 +63,8 @@ object TestEntity {
 
   case object UndefinedCmd extends Cmd with ReplyType[Evt]
 
+  case object UnhandledEvtCmd extends Cmd with ReplyType[State]
+
   case object GetAddress extends Cmd with ReplyType[Address]
 
   case object Clear extends Cmd with ReplyType[State]
@@ -81,6 +84,7 @@ object TestEntity {
       JsonSerializer(Json.format[Prepended]),
       JsonSerializer(emptySingletonFormat(InPrependMode)),
       JsonSerializer(emptySingletonFormat(InAppendMode)),
+      JsonSerializer(emptySingletonFormat(Unhandled)),
       JsonSerializer(emptySingletonFormat(Cleared))
     )
   }
@@ -96,6 +100,8 @@ object TestEntity {
   case object InPrependMode extends Evt
 
   case object InAppendMode extends Evt
+
+  case object Unhandled extends Evt
 
   case object Cleared extends Evt
 
@@ -173,6 +179,9 @@ class TestEntity(system: ActorSystem)
       }
       .onCommand[Clear.type, State] {
         case (Clear, ctx, state) => ctx.thenPersist(Cleared)(_ => ctx.reply(state))
+      }
+      .onCommand[UnhandledEvtCmd.type, State] {
+        case (_, ctx, state) => ctx.thenPersist(Unhandled)(_ => ctx.reply(state))
       }
       .onEvent {
         case (Cleared, _) => null

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriver.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriver.scala
@@ -232,7 +232,7 @@ class PersistentEntityTestDriver[C, E, S](
   def getAllIssues: immutable.Seq[Issue] = allIssues
 
   private val unhandledEvent: PartialFunction[(E, S), S] = {
-    case event =>
+    case (event, _) =>
       issues :+= UnhandledEvent(event)
       state
   }

--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriverSpec.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriverSpec.scala
@@ -75,6 +75,13 @@ class PersistentEntityTestDriverSpec extends ActorSystemSpec(JsonSerializerRegis
       outcome1.issues should be(List(PersistentEntityTestDriver.UnhandledCommand(undefined)))
     }
 
+    "record unhandled events" in {
+      val driver = newDriver()
+      val unhandledEvent = TestEntity.UnhandledEvtCmd
+      val outcome1 = driver.run(unhandledEvent)
+      outcome1.issues should be(List(PersistentEntityTestDriver.UnhandledEvent(TestEntity.Unhandled)))
+    }
+
     "be able to handle snapshot state" in {
       val driver = newDriver()
       val outcome1 = driver.initialize(Some(


### PR DESCRIPTION
# Pull Request Checklist

* [ ✔️] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [ ✔️] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ✔️] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ N/A ] Have you added copyright headers to new files?
* [ N/A ] Have you updated the documentation?
* [ ✔️ ] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx
N/A

## Purpose

Currently, when you test a PersistentEntity with the PersistentEntityTestDriver and the PersistentEntity does not handle an event, The PersistentEntityTestDriver captures an UnhandledEvent(Tuple2[Event, State]) which gives the following message:

> No event handler registered for class scala.Tuple2

What does this PR do?

By extracting the first element from the Tuple2, and therefore getting the event, the message states which class has no event handler registered instead of scala.Tuple2

## Background Context

Why did you take this approach?

N/A

## References

Are there any relevant issues / PRs / mailing lists discussions?

N/A
