### PR TITLE
Improves error messages in path param serializer resolution

### DIFF
--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceCallResolver.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceCallResolver.scala
@@ -80,7 +80,7 @@ class ServiceCallResolver(
         case clazz: Class[_] if clazz.isPrimitive => pathParamSerializerFor(ServiceCallResolver.primitiveClassMap(clazz), typeInfo)
         case clazz: Class[_] =>
           // we've already looked up by class, so we're not going to get any further - fail
-          throw new IllegalArgumentException(s"Don't know how to serialize ID $clazz")
+          throw new IllegalArgumentException(s"Don't know how to serialize path parameter $clazz")
         case param: ParameterizedType  => pathParamSerializerFor(param.getRawType, typeInfo)
         case wild: WildcardType        => throw new IllegalArgumentException(s"Cannot serialize wildcard types: $wild")
         case variable: TypeVariable[_] => throw new IllegalArgumentException(s"Cannot serialize type variables: $variable")

--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
@@ -227,7 +227,7 @@ object ServiceReader {
         serviceCallResolver.resolvePathParamSerializer(new UnresolvedTypePathParamSerializer[AnyRef], arg)
       } catch {
         case ex: IllegalArgumentException =>
-          throw new IllegalArgumentException(s"Error encountered while resolving the ${method.getDeclaringClass + "." + method.getName}" +
+          throw new IllegalPathParameterException(s"Error encountered while resolving the ${method.getDeclaringClass + "." + method.getName}" +
             s"service call: No path parameter serializer was found for the $arg path parameter. This can be fixed " +
             "either by implementing and then explicitly registering a com.lightbend.lagom.javadsl.api.PathParamSerializer for " +
             s"$arg on the ${method.getDeclaringClass} service descriptor, or perhaps this parameter is meant to be the " +

--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
@@ -221,8 +221,18 @@ object ServiceReader {
   }
 
   private def constructServiceCallHolder[Request, Response](serviceCallResolver: ServiceCallResolver, method: Method): ServiceCallHolder = {
+
     val serializers = method.getGenericParameterTypes.toSeq.map { arg =>
-      serviceCallResolver.resolvePathParamSerializer(new UnresolvedTypePathParamSerializer[AnyRef], arg)
+      try {
+        serviceCallResolver.resolvePathParamSerializer(new UnresolvedTypePathParamSerializer[AnyRef], arg)
+      } catch {
+        case ex: IllegalArgumentException =>
+          throw new RuntimeException(s"Error encountered while resolving the ${method.getDeclaringClass + "." + method.getName}" +
+            "service call: No path parameter serializer was found for the com.example.Foo path parameter. This can be fixed " +
+            "either by implementing and then explicitly registering a com.lightbend.lagom.javadsl.api.PathParamSerializer for " +
+            s"$arg on the ${method.getDeclaringClass} service descriptor, or perhaps this parameter is meant to be the " +
+            "request message declared in the ServiceCall, and not extracted out of the path?", ex)
+      }
     }
 
     import scala.collection.JavaConverters._

--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
@@ -228,7 +228,7 @@ object ServiceReader {
       } catch {
         case ex: IllegalArgumentException =>
           throw new RuntimeException(s"Error encountered while resolving the ${method.getDeclaringClass + "." + method.getName}" +
-            "service call: No path parameter serializer was found for the com.example.Foo path parameter. This can be fixed " +
+            s"service call: No path parameter serializer was found for the $arg path parameter. This can be fixed " +
             "either by implementing and then explicitly registering a com.lightbend.lagom.javadsl.api.PathParamSerializer for " +
             s"$arg on the ${method.getDeclaringClass} service descriptor, or perhaps this parameter is meant to be the " +
             "request message declared in the ServiceCall, and not extracted out of the path?", ex)

--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
@@ -227,7 +227,7 @@ object ServiceReader {
         serviceCallResolver.resolvePathParamSerializer(new UnresolvedTypePathParamSerializer[AnyRef], arg)
       } catch {
         case ex: IllegalArgumentException =>
-          throw new RuntimeException(s"Error encountered while resolving the ${method.getDeclaringClass + "." + method.getName}" +
+          throw new IllegalArgumentException(s"Error encountered while resolving the ${method.getDeclaringClass + "." + method.getName}" +
             s"service call: No path parameter serializer was found for the $arg path parameter. This can be fixed " +
             "either by implementing and then explicitly registering a com.lightbend.lagom.javadsl.api.PathParamSerializer for " +
             s"$arg on the ${method.getDeclaringClass} service descriptor, or perhaps this parameter is meant to be the " +

--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/javadsl/api/IllegalPathParameterException.java
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/javadsl/api/IllegalPathParameterException.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.api;
+
+public class IllegalPathParameterException  extends IllegalArgumentException{
+
+    public IllegalPathParameterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/service/javadsl/api/src/test/java/com/lightbend/lagom/api/mock/InvalidPathParameterService.java
+++ b/service/javadsl/api/src/test/java/com/lightbend/lagom/api/mock/InvalidPathParameterService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.api.mock;
+
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.transport.Method;
+import com.lightbend.lagom.javadsl.api.Service;
+
+import java.util.UUID;
+
+import static com.lightbend.lagom.javadsl.api.Service.*;
+
+
+public interface InvalidPathParameterService extends Service {
+    
+    ServiceCall<UUID, String> hello(Data invalidData);
+    
+    @Override
+    default Descriptor descriptor() {
+        return named("/invalid-service").withCalls(restCall(Method.GET, "/hello/:invalidData", this::hello));
+    }
+}
+
+class Data {
+}

--- a/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
+++ b/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
@@ -38,7 +38,7 @@ class ServiceReaderSpec extends WordSpec with Matchers with Inside {
     }
 
     "fail to read a Java service descriptor from a public interface because the path parameter could not be serialized" in {
-      val caught = intercept[RuntimeException] {
+      val caught = intercept[IllegalArgumentException] {
         val descriptor = serviceDescriptor[InvalidPathParameterService]
       }
       caught.getMessage should ===("Error encountered while resolving the interface com.lightbend.lagom.api.mock.InvalidPathParameterService.helloservice" +

--- a/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
+++ b/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
@@ -13,12 +13,11 @@ import com.lightbend.lagom.javadsl.api.Descriptor.RestCallId
 import com.lightbend.lagom.javadsl.api.deser.MessageSerializer.{ NegotiatedDeserializer, NegotiatedSerializer }
 import com.lightbend.lagom.javadsl.api.deser._
 import com.lightbend.lagom.javadsl.api.transport.{ MessageProtocol, Method }
-import com.lightbend.lagom.api.mock.{ BlogService, MockService }
+import com.lightbend.lagom.api.mock._
 import org.scalatest._
-import com.lightbend.lagom.api.mock.ScalaMockService
-import com.lightbend.lagom.api.mock.ScalaMockServiceWrong
 import com.lightbend.lagom.internal.javadsl.api.{ JacksonPlaceholderExceptionSerializer, JacksonPlaceholderSerializerFactory, MethodServiceCallHolder, ServiceReader }
 import com.lightbend.lagom.javadsl.api.{ Descriptor, Service, ServiceCall }
+
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
@@ -36,6 +35,17 @@ class ServiceReaderSpec extends WordSpec with Matchers with Inside {
         case simple: SimpleSerializer[_] => simple.`type` should ===(classOf[UUID])
       }
       endpoint.responseSerializer should ===(MessageSerializers.STRING)
+    }
+
+    "fail to read a Java service descriptor from a public interface because the path parameter could not be serialized" in {
+      val caught = intercept[RuntimeException] {
+        val descriptor = serviceDescriptor[InvalidPathParameterService]
+      }
+      caught.getMessage should ===("Error encountered while resolving the interface com.lightbend.lagom.api.mock.InvalidPathParameterService.helloservice" +
+        " call: No path parameter serializer was found for the class com.lightbend.lagom.api.mock.Data path parameter. This can be fixed either by implementing " +
+        "and then explicitly registering a com.lightbend.lagom.javadsl.api.PathParamSerializer for class com.lightbend.lagom.api.mock.Data on the interface " +
+        "com.lightbend.lagom.api.mock.InvalidPathParameterService service descriptor, or perhaps this parameter is meant to be the request message declared in the " +
+        "ServiceCall, and not extracted out of the path?")
     }
 
     "read a simple Scala service descriptor" in {

--- a/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
+++ b/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
@@ -16,7 +16,7 @@ import com.lightbend.lagom.javadsl.api.transport.{ MessageProtocol, Method }
 import com.lightbend.lagom.api.mock._
 import org.scalatest._
 import com.lightbend.lagom.internal.javadsl.api.{ JacksonPlaceholderExceptionSerializer, JacksonPlaceholderSerializerFactory, MethodServiceCallHolder, ServiceReader }
-import com.lightbend.lagom.javadsl.api.{ Descriptor, Service, ServiceCall }
+import com.lightbend.lagom.javadsl.api.{ Descriptor, IllegalPathParameterException, Service, ServiceCall }
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -38,14 +38,9 @@ class ServiceReaderSpec extends WordSpec with Matchers with Inside {
     }
 
     "fail to read a Java service descriptor from a public interface because the path parameter could not be serialized" in {
-      val caught = intercept[IllegalArgumentException] {
+      intercept[IllegalPathParameterException] {
         val descriptor = serviceDescriptor[InvalidPathParameterService]
       }
-      caught.getMessage should ===("Error encountered while resolving the interface com.lightbend.lagom.api.mock.InvalidPathParameterService.helloservice" +
-        " call: No path parameter serializer was found for the class com.lightbend.lagom.api.mock.Data path parameter. This can be fixed either by implementing " +
-        "and then explicitly registering a com.lightbend.lagom.javadsl.api.PathParamSerializer for class com.lightbend.lagom.api.mock.Data on the interface " +
-        "com.lightbend.lagom.api.mock.InvalidPathParameterService service descriptor, or perhaps this parameter is meant to be the request message declared in the " +
-        "ServiceCall, and not extracted out of the path?")
     }
 
     "read a simple Scala service descriptor" in {


### PR DESCRIPTION
1. Added a wrapping exception for IllegalArgumentException with a detailed error message
2. changed "ID" to "path parameter" in IllegalArgumentException error message


# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #1084 

## Purpose

What does this PR do?
Provides more information for certain run time exceptions in a lagom based java service
## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
