### PR TITLE
Split test execution for Scala 2.11 and 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ env:
   - WHITESOURCE_PROJECT_TOKEN: b47efd29-4a67-4ece-94d5-a7f38c362d8a
   - secure: "qr/+kdqj2bdXRlsDR+akjsKTq8WJe0bBX+TKWaYCGcaGrqarOdCZcLteRxrE/uXmYD3rWJKhXkasUmUwEF45nTNX7X780nllFVA/AKUk3REDkLCpDkiwryMwdu/owx1xlK8dGyzPwrQhVulYotaK2tzv5r1bttemqBWcBOAgY7+HrnVhFNwS9tSrWp9CuDZotGANGd9JZBX+nITY2Ud59DcK5UFhfB4FJlqnIeCe201hD3Z9e6yWevPmu1vvV5qGlJ7h46jQvpXdvcNIlDDZ8e0oFqULjaUx6CPGUX5h9dQ9ZHvQgJJb2ALpTfR/Dxv/iM2dx3imGdjzklvJ8jcHX44jOQNucEwOxQk7dCGs+ie0L4KXrBqRxu0OwSC9U87CtliaC25Y35isfvOfNRgzL8mvzzZ+jSTy5s9wqBQZa9C04WIml4Azq8vL5ur26F1nxyZgHJBdQFJIBtR5m4av3oQLFEjCWwsVwYLR3JOP3wzrliT4BzNpeqppXzEJR2jt7MNgNmHH4am6suB8VS+7oxkn0R3GyRqMVEwqivj3ciisYBZZYGVn/SxmdSS3IhVgUivcLaCOA3gUh6Ww7bdTik7zB2AfCFYK5Lis0+STGXt9xaCf7Tp2+RxAGVFBP5K4QeFzzREG0aIlEgF5v2pn7wewve/p59NucPdxQE4c7x0="
   matrix:
-    - SCRIPT=test
+    - SCRIPT=test-2.11
+    - SCRIPT=test-2.12
     - SCRIPT=test-sbt
     - SCRIPT=test-maven
     - SCRIPT=test-documentation

--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -6,10 +6,10 @@ set -e
 set -o pipefail
 
 runSbt() {
-  sbt --warn -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' $@
+  sbt --warn -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
 }
 
 runSbtNoisy() {
-  sbt -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' $@
+  sbt -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
 }
 

--- a/bin/test-2.11
+++ b/bin/test-2.11
@@ -2,4 +2,4 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-runSbtNoisy +test
+runSbtNoisy "+++2.11.11 test"

--- a/bin/test-2.12
+++ b/bin/test-2.12
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
+
+runSbtNoisy "+++2.12.4 test"


### PR DESCRIPTION
## Fixes

Fixes #1002.

## Purpose

Using the same strategy we are using in Play. This configures Travis build to run tests for Scala 2.11 and 2.12 in different jobs.

## References

https://github.com/playframework/playframework/pull/7873