### PR TITLE
Update ConductR guides

### DIFF
--- a/docs/manual/common/guide/production/code/conductr.sbt
+++ b/docs/manual/common/guide/production/code/conductr.sbt
@@ -1,3 +1,3 @@
 //#sbt-conductr
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.3.5")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.5.1")
 //#sbt-conductr

--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -179,3 +179,33 @@ Maven users will need to explicitly migrate to the new Akka HTTP backend. Lagom 
             <artifactId>play-akka-http-server_2.11</artifactId>
         </dependency>
 ```
+
+## ConductR
+
+ConductR users must update to `conductr-lib` 2.1.1 for full compatibility with Lagom 1.4.0.
+
+You can find more information in the [`conductr-lib` README file](https://github.com/typesafehub/conductr-lib/blob/master/README.md).
+
+### Updating ConductR with sbt
+
+Edit the `project/plugins.sbt` file to update `sbt-conductr` to version 2.5.1 or later:
+
+```scala
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.5.1")
+```
+
+This automatically includes the correct version of `conductr-lib`.
+
+### Updating ConductR with Maven
+
+Update each `pom.xml` that includes a dependency on `conductr-bundle-lib`:
+
+```xml
+<dependency>
+    <groupId>com.typesafe.conductr</groupId>
+    <artifactId>lagom14-java-conductr-bundle-lib_2.11</artifactId>
+    <version>2.1.1</version>
+</dependency>
+```
+
+Note that, in addition to updating the version, there is a new artifact ID for the Lagom 1.4 compatible module.

--- a/docs/manual/scala/releases/Migration14.md
+++ b/docs/manual/scala/releases/Migration14.md
@@ -175,3 +175,17 @@ The return types of the method below were changed, which could result in depreca
 * Typesafe config is now used instead of Play config in `AdditionalConfiguration.configuration`, see [881](https://github.com/lagom/lagom/pull/881)
 * The return types of `LagomServerBuilder.buildRouter`, `LagomServerBuilder.router`, and `LagomServer.router` were changed to be strongly typed from `Router` to `LagomServiceRouter` in [888](https://github.com/lagom/lagom/pull/888)
 * `PlayJsonSerializer` serialization of Non-`JsObject`s was fixed in [1071](https://github.com/lagom/lagom/pull/1071), changing the return type of `JsonMigration.transfrorm` from `JsObject` to `JsValue`
+
+## ConductR
+
+ConductR users must update to `conductr-lib` 2.1.1 for full compatibility with Lagom 1.4.0.
+
+You can find more information in the [`conductr-lib` README file](https://github.com/typesafehub/conductr-lib/blob/master/README.md).
+
+Edit the `project/plugins.sbt` file to update `sbt-conductr` to version 2.5.1 or later:
+
+```scala
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.5.1")
+```
+
+This automatically includes the correct version of `conductr-lib`.


### PR DESCRIPTION
## Fixes

Fixes #1138

## Purpose

- Update documentation for ConductR to the most recent, 1.4-compatible versions.
- Add a section to the migration guides about updating ConductR.