### PR TITLE
Delete PersistentEntityTestDriver.runOne

### DIFF
--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriver.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriver.scala
@@ -137,8 +137,6 @@ class PersistentEntityTestDriver[C, E, S](
       entity.PersistNone
   }
 
-  def runOne[CC <: entity.Command](command: C): Outcome[E, S] = ???
-
   /**
    * The entity will process the commands and the emitted events and side effects
    * are recorded and provided in the returned `Outcome`. Current state is also


### PR DESCRIPTION
Fixes #1080.

PersistentEntityTestDriver.runOne was never implemented, and would not have been useful if it was because the varargs method already does what this method proposes to do. This deletes it.