### PR TITLE
Introduces a JndiConfigurator that is run before SlickProvider creation

### DIFF
--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/JndiConfigurator.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/JndiConfigurator.scala
@@ -10,7 +10,6 @@ import play.api.db.DBApi
 
 import scala.util.Try
 
-
 private[lagom] object JndiConfigurator {
 
   def apply(dbApi: DBApi, config: Config): Unit = {

--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/JndiConfigurator.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/JndiConfigurator.scala
@@ -10,13 +10,10 @@ import play.api.db.DBApi
 
 import scala.util.Try
 
-private[lagom] trait JndiConfigurator
 
 private[lagom] object JndiConfigurator {
 
-  def apply(dbApi: DBApi, config: Config): JndiConfigurator = new JndiConfiguratorImpl(dbApi, config)
-
-  private final class JndiConfiguratorImpl(dbApi: DBApi, config: Config) extends JndiConfigurator {
+  def apply(dbApi: DBApi, config: Config): Unit = {
 
     val namingContext = new InitialContext()
 

--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/JndiConfigurator.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/JndiConfigurator.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.persistence.jdbc
+
+import javax.naming.InitialContext
+
+import com.typesafe.config.Config
+import play.api.db.DBApi
+
+import scala.util.Try
+
+private[lagom] trait JndiConfigurator
+
+private[lagom] object JndiConfigurator {
+
+  def apply(dbApi: DBApi, config: Config): JndiConfigurator = new JndiConfiguratorImpl(dbApi, config)
+
+  private final class JndiConfiguratorImpl(dbApi: DBApi, config: Config) extends JndiConfigurator {
+
+    val namingContext = new InitialContext()
+
+    dbApi.databases().foreach { playDb =>
+
+      val dbName = playDb.name
+
+      // each configured DB having an async-executor section
+      // is entitled to for Slick DB configured and bounded to a JNDI name
+      for {
+        dbConfig <- Try(config.getConfig(s"db.$dbName"))
+        asyncExecConfig <- Try(dbConfig.getConfig("async-executor"))
+      } yield {
+
+        // a DB config with an async-executor is expected to have an associated jndiDbName
+        // failing to do so will raise an exception
+        val jndiDbName = dbConfig.getString("jndiDbName")
+
+        val slickDb =
+          SlickDbProvider(
+            // the data source as configured by Play
+            playDb.dataSource,
+            asyncExecConfig
+          )
+
+        // we don't simply override a previously configure DB resource
+        // if name is already in use, bind() method throws NameAlreadyBoundException
+        namingContext.bind(jndiDbName, slickDb)
+      }
+    }
+  }
+
+}

--- a/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
+++ b/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
@@ -30,4 +30,5 @@ object SlickDbTestProvider {
 
     new InitialContext().rebind("DefaultDB", slickDb)
   }
+
 }

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/SlickProvider.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/SlickProvider.scala
@@ -3,17 +3,12 @@
  */
 package com.lightbend.lagom.internal.javadsl.persistence.jdbc
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
+import javax.inject.{ Inject, Singleton }
 
 import akka.actor.ActorSystem
 
-import javax.inject.{ Inject, Singleton }
-import play.api.db.DBApi
-import slick.ast._
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class SlickProvider @Inject() (
-  system: ActorSystem,
-  dbApi:  DBApi /* Ensures database is initialised before we start anything that needs it */ )(implicit ec: ExecutionContext)
-  extends com.lightbend.lagom.internal.persistence.jdbc.SlickProvider(system, dbApi)(ec)
+class SlickProvider @Inject() (system: ActorSystem)(implicit ec: ExecutionContext)
+  extends com.lightbend.lagom.internal.persistence.jdbc.SlickProvider(system)(ec)

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceModule.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceModule.scala
@@ -3,18 +3,36 @@
  */
 package com.lightbend.lagom.javadsl.persistence.jdbc
 
-import com.google.inject.{ AbstractModule, Key }
-import com.lightbend.lagom.internal.javadsl.persistence.jdbc.{ JavadslJdbcOffsetStore, JdbcPersistentEntityRegistry, JdbcReadSideImpl, JdbcSessionImpl }
-import com.lightbend.lagom.internal.persistence.jdbc.SlickOffsetStore
+import javax.inject.{ Inject, Singleton }
+
+import akka.actor.ActorSystem
+import com.google.inject.{ AbstractModule, Key, Provider }
+import com.lightbend.lagom.internal.javadsl.persistence.jdbc._
+import com.lightbend.lagom.internal.persistence.jdbc.{ JndiConfigurator, SlickOffsetStore }
 import com.lightbend.lagom.javadsl.persistence.PersistentEntityRegistry
 import com.lightbend.lagom.spi.persistence.OffsetStore
+import play.api.db.DBApi
+import scala.concurrent.ExecutionContext
 
 class JdbcPersistenceModule extends AbstractModule {
   override def configure(): Unit = {
+
+    bind(classOf[SlickProvider]).toProvider(classOf[GuiceSlickProvider])
     bind(classOf[JdbcReadSide]).to(classOf[JdbcReadSideImpl])
     bind(classOf[PersistentEntityRegistry]).to(classOf[JdbcPersistentEntityRegistry])
     bind(classOf[JdbcSession]).to(classOf[JdbcSessionImpl])
     bind(classOf[SlickOffsetStore]).to(classOf[JavadslJdbcOffsetStore])
     bind(classOf[OffsetStore]).to(Key.get(classOf[SlickOffsetStore]))
+  }
+}
+
+@Singleton
+class GuiceSlickProvider @Inject() (dbApi: DBApi, actorSystem: ActorSystem)(implicit ec: ExecutionContext)
+  extends Provider[SlickProvider] {
+
+  lazy val get = {
+    // Ensures JNDI bindings are made before we build the SlickProvider
+    JndiConfigurator(dbApi, actorSystem.settings.config)
+    new SlickProvider(actorSystem)
   }
 }

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -43,7 +43,7 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
       db
   }
 
-  protected lazy val slick = new SlickProvider(system, null)
+  protected lazy val slick = new SlickProvider(system)
   protected lazy val session: JdbcSession = new JdbcSessionImpl(slick)
   protected lazy val offsetStore = new JavadslJdbcOffsetStore(
     slick,

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -51,7 +51,7 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
   }
 
   import system.dispatcher
-  protected lazy val slick = new SlickProvider(system, null)
+  protected lazy val slick = new SlickProvider(system)
   protected lazy val session: JdbcSession = new JdbcSessionImpl(slick)
   protected lazy val jdbcReadSide: JdbcReadSide = new JdbcReadSideImpl(
     slick,

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
@@ -52,7 +52,7 @@ abstract class SlickPersistenceSpec private (_system: ActorSystem)(implicit ec: 
       _database = Some(db)
       db
   }
-  protected lazy val slick = new SlickProvider(system, null)
+  protected lazy val slick = new SlickProvider(system)
   protected lazy val slickReadSide: SlickReadSide = new SlickReadSideImpl(
     slick,
     new SlickOffsetStore(


### PR DESCRIPTION
This PR removes the need to inject a DbApi in SlickProvider. 

Fixes #1120
