### PR TITLE
Fix Kafka server dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -943,6 +943,7 @@ lazy val `kafka-broker-javadsl` = (project in file("service/javadsl/kafka/server
   .settings(runtimeLibCommon: _*)
   .settings(mimaSettings(since12): _*)
   .settings(forkedTests: _*)
+  .settings(excludeLog4jFromKafkaServer: _*)
   .settings(
     name := "lagom-javadsl-kafka-broker",
     Dependencies.`kafka-broker-javadsl`,
@@ -962,6 +963,7 @@ lazy val `kafka-broker-scaladsl` = (project in file("service/scaladsl/kafka/serv
   .settings(runtimeLibCommon: _*)
   .settings(mimaSettings(since13): _*)
   .settings(forkedTests: _*)
+  .settings(excludeLog4jFromKafkaServer: _*)
   .settings(
     name := "lagom-scaladsl-kafka-broker",
     Dependencies.`kafka-broker-scaladsl`,
@@ -1352,6 +1354,14 @@ lazy val `kafka-server` = (project in file("dev") / "kafka-server")
     name := "lagom-kafka-server",
     Dependencies.`kafka-server`
   )
+
+// kafka-server has a transitive dependency on slf4j-log4j12.
+// This is required for running Kafka in development mode, where it runs in its own process and uses log4j 1.2.
+// When running broker tests, Kafka is started in process, and its logs need to be routed to logback, which requires
+// excluding slf4j-log4j12.
+def excludeLog4jFromKafkaServer: Seq[Setting[_]] = Seq(
+  libraryDependencies += (projectID in (`kafka-server`, Test)).value exclude("org.slf4j", "slf4j-log4j12")
+)
 
 // Provides macros for testing macros. Is not published.
 lazy val `macro-testkit` = (project in file("macro-testkit"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,6 @@ object Dependencies {
   // Specific libraries that get reused
   private val scalaTest: ModuleID = "org.scalatest" %% "scalatest" % ScalaTestVersion excludeAll (excludeSlf4j: _*)
   private val guava = "com.google.guava" % "guava" % GuavaVersion
-  private val log4J = "log4j" % "log4j" % Log4jVersion
   private val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % ScalaJava8CompatVersion
   private val scalaXml = "org.scala-lang.modules" %% "scala-xml" % ScalaXmlVersion
   private val javassist = "org.javassist" % "javassist" % "3.21.0-GA"
@@ -235,7 +234,7 @@ object Dependencies {
       "scala-library", "scala-reflect"
 
     ) ++ libraryFamily("org.slf4j", Slf4jVersion)(
-      "jcl-over-slf4j", "jul-to-slf4j", "log4j-over-slf4j", "slf4j-api", "slf4j-nop"
+      "jcl-over-slf4j", "jul-to-slf4j", "log4j-over-slf4j", "slf4j-api", "slf4j-nop", "slf4j-log4j12"
     )
   }
 
@@ -271,7 +270,7 @@ object Dependencies {
     "com.101tec" % "zkclient" % "0.10",
     "com.yammer.metrics" % "metrics-core" % "2.2.0",
     "jline" % "jline" % "0.9.94",
-    "log4j" % "log4j" % "1.2.16",
+    "log4j" % "log4j" % "1.2.17",
     "net.sf.jopt-simple" % "jopt-simple" % "5.0.3",
     "org.apache.commons" % "commons-math" % "2.2",
     "org.apache.curator" % "curator-client" % "2.10.0",
@@ -689,17 +688,8 @@ object Dependencies {
     akkaPersistenceCassandra
   )
 
-  val `kafka-server` = libraryDependencies ++=
-    // log4j version prior to 1.2.17 required javax.jms, and that artifact could not properly resolved when using maven
-    // without adding a resolver. The problem doesn't appear with sbt because the log4j version brought by both zookeeper
-    // and curator dependencies are evicted to version 1.2.17. Unfortunately, because of how maven resolution works, we
-    // have to explicitly add the desired log4j version we want to use here.
-    // By the way, log4j 1.2.17 and later resolve the javax.jms dependency issue by using geronimo-jms. See
-    // http://stackoverflow.com/questions/4908651/the-following-artifacts-could-not-be-resolved-javax-jmsjmsjar1-1
-    // for more context.
-    log4jModules ++
-    Seq(
-    "org.apache.kafka" %% "kafka" % KafkaVersion exclude("org.slf4j", "slf4j-log4j12"),
+  val `kafka-server` = libraryDependencies ++= Seq(
+    "org.apache.kafka" %% "kafka" % KafkaVersion,
     // Note that curator 3.x is only compatible with zookeeper 3.5.x. Kafka currently uses zookeeper 3.4, hence we have
     // to use curator 2.x, which is compatible with zookeeper 3.4 (see the notice in
     // http://curator.apache.org/index.html - make sure to scroll to the bottom)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -270,7 +270,7 @@ object Dependencies {
     "com.101tec" % "zkclient" % "0.10",
     "com.yammer.metrics" % "metrics-core" % "2.2.0",
     "jline" % "jline" % "0.9.94",
-    "log4j" % "log4j" % "1.2.17",
+    "log4j" % "log4j" % "1.2.16",
     "net.sf.jopt-simple" % "jopt-simple" % "5.0.3",
     "org.apache.commons" % "commons-math" % "2.2",
     "org.apache.curator" % "curator-client" % "2.10.0",


### PR DESCRIPTION
We were overriding these incorrectly, with an unintended effect of adding a log4j2 dependency that is not needed and not used.

Fixes #1162.