### PR TITLE
minor documentation fix to align mvn and sbt instructions

### DIFF
--- a/docs/manual/common/guide/devmode/RunningServices.md
+++ b/docs/manual/common/guide/devmode/RunningServices.md
@@ -10,6 +10,11 @@ In Maven, you can execute the `run` task on a particular service by using the ma
 $ mvn -pl <your-project-name> lagom:run
 ```
 
-In sbt, you can specify the project to run on the sbt console by simply prefixing the service project's name, i.e., `<your-lagom-project-name>/run`.
+In sbt, you can specify the project to run on the sbt console by simply prefixing the service project's name, i.e.:
+
+```
+$ sbt
+> <your-project-name>/run
+```
 
 One thing you should remember is that `run` only starts the specific service, it doesn't start neither the Service Locator, nor the Cassandra server. Hence, prior to manually starting services, you may want to manually start both the [[Service Locator|ServiceLocator#Start-and-stop]], and the [[Cassandra server|CassandraServer#Start-and-stop]].


### PR DESCRIPTION
This is a minor documentation fix. 

While helping a user in Gitter I realised that the `sbt` instructions were not clear. At first, I even didn't see it was there. This PR add the instruction in a code block so, it becomes visually obvious.