### PR TITLE
Additional PersistentEntityRegistry, ReadSide

### DIFF
--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -3,6 +3,7 @@
  */
 package com.lightbend.lagom.internal.javadsl.persistence.cassandra
 
+import java.util.Optional
 import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
@@ -26,10 +27,6 @@ private[lagom] final class CassandraPersistentEntityRegistry @Inject() (system: 
   CassandraKeyspaceConfig.validateKeyspace("cassandra-journal", system.settings.config, log)
   CassandraKeyspaceConfig.validateKeyspace("cassandra-snapshot-store", system.settings.config, log)
 
-  override protected val journalId = CassandraReadJournal.Identifier
-
-  private val cassandraReadJournal = PersistenceQuery(system).readJournalFor[CassandraReadJournal](journalId)
-
-  override protected val eventsByTagQuery: Option[EventsByTagQuery] = Some(cassandraReadJournal)
+  override protected val queryPluginId = Optional.of(CassandraReadJournal.Identifier)
 
 }

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -22,10 +22,5 @@ private[lagom] final class CassandraPersistentEntityRegistry(system: ActorSystem
   CassandraKeyspaceConfig.validateKeyspace("cassandra-journal", system.settings.config, log)
   CassandraKeyspaceConfig.validateKeyspace("cassandra-snapshot-store", system.settings.config, log)
 
-  override protected val journalId = CassandraReadJournal.Identifier
-
-  private val cassandraReadJournal = PersistenceQuery(system).readJournalFor[CassandraReadJournal](journalId)
-
-  override protected val eventsByTagQuery: Option[EventsByTagQuery] = Some(cassandraReadJournal)
-
+  override protected val queryPluginId = Some(CassandraReadJournal.Identifier)
 }

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -3,6 +3,7 @@
  */
 package com.lightbend.lagom.internal.javadsl.persistence.jdbc
 
+import java.util.Optional
 import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
@@ -27,8 +28,6 @@ private[lagom] final class JdbcPersistentEntityRegistry @Inject() (system: Actor
     super.register(entityClass)
   }
 
-  override protected val journalId: String = JdbcReadJournal.Identifier
-  private val jdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](journalId)
-  override protected val eventsByTagQuery: Option[EventsByTagQuery] = Some(jdbcReadJournal)
+  override protected val queryPluginId = Optional.of(JdbcReadJournal.Identifier)
 
 }

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -24,8 +24,6 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
     super.register(entityFactory)
   }
 
-  override protected val journalId: String = JdbcReadJournal.Identifier
-  private val jdbcReadJournal = PersistenceQuery(system).readJournalFor[JdbcReadJournal](journalId)
-  override protected val eventsByTagQuery: Option[EventsByTagQuery] = Some(jdbcReadJournal)
+  override protected val queryPluginId = Some(JdbcReadJournal.Identifier)
 
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -13,32 +13,30 @@ import akka.event.Logging
 import akka.japi.Pair
 import akka.pattern.ask
 import akka.persistence.query.scaladsl.EventsByTagQuery
-import akka.persistence.query.{ Offset => AkkaOffset }
+import akka.persistence.query.{ PersistenceQuery, Offset => AkkaOffset }
 import akka.stream.javadsl
 import akka.util.Timeout
 import akka.{ Done, NotUsed }
 import com.google.inject.Injector
 import com.lightbend.lagom.javadsl.persistence._
-
 import scala.concurrent.duration.{ FiniteDuration, _ }
 import scala.util.control.NonFatal
+import scala.compat.java8.OptionConverters._
 
 /**
  * Provides shared functionality for implementing a persistent entity registry.
  *
  * Akka persistence plugins can extend this to implement a custom registry.
  */
-abstract class AbstractPersistentEntityRegistry(system: ActorSystem, injector: Injector) extends PersistentEntityRegistry {
+class AbstractPersistentEntityRegistry(system: ActorSystem, injector: Injector) extends PersistentEntityRegistry {
 
-  /**
-   * The ID of the journal.
-   */
-  protected val journalId: String
+  protected val name: Optional[String] = Optional.empty()
+  protected val journalPluginId: String = ""
+  protected val snapshotPluginId: String = ""
+  protected val queryPluginId: Optional[String] = Optional.empty()
 
-  /**
-   * The events by tag query. Necessary for implementing read sides and the eventStream query.
-   */
-  protected val eventsByTagQuery: Option[EventsByTagQuery] = None
+  private lazy val eventsByTagQuery: Option[EventsByTagQuery] =
+    queryPluginId.asScala.map(id => PersistenceQuery(system).readJournalFor[EventsByTagQuery](id))
 
   private val sharding = ClusterSharding(system)
   private val conf = system.settings.config.getConfig("lagom.persistence")
@@ -75,6 +73,8 @@ abstract class AbstractPersistentEntityRegistry(system: ActorSystem, injector: I
   private val registeredTypeNames = new ConcurrentHashMap[String, Class[_]]()
   private val reverseRegister = new ConcurrentHashMap[Class[_], String]()
 
+  private def prependName(entityTypeName: String) = name.asScala.fold("")(_ + "-") + entityTypeName
+
   override def register[C, E, S](entityClass: Class[_ <: PersistentEntity[C, E, S]]): Unit = {
 
     val entityFactory: () => PersistentEntity[C, E, S] =
@@ -101,19 +101,20 @@ abstract class AbstractPersistentEntityRegistry(system: ActorSystem, injector: I
 
     if (role.forall(Cluster(system).selfRoles.contains)) {
       val entityProps = PersistentEntityActor.props(
-        persistenceIdPrefix = entityTypeName, Optional.empty(), entityFactory, snapshotAfter, passivateAfterIdleTimeout
+        persistenceIdPrefix = entityTypeName, Optional.empty(), entityFactory, snapshotAfter, passivateAfterIdleTimeout,
+        journalPluginId, snapshotPluginId
       )
-      sharding.start(entityTypeName, entityProps, shardingSettings, extractEntityId, extractShardId)
+      sharding.start(prependName(entityTypeName), entityProps, shardingSettings, extractEntityId, extractShardId)
     } else {
       // not required role, start in proxy mode
-      sharding.startProxy(entityTypeName, role, extractEntityId, extractShardId)
+      sharding.startProxy(prependName(entityTypeName), role, extractEntityId, extractShardId)
     }
   }
 
   override def refFor[C](entityClass: Class[_ <: PersistentEntity[C, _, _]], entityId: String): PersistentEntityRef[C] = {
     val entityName = reverseRegister.get(entityClass)
     if (entityName == null) throw new IllegalArgumentException(s"[${entityClass.getName} must first be registered")
-    new PersistentEntityRef(entityId, sharding.shardRegion(entityName), askTimeout)
+    new PersistentEntityRef(entityId, sharding.shardRegion(prependName(entityName)), askTimeout)
   }
 
   private def entityTypeName(entityClass: Class[_]): String = Logging.simpleName(entityClass)
@@ -133,7 +134,7 @@ abstract class AbstractPersistentEntityRegistry(system: ActorSystem, injector: I
           .asJava
 
       case None =>
-        throw new UnsupportedOperationException(s"The $journalId Lagom persistence plugin does not support streaming events by tag")
+        throw new UnsupportedOperationException(s"The Lagom persistence plugin does not support streaming events by tag")
     }
   }
 

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
@@ -29,10 +29,12 @@ private[lagom] object PersistentEntityActor {
     entityId:                  Optional[String],
     entityFactory:             () => PersistentEntity[C, E, S],
     snapshotAfter:             Optional[Int],
-    passivateAfterIdleTimeout: Duration
+    passivateAfterIdleTimeout: Duration,
+    journalPluginId:           String,
+    snapshotPluginId:          String
   ): Props =
     Props(new PersistentEntityActor(persistenceIdPrefix, entityId, entityFactory(), snapshotAfter.orElse(0),
-      passivateAfterIdleTimeout))
+      passivateAfterIdleTimeout, journalPluginId, snapshotPluginId))
 
   /**
    * Stop the actor for passivation. `PoisonPill` does not work well
@@ -45,11 +47,13 @@ private[lagom] object PersistentEntityActor {
  * The `PersistentActor` that runs a [[com.lightbend.lagom.javadsl.persistence.PersistentEntity]].
  */
 private[lagom] class PersistentEntityActor[C, E, S](
-  persistenceIdPrefix:       String,
-  id:                        Optional[String],
-  entity:                    PersistentEntity[C, E, S],
-  snapshotAfter:             Int,
-  passivateAfterIdleTimeout: Duration
+  persistenceIdPrefix:           String,
+  id:                            Optional[String],
+  entity:                        PersistentEntity[C, E, S],
+  snapshotAfter:                 Int,
+  passivateAfterIdleTimeout:     Duration,
+  override val journalPluginId:  String,
+  override val snapshotPluginId: String
 ) extends PersistentActor {
   private val log = Logger(this.getClass)
 

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistrySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistrySpec.scala
@@ -39,9 +39,7 @@ class AbstractPersistentEntityRegistrySpec
 
   def withRegistry[T](block: (AbstractPersistentEntityRegistry) => T): T = {
     val injector = Guice.createInjector(new ActorSystemModule(system))
-    val registry = new AbstractPersistentEntityRegistry(system, injector) {
-      override protected val journalId = "testing-journal"
-    }
+    val registry = new AbstractPersistentEntityRegistry(system, injector)
     block(registry)
   }
 

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
@@ -58,7 +58,9 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
         Optional.of("1"),
         () => new TestEntity(system),
         Optional.empty(),
-        10.seconds
+        10.seconds,
+        "",
+        ""
       )
     )
   }

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
@@ -23,11 +23,14 @@ private[lagom] object PersistentEntityActor {
     entityId:                  Option[String],
     entityFactory:             () => PersistentEntity,
     snapshotAfter:             Option[Int],
-    passivateAfterIdleTimeout: Duration
+    passivateAfterIdleTimeout: Duration,
+    journalPluginId:           String,
+    snapshotPluginId:          String
   ): Props =
     Props(new PersistentEntityActor(persistenceIdPrefix, entityId,
       entityFactory(),
-      snapshotAfter.getOrElse(0), passivateAfterIdleTimeout))
+      snapshotAfter.getOrElse(0), passivateAfterIdleTimeout,
+      journalPluginId, snapshotPluginId))
 
   /**
    * Stop the actor for passivation. `PoisonPill` does not work well
@@ -56,11 +59,13 @@ private[lagom] object PersistentEntityActor {
  * The `PersistentActor` that runs a [[com.lightbend.lagom.scaladsl.persistence.PersistentEntity]].
  */
 private[lagom] class PersistentEntityActor(
-  persistenceIdPrefix:       String,
-  id:                        Option[String],
-  entity:                    PersistentEntity,
-  snapshotAfter:             Int,
-  passivateAfterIdleTimeout: Duration
+  persistenceIdPrefix:           String,
+  id:                            Option[String],
+  entity:                        PersistentEntity,
+  snapshotAfter:                 Int,
+  passivateAfterIdleTimeout:     Duration,
+  override val journalPluginId:  String,
+  override val snapshotPluginId: String
 ) extends PersistentActor {
 
   import PersistentEntityActor.EntityIdSeparator

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
@@ -16,7 +16,7 @@ import com.lightbend.lagom.scaladsl.persistence._
 import scala.concurrent.ExecutionContext
 
 private[lagom] class ReadSideImpl(
-  system: ActorSystem, config: ReadSideConfig, registry: PersistentEntityRegistry
+  system: ActorSystem, config: ReadSideConfig, registry: PersistentEntityRegistry, name: Option[String]
 )(implicit ec: ExecutionContext, mat: Materializer) extends ReadSide {
 
   override def register[Event <: AggregateEvent[Event]](processorFactory: => ReadSideProcessor[Event]): Unit =
@@ -30,7 +30,7 @@ private[lagom] class ReadSideImpl(
     if (config.role.forall(Cluster(system).selfRoles.contains)) {
       // try to create one instance to fail fast
       val proto = processorFactory()
-      val readSideName = proto.readSideName
+      val readSideName = name.fold("")(_ + "-") + proto.readSideName
       val encodedReadSideName = URLEncoder.encode(readSideName, "utf-8")
       val tags = proto.aggregateTags
       val entityIds = tags.map(_.tag)

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistenceComponents.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistenceComponents.scala
@@ -35,7 +35,7 @@ trait ReadSidePersistenceComponents extends WriteSidePersistenceComponents {
   def configuration: Configuration
 
   lazy val readSideConfig: ReadSideConfig = ReadSideConfig(configuration.underlying.getConfig("lagom.persistence.read-side"))
-  lazy val readSide: ReadSide = new ReadSideImpl(actorSystem, readSideConfig, persistentEntityRegistry)(
+  lazy val readSide: ReadSide = new ReadSideImpl(actorSystem, readSideConfig, persistentEntityRegistry, None)(
     executionContext, materializer
   )
 

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistrySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistrySpec.scala
@@ -36,9 +36,7 @@ class AbstractPersistentEntityRegistrySpec
   }
 
   def withRegistry[T](block: (AbstractPersistentEntityRegistry) => T): T = {
-    val registry = new AbstractPersistentEntityRegistry(system) {
-      override protected val journalId = "testing-journal"
-    }
+    val registry = new AbstractPersistentEntityRegistry(system)
     block(registry)
   }
 

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractPersistentEntityActorSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractPersistentEntityActorSpec.scala
@@ -15,7 +15,7 @@ object AbstractPersistentEntityActorSpec {
   class TestPassivationParent extends Actor {
 
     val child = context.actorOf(PersistentEntityActor.props("test", Some("1"),
-      () => new TestEntity(context.system), None, 1.second))
+      () => new TestEntity(context.system), None, 1.second, "", ""))
 
     def receive = {
       case ShardRegion.Passivate(stopMsg) =>
@@ -31,7 +31,7 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
   "PersistentEntityActor" must {
     "persist events" in {
       val p = system.actorOf(PersistentEntityActor.props("test", Some("1"),
-        () => new TestEntity(system), None, 10.seconds))
+        () => new TestEntity(system), None, 10.seconds, "", ""))
       p ! TestEntity.Get
       val state = expectMsgType[TestEntity.State]
       state.elements.size should ===(0)
@@ -47,7 +47,7 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
 
       // start another with same persistenceId should recover state
       val p2 = system.actorOf(PersistentEntityActor.props("test", Some("1"),
-        () => new TestEntity(system), None, 10.seconds))
+        () => new TestEntity(system), None, 10.seconds, "", ""))
       p2 ! TestEntity.Get
       val state3 = expectMsgType[TestEntity.State]
       state3.elements should ===(List("A", "B", "C"))
@@ -55,7 +55,7 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
 
     "be able to change behavior" in {
       val p = system.actorOf(PersistentEntityActor.props("test", Some("2"),
-        () => new TestEntity(system), None, 10.seconds))
+        () => new TestEntity(system), None, 10.seconds, "", ""))
       p ! TestEntity.Get
       val state = expectMsgType[TestEntity.State]
       state.mode should ===(TestEntity.Mode.Append)
@@ -73,7 +73,7 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
 
       // start another with same persistenceId should recover state
       val p2 = system.actorOf(PersistentEntityActor.props("test", Some("2"),
-        () => new TestEntity(system), None, 10.seconds))
+        () => new TestEntity(system), None, 10.seconds, "", ""))
       p2 ! TestEntity.Get
       val state3 = expectMsgType[TestEntity.State]
       state3.mode should ===(TestEntity.Mode.Prepend)
@@ -96,13 +96,13 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
     "notify when recovery is completed" in {
       val probe = TestProbe()
       val p = system.actorOf(PersistentEntityActor.props("test", Some("3"),
-        () => new TestEntity(system, Some(probe.ref)), None, 10.seconds))
+        () => new TestEntity(system, Some(probe.ref)), None, 10.seconds, "", ""))
       probe.expectMsgType[TestEntity.AfterRecovery]
     }
 
     "save snapshots" in {
       val p = system.actorOf(PersistentEntityActor.props("test", Some("4"),
-        () => new TestEntity(system), Some(3), 10.seconds))
+        () => new TestEntity(system), Some(3), 10.seconds, "", ""))
 
       val unhandledProbe = TestProbe()
       system.eventStream.subscribe(unhandledProbe.ref, classOf[UnhandledMessage])
@@ -121,7 +121,7 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
         awaitAssert {
           val probe2 = TestProbe()
           val p2 = system.actorOf(PersistentEntityActor.props("test", Some("4"),
-            () => new TestEntity(system, Some(probe2.ref)), Some(3), 10.seconds))
+            () => new TestEntity(system, Some(probe2.ref)), Some(3), 10.seconds, "", ""))
           val state2 = probe2.expectMsgType[TestEntity.AfterRecovery].state
           state2.elements should ===((1 to 10).toList.map(_.toString))
         }
@@ -130,7 +130,7 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
 
     "persist several events from one command" in {
       val p = system.actorOf(PersistentEntityActor.props("test", Some("5"),
-        () => new TestEntity(system), None, 10.seconds))
+        () => new TestEntity(system), None, 10.seconds, "", ""))
       p ! TestEntity.Add("a", 3)
       expectMsg(TestEntity.Appended("A"))
       p ! TestEntity.Get

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -56,7 +56,9 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
         Some("1"),
         () => new TestEntity(system),
         None,
-        10.seconds
+        10.seconds,
+        "",
+        ""
       )
     )
   }

--- a/testkit/javadsl/src/test/scala/com/lightbend/lagom/javadsl/testkit/PersistentEntityTestDriverCompatSpec.scala
+++ b/testkit/javadsl/src/test/scala/com/lightbend/lagom/javadsl/testkit/PersistentEntityTestDriverCompatSpec.scala
@@ -18,7 +18,7 @@ class PersistentEntityTestDriverCompatSpec extends CassandraPersistenceSpec {
     "produce same events and state" in {
       val probe1 = TestProbe()
       val p = system.actorOf(PersistentEntityActor.props("test", Optional.of("1"),
-        () => new TestEntity(system, probe1.ref), Optional.empty(), 10.seconds))
+        () => new TestEntity(system, probe1.ref), Optional.empty(), 10.seconds, "", ""))
       val probe2 = TestProbe()
       val driver = new PersistentEntityTestDriver(system, new TestEntity(system, probe2.ref), "1")
 

--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriverCompatSpec.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriverCompatSpec.scala
@@ -16,7 +16,7 @@ class PersistentEntityTestDriverCompatSpec extends CassandraPersistenceSpec(Test
     "produce same events and state" in {
       val probe1 = TestProbe()
       val p = system.actorOf(PersistentEntityActor.props("test", Some("1"),
-        () => new TestEntity(system, Some(probe1.ref)), None, 10.seconds))
+        () => new TestEntity(system, Some(probe1.ref)), None, 10.seconds, "", ""))
       val probe2 = TestProbe()
       val driver = new PersistentEntityTestDriver(system, new TestEntity(system, Some(probe2.ref)), "1")
 


### PR DESCRIPTION
** Soliciting feedback; not final. **

## Purpose

Enables the creation of additional named PersistentEntityRegistry and ReadSide instances, that are part of the same actor system, but may still use different plugins for journals, snapshot stores, and persistence queries.

This is necessary for multi-tenant applications where the tenant-specific data should be segregated into distinct databases.

## Limitations

This PR does not address the Akka limitation whereby persistence plugins must be configured ahead of time in the actor system Config, so it is limited to static multi-tenancy.

PersistentEntityRegistry and ReadSide instances must have distinct names, but this isn't currently checked. No additional tests have yet been added. No documentation changes have yet been made.