### PR TITLE
Set four-space indent for XML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,8 @@ trim_trailing_whitespace = true
 indent_style=space
 indent_size=2
 
+[*.xml]
+indent_size=4
 
 [*.java]
 indent_style=space


### PR DESCRIPTION
This is what most of the XML files in the repo currently use, but the `.editorconfig` configuration was using the default of two spaces.