### PR TITLE
Some migration guide fixes

### DIFF
--- a/docs/manual/java/guide/build/LagomBuild.md
+++ b/docs/manual/java/guide/build/LagomBuild.md
@@ -31,10 +31,10 @@ We recommend the usage of maven properties to define the Lagom Version and Scala
 
 ```xml
 <properties>
-    <scala.binary.version>2.12</scala.binary.version>      
-    <lagom.version>1.4.0-RC1</lagom.version>
+    <scala.binary.version>2.12</scala.binary.version>
+    <lagom.version>1.4.0</lagom.version>
 </properties>
-``` 
+```
 
 In Lagom, it is typical to use a multi module build. The Lagom maven plugin will generally be configured in the root project, which can be done by adding it to the `<plugins>` section of your `pom.xml`:
 

--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -16,8 +16,15 @@ If you're using a `lagom.version` property in the `properties` section of your r
 The version of Lagom can be updated by editing the `project/plugins.sbt` file, and updating the version of the Lagom sbt plugin. For example:
 
 ```scala
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0-RC1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 ```
+
+Lagom 1.4.0 also requires Sbt 0.13.16 or later. If your existing project is using a previous version of Sbt, you will need to upgrade it by editing the `project/build.properties` file. For example:
+
+```
+sbt.version=0.13.16
+```
+
 
 
 ## Scala 2.12 support

--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -9,7 +9,7 @@ Lagom 1.4 also updates to the latest major versions of Play (2.6) and Akka (2.5)
 
 ### Maven
 
-If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.4.0-RC1`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
+If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.4.0`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
 
 ### sbt
 
@@ -40,7 +40,7 @@ Alternatively, you can consider adding a maven property to your parent pom file.
 ```xml
   <properties>
       <scala.binary.version>2.12</scala.binary.version>
-      <lagom.version>1.4.0-RC1</lagom.version>
+      <lagom.version>1.4.0</lagom.version>
   </properties>
 ```
 

--- a/docs/manual/scala/releases/Migration14.md
+++ b/docs/manual/scala/releases/Migration14.md
@@ -10,8 +10,15 @@ Lagom 1.4 also updates to the latest major versions of Play (2.6) and Akka (2.5)
 The version of Lagom can be updated by editing the `project/plugins.sbt` file, and updating the version of the Lagom sbt plugin, for example:
 
 ```scala
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0-RC1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 ```
+
+Lagom 1.4.0 also requires Sbt 0.13.16 or later. If your existing project is using a previous version of Sbt, you will need to upgrade it by editing the `project/build.properties` file. For example:
+
+```
+sbt.version=0.13.16
+```
+
 
 ## Scala 2.12 support
 


### PR DESCRIPTION
- plugin version was still pointing to 1.4.0-R1
- Lagom 1.4.0 seems not to work with Sbt 0.13.15 (or prior). Users must update to 0.13.16