### PR TITLE
scalaVersion of lagom-internal-meta-* projects is hard coded to 2.11.…

### DIFF
--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -339,7 +339,7 @@ object LagomPlugin extends AutoPlugin {
   private val serviceLocatorProject = Project("lagom-internal-meta-project-service-locator", file("."),
     configurations = Configurations.default,
     settings = CorePlugin.projectSettings ++ IvyPlugin.projectSettings ++ JvmPlugin.projectSettings ++ Seq(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.11",
     libraryDependencies += LagomImport.component("lagom-service-locator"),
     lagomServiceLocatorStart in ThisBuild := startServiceLocatorTask.value,
     lagomServiceLocatorStop in ThisBuild := Servers.ServiceLocator.tryStop(new SbtLoggerProxy(state.value.log))
@@ -348,7 +348,7 @@ object LagomPlugin extends AutoPlugin {
   private val cassandraProject = Project("lagom-internal-meta-project-cassandra", file("."),
     configurations = Configurations.default,
     settings = CorePlugin.projectSettings ++ IvyPlugin.projectSettings ++ JvmPlugin.projectSettings ++ Seq(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.11",
     libraryDependencies += LagomImport.component("lagom-cassandra-server"),
     lagomCassandraStart in ThisBuild := startCassandraServerTask.value,
     lagomCassandraStop in ThisBuild := Servers.CassandraServer.tryStop(new SbtLoggerProxy(state.value.log))
@@ -357,7 +357,7 @@ object LagomPlugin extends AutoPlugin {
   private val kafkaServerProject = Project("lagom-internal-meta-project-kafka", file("."),
     configurations = Configurations.default,
     settings = CorePlugin.projectSettings ++ IvyPlugin.projectSettings ++ JvmPlugin.projectSettings ++ Seq(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.11",
     libraryDependencies += LagomImport.component("lagom-kafka-server"),
     lagomKafkaStart in ThisBuild := startKafkaServerTask.value,
     lagomKafkaStop in ThisBuild := Servers.KafkaServer.tryStop(new SbtLoggerProxy(state.value.log))


### PR DESCRIPTION
*Replaced hardcoded scalaVersion values from lagom-internal-meta-* projects with variables

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #908 

What does this PR do?

Replaces hardcoded scalaVersion values from lagom-internal-meta-* projects with variables

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
