### PR TITLE
Update documentation links

### DIFF
--- a/docs/manual/common/concepts/ComponentTechnologies.md
+++ b/docs/manual/common/concepts/ComponentTechnologies.md
@@ -2,18 +2,18 @@
 
 As a complete microservices platform, Lagom assembles a collection of technologies and adds value on top of them. Some of the libraries, tools, and servers that Lagom uses and supports were developed at [Lightbend](https://lightbend.com), others are third-party and open-source. As you develop with Lagom, you can also take advantage of these technologies:
 
-* Akka --- Lagom [[Persistence|PersistentEntity]], [[Publish-Subscribe|PubSub]], and [[Cluster|Cluster]] are implemented on top of [Akka](http://akka.io/), Lightbend's toolkit for building concurrent, distributed, and resilient message-driven applications. (This is an implementation detail that does not directly concern you when developing simple microservices. However, you can call also [[Akka APIs|Akka]] directly.)
+* Akka --- Lagom [[Persistence|PersistentEntity]], [[Publish-Subscribe|PubSub]], and [[Cluster|Cluster]] are implemented on top of [Akka](https://akka.io/), Lightbend's toolkit for building concurrent, distributed, and resilient message-driven applications. (This is an implementation detail that does not directly concern you when developing simple microservices. However, you can call also [[Akka APIs|Akka]] directly.)
 
-    * To scale your microservices out across multiple servers, Lagom provides clustering via [Akka Cluster](http://doc.akka.io/docs/akka/2.4/java/cluster-usage.html).
-     
-    * As described in [[Implementing services|ServiceImplementation]], A Lagom service may be "simple" or "streamed".  Streaming, asynchronous Lagom services are built on top of [Akka Streams](http://doc.akka.io/docs/akka/2.4/java/stream/index.html).
+    * To scale your microservices out across multiple servers, Lagom provides clustering via [Akka Cluster](https://doc.akka.io/docs/akka/2.5/cluster-usage.html).
+
+    * As described in [[Implementing services|ServiceImplementation]], A Lagom service may be "simple" or "streamed".  Streaming, asynchronous Lagom services are built on top of [Akka Streams](https://doc.akka.io/docs/akka/2.5/stream/index.html).
 
 * Lightbend customers can additionally use [Enterprise Suite](https://www.lightbend.com/platform/production) components to operationalize and production-harden their systems.
 
     * Akka's [Split Brain Resolver](https://tech-hub.lightbend.com/docs/akka-commercial-addons/current/split-brain-resolver.html) handles network failures and system crashes.
 
     * [Lightbend Application Monitoring](https://www.lightbend.com/products/monitoring) provides real time monitoring of system health, availability and performance.
-    
+
     * See [[Cluster]] for more details.
 
 * Cassandra --- By default, Lagom microservices that need to persist data use the  [Cassandra](https://cassandra.apache.org) instance that runs as part of the development environment. You can also use an existing [[Cassandra Server|CassandraServer]] database or another type of database. See [[Managing data persistence|ES_CQRS]] for more information.

--- a/docs/manual/common/concepts/CoreConcepts.md
+++ b/docs/manual/common/concepts/CoreConcepts.md
@@ -4,15 +4,15 @@ The Lagom framework includes libraries and a development environment that suppor
 
 * During development, a single command builds your project and starts all of your services and the supporting Lagom infrastructure. It hot-reloads when you modify code. The development environment allows you to bring up a new service or join an existing Lagom development team in just minutes.
 * You can create microservices using Java or Scala. Lagom offers an especially seamless experience for communication between microservices. Service location, communication protocols, and other issues are handled by Lagom transparently, maximizing convenience and productivity. Lagom supports Event sourcing and CQRS (Command Query Responsibility Segregation) for persistence.
-* Lagom creates service clients for you (based on service descriptors), making it extremely easy to invoke and test endpoints.  
+* Lagom creates service clients for you (based on service descriptors), making it extremely easy to invoke and test endpoints.
 * Deploy on your platform of choice, such as:
     * [Lightbend Enterprise Suite](https://www.lightbend.com/platform/production), which makes it easy to deploy, scale, monitor, and manage Lagom services in a container environment. You can run the deployment and monitoring capabilities of Enterprise Suite on up to three nodes by simply registering with Lightbend. Obtain a [Lightbend Subscription](https://www.lightbend.com/platform/subscription) to receive world class support and the ability to run more nodes.
-    * [Kubernetes](https://kubernetes.io), an open-source solution for container orchestration. See how to [deploy Lagom Microservices on Kubernetes] (https://developer.lightbend.com/guides/k8s-microservices/).
+    * [Kubernetes](https://kubernetes.io), an open-source solution for container orchestration. See how to [deploy Lagom Microservices on Kubernetes] (https://developer.lightbend.com/guides/lagom-kubernetes-k8s-deploy-microservices/).
 
 Designing a microservices system that achieves high scalability and manifests resilience in the face of unexpected failures is extremely difficult. Without a framework such as Lagom, you would need to deal with all of the complex threading and concurrency issues inherent in highly distributed systems. By using Lagom as it was designed to be used, you can avoid many of these pitfalls and increase productivity at the same time. But, rather than throwing everything out and starting anew, Lagom allows you to adopt a [reactive architecture](https://info.lightbend.com/COLL-20XX-Reactive-Microservices-Architecture-RES-LP.html) within existing constraints. For example, you can create microservices that:
 
 * Interact with legacy systems and/or replace monolithic application functionality.
-* Use Cassandra for persistence or your database of choice and/or integrate with other data stores. (Lagom's persistence APIs support Cassandra by default because it provides functionality such as sharding and read-side support that work well in a microservices system)  
+* Use Cassandra for persistence or your database of choice and/or integrate with other data stores. (Lagom's persistence APIs support Cassandra by default because it provides functionality such as sharding and read-side support that work well in a microservices system)
 
 
 
@@ -21,7 +21,7 @@ The remaining topics in this section further introduce:
 * Lagom system architecture:
     * [[Lagom design philosophy|LagomDesignPhilosophy]]
     * [[Polyglot systems|PolyglotSystems]]
-* Lagom development environment: 
+* Lagom development environment:
     * [[Overview|DevelopmentEnvironmentOverview]]
     * [[Build philosophy|BuildConcepts]]
     * [[Component technologies|ComponentTechnologies]]
@@ -36,6 +36,6 @@ The remaining topics in this section further introduce:
     * [[Advantages of Event Sourcing|ESAdvantage]]
     * [[Separating reads from writes|ReadVsWrite]]
     * [[Deploying resilient, scalable systems|ScalableDeployment]]
-    
+
 
 @toc@

--- a/docs/manual/common/concepts/InternalAndExternalCommunication.md
+++ b/docs/manual/common/concepts/InternalAndExternalCommunication.md
@@ -7,7 +7,7 @@ The following topics discuss these communication paths in more detail:
 * [Communication within a microservices system](#Communication-within-a-microservices-system)
 * [Communication with parties outside of a microservices system](#Communication-with-parties-outside-of-a-microservices-system)
 
-## Communication within a microservices system 
+## Communication within a microservices system
 
 While similar in principle, inter- and intra-service communication have very different needs, and Lagom offers multiple implementation options. Inter-service communication must use loosely-coupled protocols and message formats to maintain isolation and autonomy. Coordinating change between different services can be difficult and costly. You can achieve this in your system by taking advantage of the following:
 
@@ -17,21 +17,21 @@ While similar in principle, inter- and intra-service communication have very dif
 
 Nodes of a single service (collectively called a cluster) require less decoupling. They share the same code and are managed together, as a set, by a single team or individual. For this reason, intra-service communication can take advantage of mechanisms that have less overhead and better performance. For example:
 
-* Many Lagom components use [Akka remoting](http://doc.akka.io/docs/akka/2.4/general/remoting.html) internally, and you can use it directly in your services.
+* Many Lagom components use [Akka remoting](https://doc.akka.io/docs/akka/2.5/general/remoting.html) internally, and you can use it directly in your services.
 
 * [[Distributed publish-subscribe|PubSub]] can be used for low-latency, at-most-once messaging between nodes. Limitations include:
 <ul><ul>
 <li>Network interruptions can cause messages to be lost. </li>
 <li>When a new instance starts, joins the cluster, and subscribes, it will not receive messages sent before its subscription.</li>
-</ul></ul>  
+</ul></ul>
 
 * Databases and other persistent storage can be seen as another way that nodes of a service communicate. For microservices that use persistent entities, Lagom encourages [[event streaming|ES_CQRS]], which also takes advantage of asynchronous communication and provides guarantees via an event log.
 
-This diagram illustrates each of these types of inter- and intra-service communication in a Lagom system distributed across three servers. In the example, the Order service publishes to one or more Kafka topics, while the User service subscribes to consume the information. The User service communicates with other User service instances (cluster members) using Akka remoting. The Shipping service and User service exchange information by streaming it in service calls. [[ServiceCommunication.png]] 
+This diagram illustrates each of these types of inter- and intra-service communication in a Lagom system distributed across three servers. In the example, the Order service publishes to one or more Kafka topics, while the User service subscribes to consume the information. The User service communicates with other User service instances (cluster members) using Akka remoting. The Shipping service and User service exchange information by streaming it in service calls. [[ServiceCommunication.png]]
 
 ## Communication with parties outside of a microservices system
 
-Lagom promotes use of asynchronous communication without preventing use of synchronous communication where necessary. Third parties can obtain data asynchronously from Lagom services that publish to the Broker API and enjoy the at-least-once guarantee. Lagom services also expose an API for third parties to exchange data synchronously. This is usually mapped to HTTP. Lagom Service APIs also support streaming data to external clients by means of websockets. See [[ServiceDescriptors]] for more information. 
+Lagom promotes use of asynchronous communication without preventing use of synchronous communication where necessary. Third parties can obtain data asynchronously from Lagom services that publish to the Broker API and enjoy the at-least-once guarantee. Lagom services also expose an API for third parties to exchange data synchronously. This is usually mapped to HTTP. Lagom Service APIs also support streaming data to external clients by means of websockets. See [[ServiceDescriptors]] for more information.
 
 Interaction with the outside world could mean clients that use the services over the internet, such as browsers, mobile apps or IoT devices. While using standard HTTP or WebSockets, typically such clients do not communicate directly with individual services. Usually, a network boundary acts as a perimeter, and a well-controlled communication point acts as the intermediary between the outside world and the inside world. In Lagom, this communication point is a service gateway. Envision your microservices system as a Medieval town with a wall around it and one gate offers the only way in or out. Communication inside the walls is free and direct, but communication to or from the outside world must come through the service gateway, as illustrated in the following graphic. [[ExtraSystemCommunication.png]]
 
@@ -39,4 +39,4 @@ Interaction with the outside world could mean clients that use the services over
 
 <!---For example, in the following diagram (see slide 5), notice the microservices running in a cluster on separate nodes (JVMs). The microservices in the cluster communicate with each other. Outside the cluster, a Service Gateway, a message broker, and other services also exchange messages. You can choose the type of communication appropriate for each service, whether that is: WebSockets, Akka pub-sub, or the Kafka message broker, and for services that need persistence, event streams. In the example, where all communication is asynchronous, failures or latency will not prevent any individual service from doing its job. -->
 
- 
+

--- a/docs/manual/common/concepts/LagomDesignPhilosophy.md
+++ b/docs/manual/common/concepts/LagomDesignPhilosophy.md
@@ -9,7 +9,7 @@ Consider some of the basic requirements of a Reactive Microservice as identified
 
 The following Lagom characteristics promote these best practices:
 
-* Lagom is asynchronous by default --- its APIs make inter-service communication via streaming a first-class concept. All Lagom APIs use the asynchronous IO capabilities of [Akka Stream](http://akka.io/) for asynchronous streaming; the Java API uses [JDK8 `CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html)  for asynchronous computation; the Scala API uses [Futures](https://www.scala-lang.org/api/2.11.8/#scala.concurrent.Future).
+* Lagom is asynchronous by default --- its APIs make inter-service communication via streaming a first-class concept. All Lagom APIs use the asynchronous IO capabilities of [Akka Stream](https://akka.io/) for asynchronous streaming; the Java API uses [JDK8 `CompletionStage`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html)  for asynchronous computation; the Scala API uses [Futures](https://www.scala-lang.org/api/2.11.8/#scala.concurrent.Future).
 
 * Lagom favors distributed persistent patterns in contrast with traditional centralized databases. We encourage --- but do not require --- an event-sourced architecture for data persistence. The default pattern for persisting entities takes advantage of Event Sourcing (ES) with Command Query Responsibility Segregation (CQRS). [[Managing data persistence|ES_CQRS]] explains at a high level what event sourcing is and why it is valuable. [[Persistent Entity|PersistentEntity]] introduces Lagom's implementation of event sourcing.
 

--- a/docs/manual/common/guide/logging/SettingsLogger.md
+++ b/docs/manual/common/guide/logging/SettingsLogger.md
@@ -75,7 +75,7 @@ And, you will also need to add the following in your project's `application.conf
 akka.loglevel=DEBUG
 ```
 
-Furthermore, you may also wish to configure an appender for the Akka loggers that includes useful properties such as thread and actor address.  For more information about configuring Akka's logging, including details on Logback and Slf4j integration, see the [Akka documentation](http://doc.akka.io/docs/akka/2.4/scala/logging.html).
+Furthermore, you may also wish to configure an appender for the Akka loggers that includes useful properties such as thread and actor address.  For more information about configuring Akka's logging, including details on Logback and Slf4j integration, see the [Akka documentation](https://doc.akka.io/docs/akka/2.5/logging.html).
 
 ### Play logging configuration
 

--- a/docs/manual/java/guide/advanced/Akka.md
+++ b/docs/manual/java/guide/advanced/Akka.md
@@ -12,7 +12,7 @@ Let's look at an example of a `WorkerService` that accepts job requests and dele
 
 @[service-impl](code/docs/home/actor/WorkerServiceImpl.java)
 
-Notice how the `ActorSystem` is injected through the constructor. We create worker actors on each node that has the "worker-node" role. We create a consistent hashing group router that delegates jobs to the workers. Details on these features are in the [Akka documentation](http://doc.akka.io/docs/akka/2.4/java.html).
+Notice how the `ActorSystem` is injected through the constructor. We create worker actors on each node that has the "worker-node" role. We create a consistent hashing group router that delegates jobs to the workers. Details on these features are in the [Akka documentation](https://doc.akka.io/docs/akka/2.5/?language=java).
 
 The worker actor looks like this:
 
@@ -41,7 +41,7 @@ In your Guice module you add `AkkaGuiceSupport` and use the `bindActor` method, 
 
 That allows the actor itself to receive injected objects. It also allows the actor ref for the actor to be injected into other components. This actor is named `worker` and is also qualified with the `worker` name for injection.
 
-You can read more about this and how to use dependency injection for child actors in the [Play documentation](https://playframework.com/documentation/2.5.x/JavaAkka#Dependency-injecting-actors).
+You can read more about this and how to use dependency injection for child actors in the [Play documentation](https://playframework.com/documentation/2.6.x/JavaAkka#Dependency-injecting-actors).
 
 Adjusting the `Worker` actor from the previous section to allow injection of the `PubSubRegistry`:
 

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -51,7 +51,7 @@ The node that is configured first in the list of `seed-nodes` is special. Only t
 
 The reason for the special first seed node is to avoid forming separated islands when starting from an empty cluster. If the first seed node is restarted and there is an existing cluster it will try to join the other seed nodes, i.e. it will join the existing cluster.
 
-You can read more about cluster joining in the [Akka documentation](http://doc.akka.io/docs/akka/2.4/java/cluster-usage.html#Joining_to_Seed_Nodes).
+You can read more about cluster joining in the [Akka documentation](http://doc.akka.io/docs/akka/2.5/java/cluster-usage.html#Joining_to_Seed_Nodes).
 
 ## Downing
 

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -2,7 +2,7 @@
 
 Instances of the same service may run on multiple nodes, for scalability and redundancy. Nodes may be physical or virtual machines, grouped in a cluster.
 
-The underlying clustering technology is [Akka Cluster](http://doc.akka.io/docs/akka/2.4/java/cluster-usage.html).
+The underlying clustering technology is [Akka Cluster](https://doc.akka.io/docs/akka/2.5/cluster-usage.html?language=java).
 
 If instances of a service need to know about each other, they must join the same cluster. Within a cluster, services may use the [[Persistence|PersistentEntity]] and [[Publish-Subscribe|PubSub]] modules of Lagom.
 
@@ -51,7 +51,7 @@ The node that is configured first in the list of `seed-nodes` is special. Only t
 
 The reason for the special first seed node is to avoid forming separated islands when starting from an empty cluster. If the first seed node is restarted and there is an existing cluster it will try to join the other seed nodes, i.e. it will join the existing cluster.
 
-You can read more about cluster joining in the [Akka documentation](http://doc.akka.io/docs/akka/2.5/java/cluster-usage.html#Joining_to_Seed_Nodes).
+You can read more about cluster joining in the [Akka documentation](https://doc.akka.io/docs/akka/2.5/cluster-usage.html?language=java#joining-to-seed-nodes).
 
 ## Downing
 

--- a/docs/manual/java/guide/cluster/PersistentEntity.md
+++ b/docs/manual/java/guide/cluster/PersistentEntity.md
@@ -213,4 +213,4 @@ The default configuration should be good starting point, and the following setti
 
 ## Underlying Implementation
 
-Each `PersistentEntity` instance is executed by a [PersistentActor](http://doc.akka.io/docs/akka/2.4/java/persistence.html) that is managed by [Akka Cluster Sharding](http://doc.akka.io/docs/akka/2.4/java/cluster-sharding.html).
+Each `PersistentEntity` instance is executed by a [PersistentActor](https://doc.akka.io/docs/akka/2.5/persistence.html?language=java) that is managed by [Akka Cluster Sharding](https://doc.akka.io/docs/akka/2.5/cluster-sharding.html?language=java).

--- a/docs/manual/java/guide/cluster/PubSub.md
+++ b/docs/manual/java/guide/cluster/PubSub.md
@@ -74,4 +74,4 @@ The published messages must be serializable since they will be sent across the n
 
 ## Underlying Implementation
 
-It is implemented with [Akka Distributed Publish Subscribe](http://doc.akka.io/docs/akka/2.4/java/distributed-pub-sub.html).
+It is implemented with [Akka Distributed Publish Subscribe](https://doc.akka.io/docs/akka/2.5/distributed-pub-sub.html?language=java).

--- a/docs/manual/java/guide/cluster/ReadSide.md
+++ b/docs/manual/java/guide/cluster/ReadSide.md
@@ -25,7 +25,7 @@ That said, if you use Lagom's built in Cassandra or relational database read-sid
 
 How you query the read-side database depends on your database, but there are two things to be aware of:
 
-* Ensure that any connection pools are started once, and then shut down when Lagom shuts down. Lagom is built on Play, and uses Play's lifecycle support to register callbacks to execute on shutdown. For information on how to hook into this, see the [Play documentation](https://playframework.com/documentation/2.5.x/JavaDependencyInjection#Stopping/cleaning-up).
+* Ensure that any connection pools are started once, and then shut down when Lagom shuts down. Lagom is built on Play, and uses Play's lifecycle support to register callbacks to execute on shutdown. For information on how to hook into this, see the [Play documentation](https://playframework.com/documentation/2.6.x/JavaDependencyInjection#Stopping/cleaning-up).
 * Ensure that any blocking actions are done in an appropriate execution context. Lagom assumes that all actions are asynchronous, and has thread pools tuned for asynchronous tasks. The use of unmanaged blocking can cause your application to stop responding at very low loads. For details on how to correctly manage thread pools for blocking database calls, see Play's documentation on [thread pools](https://www.playframework.com/documentation/2.6.x/ThreadPools).
 
 ## Update the Read-Side

--- a/docs/manual/java/guide/cluster/ReadSideCassandra.md
+++ b/docs/manual/java/guide/cluster/ReadSideCassandra.md
@@ -102,5 +102,5 @@ Once you have finished registering all your event handlers, you can invoke the `
 
 The `CassandraSession` is using the [Datastax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver).
 
-Each `ReadSideProcessor` instance is executed by an [Actor](http://doc.akka.io/docs/akka/2.4/java/untyped-actors.html) that is managed by [Akka Cluster Sharding](http://doc.akka.io/docs/akka/2.4/java/cluster-sharding.html). The processor consumes a stream of persistent events delivered by the `eventsByTag` [Persistence Query](http://doc.akka.io/docs/akka/2.4/java/persistence-query.html) implemented by [akka-persistence-cassandra](https://github.com/akka/akka-persistence-cassandra). The tag corresponds to the `tag` defined by the `AggregateEventTag`.
+Each `ReadSideProcessor` instance is executed by an [Actor](https://doc.akka.io/docs/akka/2.5/actors.html?language=java) that is managed by [Akka Cluster Sharding](https://doc.akka.io/docs/akka/2.5/cluster-sharding.html?language=java). The processor consumes a stream of persistent events delivered by the `eventsByTag` [Persistence Query](https://doc.akka.io/docs/akka/2.5/persistence-query.html?language=java) implemented by [akka-persistence-cassandra](https://github.com/akka/akka-persistence-cassandra). The tag corresponds to the `tag` defined by the `AggregateEventTag`.
 

--- a/docs/manual/java/guide/production/ProductionOverview.md
+++ b/docs/manual/java/guide/production/ProductionOverview.md
@@ -1,16 +1,16 @@
 # Production
 
-Lagom doesn't prescribe any particular production environment. If you are interested in deploying on [Kubernetes](https://kubernetes.io/), see our guide that demonstrates [how to deploy the Chirper example application](https://developer.lightbend.com/guides/k8s-microservices/).
+Lagom doesn't prescribe any particular production environment. If you are interested in deploying on [Kubernetes](https://kubernetes.io/), see our guide that demonstrates [how to deploy the Chirper example application](https://developer.lightbend.com/guides/lagom-kubernetes-k8s-deploy-microservices/).
 
 ## Deployment considerations
 
-The deployment platform determines the type of archive you will need to use for packaging your microservices as well as the way you set up service location. For packaging: 
+The deployment platform determines the type of archive you will need to use for packaging your microservices as well as the way you set up service location. For packaging:
 
 * Lagom sbt support leverages the [sbt-native-packager](http://www.scala-sbt.org/sbt-native-packager/) to produce archives of various types. By default zip archives can be produced, but you can also produce tar.gz, MSI, debian, RPM, Docker and more.
 
 * Maven has a variety of plugins to produce artifacts for various platforms.
 
-At runtime, services need to locate each other. This requires you to provide an implementation of a [ServiceLocator](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html). And, the deployment platform you choose might impose its own requirements on configuration. 
+At runtime, services need to locate each other. This requires you to provide an implementation of a [ServiceLocator](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html). And, the deployment platform you choose might impose its own requirements on configuration.
 
 The Cassandra module provided by `akka-persistence-cassandra` uses static lookup by default. Lagom overrides that behavior by implementing a Session provider based on service location. That allows all services to continue to operate without the need to redeploy if/when the Cassandra `contact-points` are updated or fail. Using this approach provides higher resiliency. However, it is possible to hardcode the list of `contact-points` where Cassandra may be located even when the server is stared with a dynamic service locator as described in the section below.
 
@@ -44,7 +44,7 @@ lagom.persistence.read-side.cassandra {
 }
 ```
 
-## Using static values for services and Cassandra to simulate a managed runtime 
+## Using static values for services and Cassandra to simulate a managed runtime
 
 While we would never advise using static service locations in production, to simulate a working Lagom system in the absence of a managed runtime, you can deploy Lagom systems to static locations by using static configuration. When using static service location, you can also hardcode Cassandra locations. To achieve this, you will need to:
 

--- a/docs/manual/java/guide/services/ServiceDescriptors.md
+++ b/docs/manual/java/guide/services/ServiceDescriptors.md
@@ -68,7 +68,7 @@ So far, all of the service call examples we've seen have used strict messages, f
 
 ### Streamed messages
 
-A streamed message is a message of type [`Source`](http://doc.akka.io/japi/akka/2.4.4/akka/stream/javadsl/Source.html).  `Source` is an [Akka streams](http://doc.akka.io/docs/akka/2.4/java.html) API that allows asynchronous streaming and handling of messages.  Here's an example streamed service call:
+A streamed message is a message of type [`Source`](https://doc.akka.io/japi/akka/2.5/akka/stream/javadsl/Source.html).  `Source` is an [Akka streams](https://doc.akka.io/docs/akka/2.5/stream/?language=java) API that allows asynchronous streaming and handling of messages.  Here's an example streamed service call:
 
 @[call-stream](code/docs/services/FirstDescriptor.java)
 

--- a/docs/manual/java/guide/services/ServiceImplementation.md
+++ b/docs/manual/java/guide/services/ServiceImplementation.md
@@ -22,7 +22,7 @@ It will take the request, and return the response as a [`CompletionStage`](https
 
 Of course, a simple hello world computation is not asynchronous, all it needs is to do is concatenate two Strings, and that returns immediately.  In this case, we need to wrap the result of that in a `CompletionStage`.  This can be done by calling `CompletableFuture.completedFuture()`, which returns a subclass of `CompletionStage` wrapping an immediately available value.
 
-Having provided an implementation of the service, we can now register that with the Lagom framework.  Lagom is built on top of Play Framework, and so uses Play's Guice based [dependency injection support](https://playframework.com/documentation/2.5.x/JavaDependencyInjection) to register components.  To register a service, you'll need to implement a Guice module.  This can be done by creating a class called `Module` in the root package:
+Having provided an implementation of the service, we can now register that with the Lagom framework.  Lagom is built on top of Play Framework, and so uses Play's Guice based [dependency injection support](https://playframework.com/documentation/2.6.x/JavaDependencyInjection) to register components.  To register a service, you'll need to implement a Guice module.  This can be done by creating a class called `Module` in the root package:
 
 @[hello-service-binding](code/docs/services/server/Module.java)
 

--- a/docs/manual/java/guide/services/Test.md
+++ b/docs/manual/java/guide/services/Test.md
@@ -74,11 +74,11 @@ Let's say we have a service that have streaming request and/or response paramete
 
 @[echo-service](code/docs/services/test/EchoService.java)
 
-When writing tests for that the [Akka Streams TestKit](http://doc.akka.io/docs/akka/2.4/java/stream/stream-testkit.html#Streams_TestKit) is very useful. We use the Streams TestKit together with the Lagom `ServiceTest` utilities:
+When writing tests for that the [Akka Streams TestKit](https://doc.akka.io/docs/akka/2.5/stream/stream-testkit.html?language=java#streams-testkit) is very useful. We use the Streams TestKit together with the Lagom `ServiceTest` utilities:
 
 @[test](code/docs/services/test/EchoServiceTest.java)
 
-Read more about it in the documentation of the [Akka Streams TestKit](http://doc.akka.io/docs/akka/2.4/java/stream/stream-testkit.html#Streams_TestKit).
+Read more about it in the documentation of the [Akka Streams TestKit](https://doc.akka.io/docs/akka/2.5/stream/stream-testkit.html?language=java#streams-testkit).
 
 ## How to test broker publishing and consuming
 

--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -120,7 +120,7 @@ Moreover, in `akka-persistence-jdbc` 3.0.x series, the `Events` query treats the
 
 ## Upgrading to Play 2.6 and Akka 2.5
 
-The internal upgrade to latest major versions of Play and Akka may need some changes in your code if you are using either of them directly. Please refer to the [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26) and the [Akka 2.5 migration guide](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html) for more details.
+The internal upgrade to latest major versions of Play and Akka may need some changes in your code if you are using either of them directly. Please refer to the [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26) and the [Akka 2.5 migration guide](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html?language=java) for more details.
 
 ### Deprecations
 
@@ -132,9 +132,9 @@ When running a rolling upgrade the nodes composing your Akka cluster must keep t
 
 If you are running Lagom 1.2.x and must do a rolling upgrade, you must first migrate to Lagom  1.3.5. Lagom 1.2.x nodes can't form a cluster with Lagom 1.4.x nodes.
 
-One relevant change Akka 2.5 introduced involves a new method (DData) [internally handle the sharding](http://doc.akka.io/docs/akka/current/java/project/migration-guide-2.4.x-2.5.x.html#cluster-sharding-state-store-mode) of your Persistent Entities in Lagom. We have decided to not enable that new method so your migration from Lagom 1.3.x to 1.4.x should be fine. You may opt in and use DData instead of the default persistence-based one but keep in mind that switching from persistence-based to DData requires a complete-cluster shutdown.
+One relevant change Akka 2.5 introduced involves a new method (DData) [internally handle the sharding](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html?language=java#cluster-sharding-state-store-mode) of your Persistent Entities in Lagom. We have decided to not enable that new method so your migration from Lagom 1.3.x to 1.4.x should be fine. You may opt in and use DData instead of the default persistence-based one but keep in mind that switching from persistence-based to DData requires a complete-cluster shutdown.
 
-The Java serialization was already discouraged and since Lagom 1.4.0 it is not the default anymore. This is a setting we inherit from Akka and which we are propagating transparently. If your code was dependant on the Java serialization you will need to review your serializers. This change in the defaults will also affect your ability to do a rolling upgrade. If you must support rolling upgrades and you depended on the default serializations you may override the new defaults using the [additional-serialization-bindings](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html#additional-serialization-bindings) settings.
+The Java serialization was already discouraged and since Lagom 1.4.0 it is not the default anymore. This is a setting we inherit from Akka and which we are propagating transparently. If your code was dependant on the Java serialization you will need to review your serializers. This change in the defaults will also affect your ability to do a rolling upgrade. If you must support rolling upgrades and you depended on the default serializations you may override the new defaults using the [additional-serialization-bindings](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html?language=java#additional-serialization-bindings) settings.
 
 Lagom 1.4.x has switched to a new serialization format for one of its internal messages. This new format was added in Lagom 1.3.10, but not enabled. If you are doing a rolling upgrading from 1.3.10 or later to 1.4.x, then the change over will work with no problems. However, if you're doing a rolling upgrading from 1.3.9 or earlier to 1.4.x, then you will need to add the following configuration to your application to disable the new serializer until all nodes are upgraded to a version of Lagom that has the serializer:
 

--- a/docs/manual/scala/guide/advanced/Akka.md
+++ b/docs/manual/scala/guide/advanced/Akka.md
@@ -12,7 +12,7 @@ Let's look at an example of a `WorkerService` that accepts job requests and dele
 
 @[service-impl](code/Akka.scala)
 
-Notice how the `ActorSystem` is injected through the constructor. We create worker actors on each node that has the "worker-node" role. We create a consistent hashing group router that delegates jobs to the workers. Details on these features are in the [Akka documentation](http://doc.akka.io/docs/akka/2.4/scala.html).
+Notice how the `ActorSystem` is injected through the constructor. We create worker actors on each node that has the "worker-node" role. We create a consistent hashing group router that delegates jobs to the workers. Details on these features are in the [Akka documentation](https://doc.akka.io/docs/akka/2.5/?language=scala).
 
 The worker actor looks like this:
 

--- a/docs/manual/scala/guide/cluster/Cluster.md
+++ b/docs/manual/scala/guide/cluster/Cluster.md
@@ -2,7 +2,7 @@
 
 Instances of the same service may run on multiple nodes, for scalability and redundancy. Nodes may be physical or virtual machines, grouped in a cluster.
 
-The underlying clustering technology is [Akka Cluster](http://doc.akka.io/docs/akka/2.4/scala/cluster-usage.html).
+The underlying clustering technology is [Akka Cluster](https://doc.akka.io/docs/akka/2.5/cluster-usage.html?language=scala).
 
 If instances of a service need to know about each other, they must join the same cluster. Within a cluster, services may use the [[Persistence|PersistentEntity]] and [[Publish-Subscribe|PubSub]] modules of Lagom.
 
@@ -55,7 +55,7 @@ The node that is configured first in the list of `seed-nodes` is special. Only t
 
 The reason for the special first seed node is to avoid forming separated islands when starting from an empty cluster. If the first seed node is restarted and there is an existing cluster it will try to join the other seed nodes, i.e. it will join the existing cluster.
 
-You can read more about cluster joining in the [Akka documentation](http://doc.akka.io/docs/akka/2.4/scala/cluster-usage.html#Joining_to_Seed_Nodes).
+You can read more about cluster joining in the [Akka documentation](https://doc.akka.io/docs/akka/2.5/cluster-usage.html?language=scala#joining-to-seed-nodes).
 
 ## Downing
 

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -215,4 +215,4 @@ The default configuration should be good starting point, and the following setti
 
 ## Underlying Implementation
 
-Each `PersistentEntity` instance is executed by a [PersistentActor](http://doc.akka.io/docs/akka/2.4/java/persistence.html) that is managed by [Akka Cluster Sharding](http://doc.akka.io/docs/akka/2.4/java/cluster-sharding.html).
+Each `PersistentEntity` instance is executed by a [PersistentActor](https://doc.akka.io/docs/akka/2.5/persistence.html?language=scala) that is managed by [Akka Cluster Sharding](https://doc.akka.io/docs/akka/2.5/cluster-sharding.html?language=scala).

--- a/docs/manual/scala/guide/cluster/PubSub.md
+++ b/docs/manual/scala/guide/cluster/PubSub.md
@@ -62,4 +62,4 @@ The published messages must be serializable since they will be sent across the n
 
 ## Underlying Implementation
 
-It is implemented with [Akka Distributed Publish Subscribe](http://doc.akka.io/docs/akka/2.4/java/distributed-pub-sub.html).
+It is implemented with [Akka Distributed Publish Subscribe](https://doc.akka.io/docs/akka/2.5/distributed-pub-sub.html?language=scala).

--- a/docs/manual/scala/guide/cluster/ReadSide.md
+++ b/docs/manual/scala/guide/cluster/ReadSide.md
@@ -25,7 +25,7 @@ That said, if you use Lagom's built in Cassandra or relational database read-sid
 
 How you query the read-side database depends on your database, but there are two things to be aware of:
 
-* Ensure that any connection pools are started once, and then shut down when Lagom shuts down. Lagom is built on Play, and uses Play's lifecycle support to register callbacks to execute on shutdown. For information on how to hook into this, see the [Play documentation](https://playframework.com/documentation/2.5.x/ScalaDependencyInjection#Stopping/cleaning-up).
+* Ensure that any connection pools are started once, and then shut down when Lagom shuts down. Lagom is built on Play, and uses Play's lifecycle support to register callbacks to execute on shutdown. For information on how to hook into this, see the [Play documentation](https://playframework.com/documentation/2.6.x/ScalaDependencyInjection#Stopping/cleaning-up).
 * Ensure that any blocking actions are done in an appropriate execution context. Lagom assumes that all actions are asynchronous, and has thread pools tuned for asynchronous tasks. The use of unmanaged blocking can cause your application to stop responding at very low loads. For details on how to correctly manage thread pools for blocking database calls, see Play's documentation on [thread pools](https://www.playframework.com/documentation/2.6.x/ThreadPools).
 
 ## Update the Read-Side

--- a/docs/manual/scala/guide/cluster/ReadSideCassandra.md
+++ b/docs/manual/scala/guide/cluster/ReadSideCassandra.md
@@ -102,5 +102,5 @@ Once you have finished registering all your event handlers, you can invoke the `
 
 The `CassandraSession` is using the [Datastax Java Driver for Apache Cassandra](https://github.com/datastax/java-driver).
 
-Each `ReadSideProcessor` instance is executed by an [Actor](http://doc.akka.io/docs/akka/2.4/scala/actors.html) that is managed by [Akka Cluster Sharding](http://doc.akka.io/docs/akka/2.4/scala/cluster-sharding.html). The processor consumes a stream of persistent events delivered by the `eventsByTag` [Persistence Query](http://doc.akka.io/docs/akka/2.4/scala/persistence-query.html) implemented by [akka-persistence-cassandra](https://github.com/akka/akka-persistence-cassandra). The tag corresponds to the `tag` defined by the `AggregateEventTag`.
+Each `ReadSideProcessor` instance is executed by an [Actor](https://doc.akka.io/docs/akka/2.5/actors.html?language=scala) that is managed by [Akka Cluster Sharding](https://doc.akka.io/docs/akka/2.5/cluster-sharding.html?language=scala). The processor consumes a stream of persistent events delivered by the `eventsByTag` [Persistence Query](https://doc.akka.io/docs/akka/2.5/persistence-query.html?language=scala) implemented by [akka-persistence-cassandra](https://github.com/akka/akka-persistence-cassandra). The tag corresponds to the `tag` defined by the `AggregateEventTag`.
 

--- a/docs/manual/scala/guide/cluster/ReadSideSlick.md
+++ b/docs/manual/scala/guide/cluster/ReadSideSlick.md
@@ -19,7 +19,7 @@ Let us first look at how a service implementation can retrieve data from a relat
 @[service-impl](code/docs/home/scaladsl/persistence/SlickReadSideQuery.scala)
 
 
-Note that a Slick [Database](http://slick.lightbend.com/doc/3.2.0/api/#slick.jdbc.JdbcBackend$DatabaseDef) is injected in the constructor together with the previously defined `PostSummaryRepository`. Slick's [Database](http://slick.lightbend.com/doc/3.2.0/api/#slick.jdbc.JdbcBackend$DatabaseDef) allows the execution of the Slick `DBIOAciton` returned by `selectPostSummaries()`. Importantly, it also manages execution of the blocking JDBC calls in a thread pool designed to handle it, which is why it returns a `Future`.
+Note that a Slick [Database](http://slick.lightbend.com/doc/3.2.1/api/#slick.jdbc.JdbcBackend$DatabaseDef) is injected in the constructor together with the previously defined `PostSummaryRepository`. Slick's [Database](http://slick.lightbend.com/doc/3.2.1/api/#slick.jdbc.JdbcBackend$DatabaseDef) allows the execution of the Slick `DBIOAciton` returned by `selectPostSummaries()`. Importantly, it also manages execution of the blocking JDBC calls in a thread pool designed to handle it, which is why it returns a `Future`.
 
 ## Update the Read-Side
 

--- a/docs/manual/scala/guide/cluster/Serialization.md
+++ b/docs/manual/scala/guide/cluster/Serialization.md
@@ -13,14 +13,14 @@ The Play JSON abstraction for serializing and deserializing a class into JSON is
 
 To enable JSON Serialization there are three steps you need to follow.
 
-The first step is to define your [Format](https://www.playframework.com/documentation/2.6.x/api/scala/play/api/libs/json/Format.html) for each class that is to be serialized, this can be done using [automated mapping](#Automated-mapping) or [manual mapping](#Manual-mapping). 
+The first step is to define your [Format](https://www.playframework.com/documentation/2.6.x/api/scala/play/api/libs/json/Format.html) for each class that is to be serialized, this can be done using [automated mapping](#Automated-mapping) or [manual mapping](#Manual-mapping).
 
 @[format](code/docs/home/scaladsl/serialization/AddPost.scala)
 
 Best practice is to define the `Format` as an implicit in the classes companion object, so that it can be found by implicit resolution.
- 
+
 The second step is to implement [JsonSerializerRegistry](api/com/lightbend/lagom/scaladsl/playjson/JsonSerializerRegistry.html) and have all the service formats returned from its `serializers` method.
-   
+
 @[registry](code/docs/home/scaladsl/serialization/Registry.scala)
 
 Having done that, you can provide the serializer registry by overriding the `jsonSerializerRegistry` component method in your application cake, for example:
@@ -42,7 +42,7 @@ JSON can be rather verbose and for large messages it can be beneficial to enable
 The serializer will by default only compress messages that are larger than 1024 bytes. This threshold can be changed with configuration property:
 
 @[compress-larger-than](../../../../../play-json/src/main/resources/reference.conf)
-   
+
 ## Automated mapping
 
 The [Json.format\[MyClass\]](https://www.playframework.com/documentation/2.6.x/api/scala/index.html#play.api.libs.json.Json$@format[A]:play.api.libs.json.OFormat[A]) macro will inspect a `case class` for what fields it contains and produce a `Format` that uses the field names and types of the class in the resulting JSON.
@@ -55,7 +55,7 @@ If the class contains fields of complex types, it pulls those in from `implicit`
 
 ## Manual mapping
 
-Defining a `Format` can be done in several ways using the Play JSON APIs, either using [JSON Combinators](https://playframework.com/documentation/2.5.x/ScalaJsonCombinators#Format) or by manually implementing functions that turn a `JsValue` into a `JsSuccess(T)` or a `JsFailure()`.
+Defining a `Format` can be done in several ways using the Play JSON APIs, either using [JSON Combinators](https://playframework.com/documentation/2.6.x/ScalaJsonCombinators#Format) or by manually implementing functions that turn a `JsValue` into a `JsSuccess(T)` or a `JsFailure()`.
 
 @[manualMapping](code/docs/home/scaladsl/serialization/AddOrder.scala)
 

--- a/docs/manual/scala/guide/production/ProductionOverview.md
+++ b/docs/manual/scala/guide/production/ProductionOverview.md
@@ -1,21 +1,21 @@
 # Production
 
-Lagom doesn't prescribe any particular production environment. If you are interested in deploying on [Kubernetes](https://kubernetes.io/), see our guide that demonstrates [how to deploy the Chirper example application](https://developer.lightbend.com/guides/k8s-microservices/).
+Lagom doesn't prescribe any particular production environment. If you are interested in deploying on [Kubernetes](https://kubernetes.io/), see our guide that demonstrates [how to deploy the Chirper example application](https://developer.lightbend.com/guides/lagom-kubernetes-k8s-deploy-microservices/).
 
 
 ## Deployment considerations
 
-The deployment platform determines the type of archive you will need to use for packaging your microservices and the way you provide service location, including that for Cassandra: 
+The deployment platform determines the type of archive you will need to use for packaging your microservices and the way you provide service location, including that for Cassandra:
 
 * Lagom leverages the [sbt-native-packager](http://www.scala-sbt.org/sbt-native-packager/) to produce archives of various types. By default, sbt produces zip archives, but you can easily produce tar.gz, MSI, debian, RPM, Docker and more.
 
-* At runtime, services need to locate each other. This requires you to provide an implementation of a  [ServiceLocator](api/com/lightbend/lagom/scaladsl/api/ServiceLocator.html). And, the deployment platform you choose might impose its own requirements on configuration. 
+* At runtime, services need to locate each other. This requires you to provide an implementation of a  [ServiceLocator](api/com/lightbend/lagom/scaladsl/api/ServiceLocator.html). And, the deployment platform you choose might impose its own requirements on configuration.
 
 * The Cassandra module provided by `akka-persistence-cassandra` uses static lookup by default. Lagom overrides that behavior by implementing a Session provider based on service location. That allows all services to continue to operate without the need to redeploy if/when the Cassandra `contact-points` are updated or fail. Using this approach provides higher resiliency. However, it is possible to hardcode the list of `contact-points` where Cassandra may be located even when the server is stared with a dynamic service locator as described in the section below.
 
 ### Deploying using static Cassandra contact-points
 
-If you want to use dynamic service location for your services but need to statically locate Cassandra, modify the `application.conf` for your service. You will need to disable Lagom's `ConfigSessionProvider` and fall back to the one provided in `akka-persistence-cassandra`, which uses the list of endpoints listed in `contact-points`. The `application.conf` settings will be applied in all environments (development and production) unless overridden. See developer mode settings on [[overriding Cassandra setup in Dev Mode|CassandraServer#Connecting-to-a-locally-running-Cassandra-instance]] for more information on settings up Cassandra in dev mode. 
+If you want to use dynamic service location for your services but need to statically locate Cassandra, modify the `application.conf` for your service. You will need to disable Lagom's `ConfigSessionProvider` and fall back to the one provided in `akka-persistence-cassandra`, which uses the list of endpoints listed in `contact-points`. The `application.conf` settings will be applied in all environments (development and production) unless overridden. See developer mode settings on [[overriding Cassandra setup in Dev Mode|CassandraServer#Connecting-to-a-locally-running-Cassandra-instance]] for more information on settings up Cassandra in dev mode.
 
 To set up static Cassandra `contact-points` and disable `ConfigSessionProvider`, modify the following sections of the `application-conf` file:
 

--- a/docs/manual/scala/guide/services/ScalaComponents.md
+++ b/docs/manual/scala/guide/services/ScalaComponents.md
@@ -35,7 +35,7 @@ This is a list of available Components you may use to build your application cak
 
 You can mix in `Components` from other frameworks or libraries, for example:
 
- * [ConductRApplicationComponents](https://github.com/typesafehub/conductr-lib/blob/master/lagom1-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala): provides a Service Locator provided by ConductR, reads any ConductR provided configuration and makes the service register into ConductR's Service Registry. See [[ConductR]]
+ * [ConductRApplicationComponents](https://github.com/typesafehub/conductr-lib/blob/master/lagom14-scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/lagom/scaladsl/ConductRApplicationComponents.scala): provides a Service Locator provided by ConductR, reads any ConductR provided configuration and makes the service register into ConductR's Service Registry. See [[ConductR]]
  * [AhcWSComponents](https://www.playframework.com/documentation/2.6.x/api/scala/index.html#play.api.libs.ws.ahc.AhcWSComponents): provides a `WSClient` based on an Async HTTP Client.
  * [DBComponents](https://www.playframework.com/documentation/2.6.x/api/scala/play/api/db/DBComponents.html)
  * [HikariCPComponents](https://www.playframework.com/documentation/2.6.x/api/scala/play/api/db/HikariCPComponents.html)

--- a/docs/manual/scala/guide/services/ServiceDescriptors.md
+++ b/docs/manual/scala/guide/services/ServiceDescriptors.md
@@ -64,12 +64,12 @@ So far, all of the service call examples we've seen have used strict messages, f
 
 ### Streamed messages
 
-A streamed message is a message of type [`Source`](http://doc.akka.io/api/akka/2.4.4/akka/stream/scaladsl/Source.html). `Source` is an [Akka streams](http://doc.akka.io/docs/akka/2.4/scala.html) API that allows asynchronous streaming and handling of messages.  Here's an example streamed service call:
+A streamed message is a message of type [`Source`](https://doc.akka.io/api/akka/2.5/akka/stream/scaladsl/Source.html). `Source` is an [Akka streams](https://doc.akka.io/docs/akka/2.5/stream/?language=scala) API that allows asynchronous streaming and handling of messages.  Here's an example streamed service call:
 
 @[call-stream](code/ServiceDescriptors.scala)
 
 This service call has a strict request type and a streamed response type.  An implementation of this might return a `Source` that sends the input tick message `String` at the specified interval.
-    
+
 A bidirectional streamed call might look like this:
 
 @[hello-stream](code/ServiceDescriptors.scala)

--- a/docs/manual/scala/guide/services/TestingServices.md
+++ b/docs/manual/scala/guide/services/TestingServices.md
@@ -74,11 +74,11 @@ Let's say we have a service that has streaming request and/or response parameter
 
 @[echo-service](code/TestingServices.scala)
 
-When writing tests for that the [Akka Streams TestKit](http://doc.akka.io/docs/akka/2.4/java/stream/stream-testkit.html#Streams_TestKit) is very useful. We use the Streams TestKit together with the Lagom `ServiceTest` utilities:
+When writing tests for that the [Akka Streams TestKit](https://doc.akka.io/docs/akka/2.5/stream/stream-testkit.html?language=scala#streams-testkit) is very useful. We use the Streams TestKit together with the Lagom `ServiceTest` utilities:
 
 @[echo-service-spec](code/TestingServices.scala)
 
-Read more about it in the documentation of the [Akka Streams TestKit](http://doc.akka.io/docs/akka/2.4/java/stream/stream-testkit.html#Streams_TestKit).
+Read more about it in the documentation of the [Akka Streams TestKit](https://doc.akka.io/docs/akka/2.5/stream/stream-testkit.html?language=scala#streams-testkit).
 
 ## How to test a persistent entity
 

--- a/docs/manual/scala/releases/Migration14.md
+++ b/docs/manual/scala/releases/Migration14.md
@@ -124,7 +124,7 @@ Moreover, in `akka-persistence-jdbc` 3.0.x series, the `Events` query treats the
 
 ## Upgrading to Play 2.6 and Akka 2.5
 
-The internal upgrade to latest major versions of Play and Akka may need some changes in your code if you are using either of them directly. Please refer to the [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26) and the [Akka 2.5 migration guide](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html) for more details.
+The internal upgrade to latest major versions of Play and Akka may need some changes in your code if you are using either of them directly. Please refer to the [Play 2.6 migration guide](https://www.playframework.com/documentation/2.6.x/Migration26) and the [Akka 2.5 migration guide](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html?language=scala) for more details.
 
 ### Default Service Locator port
 
@@ -134,9 +134,9 @@ Historically, Lagom's service locator has listened on port 8000. Because port 80
 
 When running a rolling upgrade the nodes composing your Akka cluster must keep the ability to connect to each other and must use the same serialization formats.
 
-One relevant change Akka 2.5 introduced involves a new method (DData) to [internally handle the sharding](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html#cluster-sharding-state-store-mode) of your Persistent Entities in Lagom. We have decided to not enable that new method so your migration from Lagom 1.3.x to 1.4.x should be fine. You may opt in and use DData instead of the default persistence-based one. Switching from persistence-based to DData requires a complete-cluster shutdown.
+One relevant change Akka 2.5 introduced involves a new method (DData) to [internally handle the sharding](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html?language=scala#cluster-sharding-state-store-mode) of your Persistent Entities in Lagom. We have decided to not enable that new method so your migration from Lagom 1.3.x to 1.4.x should be fine. You may opt in and use DData instead of the default persistence-based one. Switching from persistence-based to DData requires a complete-cluster shutdown.
 
-The Java serialization was already discouraged and since Lagom 1.4.0 it is not the default anymore. This is a setting we inherit from Akka and which we are propagating transparently. If your code was dependant on the Java serialization you will need to review your serializers. This change in the defaults will also affect your ability to do a rolling upgrade. If you must support rolling upgrades and you depended on the default serializations you may override the new defaults using the [additional-serialization-bindings](http://doc.akka.io/docs/akka/current/scala/project/migration-guide-2.4.x-2.5.x.html#additional-serialization-bindings) settings.
+The Java serialization was already discouraged and since Lagom 1.4.0 it is not the default anymore. This is a setting we inherit from Akka and which we are propagating transparently. If your code was dependant on the Java serialization you will need to review your serializers. This change in the defaults will also affect your ability to do a rolling upgrade. If you must support rolling upgrades and you depended on the default serializations you may override the new defaults using the [additional-serialization-bindings](https://doc.akka.io/docs/akka/current/project/migration-guide-2.4.x-2.5.x.html?language=scala#additional-serialization-bindings) settings.
 
 Lagom 1.4.x has switched to a new serialization format for one of its internal messages. This new format was added in Lagom 1.3.10, but not enabled. If you are doing a rolling upgrading from 1.3.10 or later to 1.4.x, then the change over will work with no problems. However, if you're doing a rolling upgrading from 1.3.9 or earlier to 1.4.x, then you will need to add the following configuration to your application to disable the new serializer until all nodes are upgraded to a version of Lagom that has the serializer:
 
@@ -148,7 +148,7 @@ akka.actor.serialization-bindings {
 
 Once all nodes are upgraded to 1.4.x, you should then remove the above configuration for the next rolling upgrade. For more details on this process and why it's needed, see [here](https://github.com/lagom/lagom/issues/933#issuecomment-327738303).
 
-## Breaking Changes 
+## Breaking Changes
 
 The return types of the method below were changed, which could result in deprecation warnings:
 


### PR DESCRIPTION
Update documentation links

- Change Akka 2.4 links to 2.5
- Update Java/Scala specific links to Akka's new format
- Fix anchors that changed in the Akka documentation
- Change Play 2.5.x links to 2.6.x
- Update broken or redirected links
- Changed links from the common documentation pages to be language-neutral
- Fix a few links to the Java version of Akka documentation from the Scala version of the Lagom documentation

Supersedes #1111 and includes a cherry-picked copy of the commit from that pull request.