### PR TITLE
Added a check to warn about slow startup problems

### DIFF
--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -26,6 +26,16 @@ import scala.util.{ Failure, Success, Try }
 object LagomReloadableDevServerStart {
 
   /**
+    * A threshold for retrieving the current hostname.
+    *
+    * If Lagom startup takes too long, it can cause a number of issues and we try to detect it using
+    * InetAddress.getLocalHost. If it takes longer than this threshold, it might be a signal
+    * of a well-known problem with MacOS that might cause issues with Lagom.
+    */
+  val startupWarningThreshold = 1000L
+
+
+  /**
    * Provides an HTTPS-only server for the dev environment.
    *
    * <p>This method uses simple Java types so that it can be used with reflection by code
@@ -87,9 +97,9 @@ object LagomReloadableDevServerStart {
         val before = System.currentTimeMillis()
         val address = InetAddress.getLocalHost
         val after = System.currentTimeMillis()
-        if (after - before > 100) {
-          System.out.println(s"WARNING: Retrieving local host name ${address} took more than 100ms, this can create problems at startup with Lagom.\n" +
-            "You are probably using MACOS Sierra with a wrongly configured /etc/host . See https://thoeni.io/post/macos-sierra-java/ for a solution")
+        if (after - before > startupWarningThreshold) {
+          println(play.utils.Colors.red("WARNING: Retrieving local host name ${address} took more than 100ms, this can create problems at startup with Lagom"))
+          println(play.utils.Colors.red("If you are using macOS, see https://thoeni.io/post/macos-sierra-java/ for a potential solution"))
         }
 
         // First delete the default log file for a fresh start (only in Dev Mode)

--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -88,7 +88,7 @@ object LagomReloadableDevServerStart {
         val address = InetAddress.getLocalHost
         val after = System.currentTimeMillis()
         if (after - before > 100) {
-          System.out.println(s"WARNING: Retrieving local host name ${address} took more than 100ms, this can create problems at startup with Lagom. \r\n" +
+          System.out.println(s"WARNING: Retrieving local host name ${address} took more than 100ms, this can create problems at startup with Lagom.\n" +
             "You are probably using MACOS Sierra with a wrongly configured /etc/host . See https://thoeni.io/post/macos-sierra-java/ for a solution")
         }
 

--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -32,7 +32,7 @@ object LagomReloadableDevServerStart {
     * InetAddress.getLocalHost. If it takes longer than this threshold, it might be a signal
     * of a well-known problem with MacOS that might cause issues with Lagom.
     */
-  val startupWarningThreshold = 1000L
+  private val startupWarningThreshold = 1000L
 
 
   /**
@@ -98,7 +98,7 @@ object LagomReloadableDevServerStart {
         val address = InetAddress.getLocalHost
         val after = System.currentTimeMillis()
         if (after - before > startupWarningThreshold) {
-          println(play.utils.Colors.red("WARNING: Retrieving local host name ${address} took more than 100ms, this can create problems at startup with Lagom"))
+          println(play.utils.Colors.red("WARNING: Retrieving local host name ${address} took more than ${startupWarningThreshold}ms, this can create problems at startup with Lagom"))
           println(play.utils.Colors.red("If you are using macOS, see https://thoeni.io/post/macos-sierra-java/ for a potential solution"))
         }
 

--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -4,6 +4,7 @@
 package play.core.server
 
 import java.io.File
+import java.net.InetAddress
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
@@ -81,6 +82,14 @@ object LagomReloadableDevServerStart {
             System.out.println("\n---- The where is Scala? test ----\n")
             System.out.println(this.getClass.getClassLoader.getResource("scala/Predef$.class"))
           }
+        }
+
+        val before = System.currentTimeMillis()
+        val address = InetAddress.getLocalHost
+        val after = System.currentTimeMillis()
+        if (after - before > 100) {
+          System.out.println(s"WARNING: Retrieving local host name ${address} took more than 100ms, this can create problems at startup with Lagom. \r\n" +
+            "You are probably using MACOS Sierra with a wrongly configured /etc/host . See https://thoeni.io/post/macos-sierra-java/ for a solution")
         }
 
         // First delete the default log file for a fresh start (only in Dev Mode)


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #941 

## Purpose

It prints out a warning about potential errors due to slow Lagom startup

## Background Context

LagomReloadableDevServer is shared both by Maven Runner and Sbt runner. It is invoked by the Reloader, in build-tool-support, which itself is invoked by the Maven and SBT plugin.
