### PR TITLE
Added support for JDBC testing in ServiceTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -572,7 +572,17 @@ lazy val `testkit-javadsl` = (project in file("testkit/javadsl"))
     Dependencies.`testkit-javadsl`,
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[IncompatibleTemplateDefProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest$Setup"),
-      ProblemFilters.exclude[MissingClassProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest$Setup$")
+      ProblemFilters.exclude[MissingClassProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest$Setup$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.copy$default$3"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.this"),
+      ProblemFilters.exclude[MissingTypesProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest$SetupImpl$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.apply"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withCluster"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withJdbc"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withCassandra"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.jdbc"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withJdbc")
     )
   )
   .dependsOn(
@@ -597,7 +607,17 @@ lazy val `testkit-scaladsl` = (project in file("testkit/scaladsl"))
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.TopicStub#SubscriberStub.this"),
 
       // See https://github.com/lagom/lagom/pull/1081 for justification for this breaking change
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.PersistentEntityTestDriver.runOne")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.PersistentEntityTestDriver.runOne"),
+
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withCluster"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withJdbc"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withCassandra"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.jdbc"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withJdbc"),
+      ProblemFilters.exclude[MissingTypesProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest$SetupImpl$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#SetupImpl.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#SetupImpl.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#SetupImpl.this")
     )
   )
   .dependsOn(
@@ -1058,7 +1078,7 @@ lazy val `build-tool-support` = (project in file("dev") / "build-tool-support")
 // while `build-tool-support` targets Maven and possibly other build
 // systems. We did something similar for routes compiler in Play:
 //
-// https://github.com/playframework/playframework/blob/2.6.7/framework/build.sbt#L27-L40 
+// https://github.com/playframework/playframework/blob/2.6.7/framework/build.sbt#L27-L40
 lazy val `sbt-build-tool-support` = (project in file("dev") / "build-tool-support")
   .settings(common: _*)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -564,26 +564,11 @@ lazy val `testkit-core` = (project in file("testkit/core"))
 
 lazy val `testkit-javadsl` = (project in file("testkit/javadsl"))
   .settings(runtimeLibCommon: _*)
-  .settings(mimaSettings(since10): _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(forkedTests: _*)
   .settings(
     name := "lagom-javadsl-testkit",
-    Dependencies.`testkit-javadsl`,
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleTemplateDefProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest$Setup"),
-      ProblemFilters.exclude[MissingClassProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest$Setup$"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.copy"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.copy$default$3"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.this"),
-      ProblemFilters.exclude[MissingTypesProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest$SetupImpl$"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#SetupImpl.apply"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withCluster"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withJdbc"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withCassandra"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.jdbc"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.javadsl.testkit.ServiceTest#Setup.withJdbc")
-    )
+    Dependencies.`testkit-javadsl`
   )
   .dependsOn(
     `testkit-core`,
@@ -597,28 +582,11 @@ lazy val `testkit-javadsl` = (project in file("testkit/javadsl"))
 
 lazy val `testkit-scaladsl` = (project in file("testkit/scaladsl"))
   .settings(runtimeLibCommon: _*)
-  .settings(mimaSettings(since13): _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(forkedTests: _*)
   .settings(
     name := "lagom-scaladsl-testkit",
-    Dependencies.`testkit-scaladsl`,
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.TopicStub#SubscriberStub.this"),
-
-      // See https://github.com/lagom/lagom/pull/1081 for justification for this breaking change
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.PersistentEntityTestDriver.runOne"),
-
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withCluster"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withJdbc"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withCassandra"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.jdbc"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#Setup.withJdbc"),
-      ProblemFilters.exclude[MissingTypesProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest$SetupImpl$"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#SetupImpl.apply"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#SetupImpl.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.testkit.ServiceTest#SetupImpl.this")
-    )
+    Dependencies.`testkit-scaladsl`
   )
   .dependsOn(
     `testkit-core`,

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceTest.java
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/__service1Name__-impl/src/test/java/__packageInPathFormat__/__service1Name__/impl/__service1ClassName__ServiceTest.java
@@ -14,7 +14,7 @@ public class ${service1ClassName}ServiceTest {
 
   @Test
   public void shouldStorePersonalizedGreeting() throws Exception {
-    withServer(defaultSetup().withCassandra(true), server -> {
+    withServer(defaultSetup().withCassandra(), server -> {
       ${service1ClassName}Service service = server.client(${service1ClassName}Service.class);
 
       String msg1 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);

--- a/dev/maven-plugin/src/maven-test/start-all-2.11/helloworld-impl/src/test/java/sample/helloworld/impl/HelloServiceTest.java
+++ b/dev/maven-plugin/src/maven-test/start-all-2.11/helloworld-impl/src/test/java/sample/helloworld/impl/HelloServiceTest.java
@@ -18,7 +18,7 @@ public class HelloServiceTest {
 
   @Test
   public void shouldStorePersonalizedGreeting() throws Exception {
-    withServer(defaultSetup().withCassandra(true), server -> {
+    withServer(defaultSetup().withCassandra(), server -> {
       HelloService service = server.client(HelloService.class);
 
       String msg1 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);

--- a/dev/maven-plugin/src/maven-test/start-all-2.12/helloworld-impl/src/test/java/sample/helloworld/impl/HelloServiceTest.java
+++ b/dev/maven-plugin/src/maven-test/start-all-2.12/helloworld-impl/src/test/java/sample/helloworld/impl/HelloServiceTest.java
@@ -18,7 +18,7 @@ public class HelloServiceTest {
 
   @Test
   public void shouldStorePersonalizedGreeting() throws Exception {
-    withServer(defaultSetup().withCassandra(true), server -> {
+    withServer(defaultSetup().withCassandra(), server -> {
       HelloService service = server.client(HelloService.class);
 
       String msg1 = service.hello("Alice").invoke().toCompletableFuture().get(5, SECONDS);

--- a/docs/manual/java/guide/services/Test.md
+++ b/docs/manual/java/guide/services/Test.md
@@ -50,17 +50,17 @@ Note how the dependency is overridden when constructing the test `Setup` object,
 
 The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and [[persistence|PersistentEntity]] features disabled. You may want to enable cluster in the `Setup`:
 
-@[enable-cluster](code/docs/services/test/EnablePersistence.java)
+@[enable-cluster](code/docs/services/test/EnablePersistenceCluster.java)
 
 If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when when enabling one or another, cluster will also be enabled automatically.
 
 To enable Cassandra Persistence:
 
-@[enable-cassandra](code/docs/services/test/EnablePersistence.java)
+@[enable-cassandra](code/docs/services/test/EnablePersistenceCassandra.java)
 
 To enable JDBC Persistence:
 
-@[enable-jdbc](code/docs/services/test/EnablePersistence.java)
+@[enable-jdbc](code/docs/services/test/EnablePersistenceJdbc.java)
 
 There's no way to explicitly enable or disable [[pubsub|PubSub]]. When cluster is enabled (either explicitly or transitively via enabling Cassandra or JDBC), pubsub will be available.
 

--- a/docs/manual/java/guide/services/Test.md
+++ b/docs/manual/java/guide/services/Test.md
@@ -50,13 +50,19 @@ Note how the dependency is overridden when constructing the test `Setup` object,
 
 The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and [[persistence|PersistentEntity]] features disabled. You may want to enable cluster in the `Setup`:
 
-@[setup2](code/docs/services/test/EnablePersistence.java)
+@[enable-cluster](code/docs/services/test/EnablePersistence.java)
 
-If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. Cassandra Persistence requires clustering, so when you enable Cassandra, cluster will also be enabled automatically. Enable Cassandra Persistence:
+If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when when enabling one or another, cluster will also be enabled automatically.
 
-@[setup1](code/docs/services/test/EnablePersistence.java)
+To enable Cassandra Persistence:
 
-There's no way to explicitly enable or disable [[pubsub|PubSub]]. When cluster is enabled (either explicitly or transitively via enabling Cassandra), pubsub will be available.
+@[enable-cassandra](code/docs/services/test/EnablePersistence.java)
+
+To enable JDBC Persistence:
+
+@[enable-jdbc](code/docs/services/test/EnablePersistence.java)
+
+There's no way to explicitly enable or disable [[pubsub|PubSub]]. When cluster is enabled (either explicitly or transitively via enabling Cassandra or JDBC), pubsub will be available.
 
 There are two different styles that can be used when writing the tests. It is most convenient to use `withServer` as illustrated in the above `HelloServiceTest`. It automatically starts and stops the server before and after the given lambda.
 

--- a/docs/manual/java/guide/services/code/docs/services/test/EnablePersistence.java
+++ b/docs/manual/java/guide/services/code/docs/services/test/EnablePersistence.java
@@ -5,13 +5,22 @@ import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
 import com.lightbend.lagom.javadsl.testkit.ServiceTest.Setup;
 
 @SuppressWarnings("unused")
-public class EnablePersistence {
+public class EnablePersistenceCassandra {
+    //#enable-cassandra
+    private final Setup setup = defaultSetup().withCassandra();
+    //#enable-cassandra
+}
 
-  //#setup1
-  private final Setup setup1 = defaultSetup().withCassandra(true);
-  //#setup1
+@SuppressWarnings("unused")
+public class EnablePersistenceJdbc {
+    //#enable-jdbc
+    private final Setup setup = defaultSetup().withJdbc();
+    //#enable-jdbc
+}
 
-  //#setup2
-  private final Setup setup2 = defaultSetup().withCluster(true);
-  //#setup2
+@SuppressWarnings("unused")
+public class EnablePersistenceCluster {
+    //#enable-cluster
+    private final Setup setup = defaultSetup().withCluster();
+    //#enable-cluster
 }

--- a/docs/manual/java/guide/services/code/docs/services/test/EnablePersistenceCassandra.java
+++ b/docs/manual/java/guide/services/code/docs/services/test/EnablePersistenceCassandra.java
@@ -10,17 +10,3 @@ public class EnablePersistenceCassandra {
     private final Setup setup = defaultSetup().withCassandra();
     //#enable-cassandra
 }
-
-@SuppressWarnings("unused")
-public class EnablePersistenceJdbc {
-    //#enable-jdbc
-    private final Setup setup = defaultSetup().withJdbc();
-    //#enable-jdbc
-}
-
-@SuppressWarnings("unused")
-public class EnablePersistenceCluster {
-    //#enable-cluster
-    private final Setup setup = defaultSetup().withCluster();
-    //#enable-cluster
-}

--- a/docs/manual/java/guide/services/code/docs/services/test/EnablePersistenceCluster.java
+++ b/docs/manual/java/guide/services/code/docs/services/test/EnablePersistenceCluster.java
@@ -1,0 +1,12 @@
+package docs.services.test;
+
+import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
+
+import com.lightbend.lagom.javadsl.testkit.ServiceTest.Setup;
+
+@SuppressWarnings("unused")
+public class EnablePersistenceCluster {
+    //#enable-cluster
+    private final Setup setup = defaultSetup().withCluster();
+    //#enable-cluster
+}

--- a/docs/manual/java/guide/services/code/docs/services/test/EnablePersistenceJdbc.java
+++ b/docs/manual/java/guide/services/code/docs/services/test/EnablePersistenceJdbc.java
@@ -1,0 +1,12 @@
+package docs.services.test;
+
+import static com.lightbend.lagom.javadsl.testkit.ServiceTest.defaultSetup;
+
+import com.lightbend.lagom.javadsl.testkit.ServiceTest.Setup;
+
+@SuppressWarnings("unused")
+public class EnablePersistenceJdbc {
+    //#enable-jdbc
+    private final Setup setup = defaultSetup().withJdbc();
+    //#enable-jdbc
+}

--- a/docs/manual/scala/guide/services/TestingServices.md
+++ b/docs/manual/scala/guide/services/TestingServices.md
@@ -58,11 +58,17 @@ The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and
 
 @[enable-cluster](code/TestingServices.scala)
 
-If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. Cassandra Persistence requires clustering, so when you enable Cassandra, cluster will also be enabled automatically. Enable Cassandra Persistence:
+If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when when enabling one or another, cluster will also be enabled automatically.
+
+To enable Cassandra Persistence:
 
 @[enable-cassandra](code/TestingServices.scala)
 
-There's no way to explicitly enable or disable [[pubsub|PubSub]]. When cluster is enabled (either explicitly or transitively via enabling Cassandra), pubsub will be available.
+To enable JDBC Persistence:
+
+@[enable-jdbc](code/TestingServices.scala)
+
+There's no way to explicitly enable or disable [[pubsub|PubSub]]. When cluster is enabled (either explicitly or transitively via enabling Cassandra or JDBC), pubsub will be available.
 
 ## How to test several services
 

--- a/docs/manual/scala/guide/services/code/TestingServices.scala
+++ b/docs/manual/scala/guide/services/code/TestingServices.scala
@@ -109,13 +109,33 @@ package enablecassandra {
 
     //#enable-cassandra
     lazy val server = ServiceTest.startServer(
-      ServiceTest.defaultSetup.withCassandra(true)
+      ServiceTest.defaultSetup.withCassandra()
     ) { ctx =>
       new HelloApplication(ctx) with LocalServiceLocator
     }
     //#enable-cassandra
   }
 }
+
+
+package enablejdbc {
+
+  import docs.scaladsl.services.lagomapplication.HelloApplication
+  import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
+  import com.lightbend.lagom.scaladsl.testkit.ServiceTest
+
+  class HelloServiceSpec {
+
+    //#enable-jdbc
+    lazy val server = ServiceTest.startServer(
+      ServiceTest.defaultSetup.withJdbc()
+    ) { ctx =>
+      new HelloApplication(ctx) with LocalServiceLocator
+    }
+    //#enable-jdbc
+  }
+}
+
 
 package enablecluster {
 
@@ -127,7 +147,7 @@ package enablecluster {
 
     //#enable-cluster
     lazy val server = ServiceTest.startServer(
-      ServiceTest.defaultSetup.withCluster(true)
+      ServiceTest.defaultSetup.withCluster()
     ) { ctx =>
       new HelloApplication(ctx) with LocalServiceLocator
     }

--- a/service/javadsl/integration-tests/src/test/java/com/lightbend/lagom/it/mocks/PersistenceServiceTest.java
+++ b/service/javadsl/integration-tests/src/test/java/com/lightbend/lagom/it/mocks/PersistenceServiceTest.java
@@ -15,19 +15,19 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class PersistenceServiceTest {
-  
+
   private static TestServer server;
   private static PersistenceService client;
-  
+
   @BeforeClass
   public static void setUp() {
     server = startServer(defaultSetup()
-                    .withCassandra(true)
+                    .withCassandra()
                     .configureBuilder(b -> b.bindings(new PersistenceServiceModule()))
     );
     client = server.client(PersistenceService.class);
   }
-  
+
   @AfterClass
   public static void tearDown() {
     if (server != null) {
@@ -36,17 +36,17 @@ public class PersistenceServiceTest {
       client = null;
     }
   }
-  
+
   @Test
   public void shouldProvidePersistenceComponentsForInjection() throws Exception {
     assertEquals("ok", client.checkInjected().invoke().toCompletableFuture().get(10, SECONDS));
   }
-  
+
   @Test
   public void shouldHaveAWorkingCassandraSession() throws Exception {
     assertEquals("ok", client.checkCassandraSession().invoke().toCompletableFuture().get(20, SECONDS));
   }
-  
-  
+
+
 
 }

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -84,6 +84,36 @@ object ServiceTest {
      */
     def withCassandra(enabled: Boolean): Setup
 
+    /**
+     * Enable Cassandra.
+     *
+     * If enabled, this will start an embedded Cassandra server before the tests start, and shut it down afterwards.
+     * It will also configure Lagom to use the embedded Cassandra server. Enabling Cassandra will also enable the
+     * cluster.
+     *
+     * @return A copy of this setup.
+     */
+    def withCassandra(): Setup = withCassandra(true)
+
+    /**
+     * Enable or disable JDBC.
+     *
+     * Enabling JDBC will also enable the cluster.
+     *
+     * @param enabled True if JDBC should be enabled, or false if disabled.
+     * @return A copy of this setup.
+     */
+    def withJdbc(enabled: Boolean): Setup
+
+    /**
+     * Enable JDBC.
+     *
+     * Enabling JDBC will also enable the cluster.
+     *
+     * @return A copy of this setup.
+     */
+    def withJdbc(): Setup = withJdbc(true)
+
     @deprecated(message = "Use configureBuilder instead", since = "1.2.0")
     def withConfigureBuilder(configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]) =
       this.configureBuilder(configureBuilder)
@@ -100,7 +130,7 @@ object ServiceTest {
     def configureBuilder(configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]): Setup
 
     /**
-     * Enable clustering.
+     * Enable or disable clustering.
      *
      * Disabling this will automatically disable any persistence plugins, since persistence requires clustering.
      *
@@ -110,9 +140,23 @@ object ServiceTest {
     def withCluster(enabled: Boolean): Setup
 
     /**
+     * Enable clustering.
+     *
+     * Disabling this will automatically disable any persistence plugins, since persistence requires clustering.
+     *
+     * @return A copy of this setup.
+     */
+    def withCluster(): Setup = withCluster(true)
+
+    /**
      * Whether Cassandra is enabled.
      */
     def cassandra: Boolean
+
+    /**
+     * Whether JDBC is enabled.
+     */
+    def jdbc: Boolean
 
     /**
      * Whether clustering is enabled.
@@ -126,11 +170,16 @@ object ServiceTest {
 
   }
 
-  private case class SetupImpl(cassandra: Boolean, cluster: Boolean,
-                               configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]) extends Setup {
+  private case class SetupImpl(
+    cassandra:        Boolean,
+    jdbc:             Boolean,
+    cluster:          Boolean,
+    configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]
+  ) extends Setup {
 
     def this() = this(
       cassandra = false,
+      jdbc = false,
       cluster = false,
       configureBuilder = new JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder] {
       override def apply(b: GuiceApplicationBuilder): GuiceApplicationBuilder = b
@@ -144,6 +193,13 @@ object ServiceTest {
         copy(cassandra = false)
       }
     }
+
+    override def withJdbc(enabled: Boolean): Setup =
+      if (enabled) {
+        copy(jdbc = true, cluster = true)
+      } else {
+        copy(jdbc = false)
+      }
 
     override def configureBuilder(configureBuilder: JFunction[GuiceApplicationBuilder, GuiceApplicationBuilder]): Setup = {
       copy(configureBuilder = configureBuilder)
@@ -245,7 +301,7 @@ object ServiceTest {
     val now = DateTimeFormatter.ofPattern("yyMMddHHmmssSSS").format(LocalDateTime.now())
     val testName = s"ServiceTest_$now"
 
-    val b1 = new GuiceApplicationBuilder()
+    val initialBuilder = new GuiceApplicationBuilder()
       .bindings(sBind[TestServiceLocatorPort].to(testServiceLocatorPort))
       .bindings(sBind[ServiceLocator].to(classOf[TestServiceLocator]))
       .bindings(sBind[TopicFactory].to(classOf[TestTopicFactory]))
@@ -253,33 +309,57 @@ object ServiceTest {
 
     val log = Logger(getClass)
 
-    val b3 =
+    val finalBuilder =
       if (setup.cassandra) {
+
         val cassandraPort = CassandraLauncher.randomPort
         val cassandraDirectory = Files.createTempDirectory(testName).toFile
         val t0 = System.nanoTime()
-        CassandraLauncher.start(cassandraDirectory, LagomTestConfigResource, clean = false, port = cassandraPort,
-          CassandraLauncher.classpathForResources(LagomTestConfigResource))
+
+        CassandraLauncher.start(
+          cassandraDirectory,
+          LagomTestConfigResource,
+          clean = false,
+          port = cassandraPort,
+          CassandraLauncher.classpathForResources(LagomTestConfigResource)
+        )
+
         log.debug(s"Cassandra started in ${TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0)} ms")
-        val b2 = b1.configure(CassandraTestConfig.persistenceConfig(testName, cassandraPort))
+
+        initialBuilder
+          .configure(CassandraTestConfig.persistenceConfig(testName, cassandraPort))
           .configure("lagom.cluster.join-self", "on")
-        disableModules(b2, KafkaClientModule, KafkaBrokerModule)
+          .disableModules(KafkaClientModule, KafkaBrokerModule)
+
+      } else if (setup.jdbc) {
+
+        initialBuilder
+          .configure(CassandraTestConfig.clusterConfig())
+          .configure("lagom.cluster.join-self", "on")
+          .disableModules(CassandraPersistenceModule, KafkaClientModule, KafkaBrokerModule)
+
       } else if (setup.cluster) {
-        val b2 = b1.configure(CassandraTestConfig.clusterConfig)
+
+        initialBuilder
+          .configure(CassandraTestConfig.clusterConfig())
           .configure("lagom.cluster.join-self", "on")
           .disable(classOf[PersistenceModule])
           .bindings(play.api.inject.bind[OffsetStore].to[InMemoryOffsetStore])
-        disableModules(b2, CassandraPersistenceModule, KafkaClientModule, KafkaBrokerModule)
+          .disableModules(CassandraPersistenceModule, KafkaClientModule, KafkaBrokerModule)
+
       } else {
-        val b2 = b1.configure("akka.actor.provider", "akka.actor.LocalActorRefProvider")
+
+        initialBuilder
+          .configure("akka.actor.provider", "akka.actor.LocalActorRefProvider")
           .disable(classOf[PersistenceModule], classOf[PubSubModule], classOf[JoinClusterModule])
           .bindings(play.api.inject.bind[OffsetStore].to[InMemoryOffsetStore])
-        disableModules(b2, CassandraPersistenceModule, JdbcPersistenceModule, KafkaClientModule, KafkaBrokerModule)
+          .disableModules(CassandraPersistenceModule, JdbcPersistenceModule, KafkaClientModule, KafkaBrokerModule)
       }
 
-    val application = setup.configureBuilder(b3).build()
+    val application = setup.configureBuilder(finalBuilder).build()
 
     Play.start(application.getWrappedApplication)
+
     val serverConfig = ServerConfig(port = Some(0), mode = Mode.Test)
     val srv = ServerProvider.defaultServerProvider.createServer(serverConfig, application.getWrappedApplication)
     val assignedPort = srv.httpPort.orElse(srv.httpsPort).get
@@ -293,19 +373,24 @@ object ServiceTest {
     new TestServer(assignedPort, application, srv)
   }
 
-  private def disableModules(builder: GuiceApplicationBuilder, classes: String*): GuiceApplicationBuilder = {
-    val loadedClasses = classes.flatMap { className =>
-      try {
-        Seq(getClass.getClassLoader.loadClass(className))
-      } catch {
-        case cfne: ClassNotFoundException =>
-          Seq.empty[Class[_]]
+  /**
+   * Enriches [[GuiceApplicationBuilder]] with a `disableModules` method.
+   */
+  private implicit class GuiceBuilderOps(val builder: GuiceApplicationBuilder) extends AnyVal {
+    def disableModules(classes: String*): GuiceApplicationBuilder = {
+      val loadedClasses = classes.flatMap { className =>
+        try {
+          Seq(getClass.getClassLoader.loadClass(className))
+        } catch {
+          case cfne: ClassNotFoundException =>
+            Seq.empty[Class[_]]
+        }
       }
-    }
-    if (loadedClasses.nonEmpty) {
-      builder.disable(loadedClasses: _*)
-    } else {
-      builder
+      if (loadedClasses.nonEmpty) {
+        builder.disable(loadedClasses: _*)
+      } else {
+        builder
+      }
     }
   }
 

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -365,7 +365,7 @@ object ServiceTest {
     val assignedPort = srv.httpPort.orElse(srv.httpsPort).get
     port.success(assignedPort)
 
-    if (setup.cassandra) {
+    if (setup.cassandra || setup.jdbc) {
       val system = application.injector().instanceOf(classOf[ActorSystem])
       CassandraTestConfig.awaitPersistenceInit(system)
     }

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
@@ -294,7 +294,7 @@ object ServiceTest {
       case other => ()
     }
 
-    if (setup.cassandra) {
+    if (setup.cassandra || setup.jdbc) {
       TestUtil.awaitPersistenceInit(lagomApplication.actorSystem)
     }
 


### PR DESCRIPTION
This PR adds the possibility to configure `ServiceTest` to be used for JDBC test. 

Fixes: #304

