### PR TITLE
Upgrades to scala 2.11.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,17 +94,29 @@ def releaseSettings: Seq[Setting[_]] = Seq(
   }
 )
 
-def runtimeLibCommon: Seq[Setting[_]] = common ++ Seq(
+def runtimeScalaSettings: Seq[Setting[_]] = Seq(
   crossScalaVersions := Seq(Dependencies.ScalaVersion),
   scalaVersion := crossScalaVersions.value.head,
   crossVersion := CrossVersion.binary,
   crossPaths := false,
 
+  // compile options
+  scalacOptions in Compile ++= Seq(
+    "-encoding",
+    "UTF-8",
+    "-target:jvm-1.8",
+    "-feature",
+    "-unchecked",
+    "-Xlog-reflective-calls",
+    "-Xlint",
+    "-deprecation"
+  )
+)
+
+
+def runtimeLibCommon: Seq[Setting[_]] = common ++ runtimeScalaSettings ++ Seq(
   Dependencies.validateDependenciesSetting,
   Dependencies.dependencyWhitelistSetting,
-
-  // compile options
-  scalacOptions in Compile ++= Seq("-encoding", "UTF-8", "-target:jvm-1.8", "-feature", "-unchecked", "-Xlog-reflective-calls", "-Xlint", "-deprecation"),
 
   incOptions := incOptions.value.withNameHashing(true),
 
@@ -1048,6 +1060,7 @@ lazy val `play-integration-javadsl` = (project in file("dev") / "service-registr
 
 lazy val `cassandra-server` = (project in file("dev") / "cassandra-server")
   .settings(common: _*)
+  .settings(runtimeScalaSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-cassandra-server",
@@ -1057,6 +1070,7 @@ lazy val `cassandra-server` = (project in file("dev") / "cassandra-server")
 
 lazy val `kafka-server` = (project in file("dev") / "kafka-server")
   .settings(common: _*)
+  .settings(runtimeScalaSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-kafka-server",

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -341,7 +341,7 @@ object LagomPlugin extends AutoPlugin {
   private val serviceLocatorProject = Project("lagom-internal-meta-project-service-locator", file("."),
     configurations = Configurations.default,
     settings = CorePlugin.projectSettings ++ IvyPlugin.projectSettings ++ JvmPlugin.projectSettings ++ Seq(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.12",
     libraryDependencies += LagomImport.component("lagom-service-locator"),
     lagomServiceLocatorStart in ThisBuild := startServiceLocatorTask.value,
     lagomServiceLocatorStop in ThisBuild := Servers.ServiceLocator.tryStop(new SbtLoggerProxy(state.value.log))
@@ -350,7 +350,7 @@ object LagomPlugin extends AutoPlugin {
   private val cassandraProject = Project("lagom-internal-meta-project-cassandra", file("."),
     configurations = Configurations.default,
     settings = CorePlugin.projectSettings ++ IvyPlugin.projectSettings ++ JvmPlugin.projectSettings ++ Seq(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.12",
     libraryDependencies += LagomImport.component("lagom-cassandra-server"),
     lagomCassandraStart in ThisBuild := startCassandraServerTask.value,
     lagomCassandraStop in ThisBuild := Servers.CassandraServer.tryStop(new SbtLoggerProxy(state.value.log))
@@ -359,7 +359,7 @@ object LagomPlugin extends AutoPlugin {
   private val kafkaServerProject = Project("lagom-internal-meta-project-kafka", file("."),
     configurations = Configurations.default,
     settings = CorePlugin.projectSettings ++ IvyPlugin.projectSettings ++ JvmPlugin.projectSettings ++ Seq(
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.12",
     libraryDependencies += LagomImport.component("lagom-kafka-server"),
     lagomKafkaStart in ThisBuild := startKafkaServerTask.value,
     lagomKafkaStop in ThisBuild := Servers.KafkaServer.tryStop(new SbtLoggerProxy(state.value.log))

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/build.sbt
@@ -5,7 +5,7 @@ lazy val `my-project` = (project in file(".")).enablePlugins(LagomJava)
     libraryDependencies ++= Seq(lagomJavadslPersistenceCassandra, lagomSbtScriptedLibrary)
   )
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 interactionMode := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-server-disabled-but-defaults-config-still-injected/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-server-disabled-but-defaults-config-still-injected/build.sbt
@@ -7,7 +7,7 @@ lazy val `my-project` = (project in file(".")).enablePlugins(LagomJava)
   )
   .settings(libraryDependencies ++= Seq(lagomJavadslPersistenceCassandra, lagomSbtScriptedLibrary))
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 interactionMode := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/build.sbt
@@ -7,13 +7,13 @@ lagomServicesPortRange in ThisBuild := PortRange(10000, 10001)
 lazy val a = (project in file("a")).enablePlugins(LagomJava)
   .settings(Seq(
     sourceDirectory := baseDirectory.value / "src-a",
-    scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+    scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
   ))
 
 lazy val b = (project in file("b")).enablePlugins(LagomJava)
   .settings(Seq(
     sourceDirectory := baseDirectory.value / "src-b",
-    scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+    scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
   ))
 
 InputKey[Unit]("verifyPortProjA") := {

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
@@ -1,7 +1,7 @@
 import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 import com.lightbend.lagom.sbt.Internal
 
-scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
@@ -1,6 +1,6 @@
 import play.sbt.PlayImport
 
-scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
@@ -1,6 +1,6 @@
 import play.sbt.PlayImport
 
-scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/build.sbt
@@ -3,7 +3,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 lazy val `my-project` = (project in file(".")).enablePlugins(LagomJava)
   .settings(libraryDependencies ++= Seq(lagomJavadslPersistenceCassandra, lagomSbtScriptedLibrary))
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 interactionMode := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
-scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 lazy val `a-api` = (project in file("a") / "api")
   .settings(

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
-scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
-scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion in ThisBuild := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 lazy val p = (project in file("p")).enablePlugins(PlayJava && LagomPlay)
   .settings(

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 lazy val root = (project in file(".")).enablePlugins(LagomJava)
 
-scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/build.sbt
@@ -3,7 +3,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
 lazy val commonSettings = Seq(
-  scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+  scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
 )
 
 lazy val fooApi = (project in file("foo/api"))

--- a/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
+++ b/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
@@ -93,7 +93,7 @@ object ScriptedTools extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.7")
+    scalaVersion := Option(System.getProperty("scala.version")).getOrElse("2.11.12")
   )
 
   private def repeatUntilSuccessful[T](log: Logger, operation: => T, times: Int = 10): T = {

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -17,7 +17,7 @@ lazy val docs = project
   .settings(forkedTests: _*)
   .settings(
     resolvers += Resolver.typesafeIvyRepo("releases"),
-    scalaVersion := "2.11.11",
+    scalaVersion := "2.11.12",
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % "test",
       "org.apache.cassandra" % "cassandra-all" % "3.0.9" % "test",
@@ -126,7 +126,7 @@ lazy val theme = project
   .enablePlugins(SbtWeb, SbtTwirl)
   .settings(
     name := "lagom-docs-theme",
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.12",
     resolvers += Resolver.typesafeIvyRepo("releases"),
     libraryDependencies ++= Seq(
       "com.lightbend.markdown" %% "lightbend-markdown-server" % LightbendMarkdownVersion

--- a/docs/manual/java/guide/build/code/lagom-build.sbt
+++ b/docs/manual/java/guide/build/code/lagom-build.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "X.Y.Z") // replace 'X
 //#add-sbt-plugin
 
 //#scala-version
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.12"
 //#scala-version
 
 //#hello-api

--- a/docs/manual/java/guide/build/code/multiple-builds.sbt
+++ b/docs/manual/java/guide/build/code/multiple-builds.sbt
@@ -12,7 +12,7 @@ bintrayOmitLicense in ThisBuild := false
 //#hello-build
 organization in ThisBuild := "com.example"
 
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.12"
 
 lazy val `hello-api` = (project in file("hello-api"))
   .settings(version := "1.0")

--- a/docs/manual/scala/guide/build/code/lagom-build.sbt
+++ b/docs/manual/scala/guide/build/code/lagom-build.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "X.Y.Z")
 //#add-sbt-plugin
 
 //#scala-version
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.12"
 //#scala-version
 
 //#hello-api

--- a/docs/manual/scala/guide/build/code/multiple-builds.sbt
+++ b/docs/manual/scala/guide/build/code/multiple-builds.sbt
@@ -12,7 +12,7 @@ bintrayOmitLicense in ThisBuild := false
 //#hello-build
 organization in ThisBuild := "com.example"
 
-scalaVersion in ThisBuild := "2.11.7"
+scalaVersion in ThisBuild := "2.11.12"
 
 lazy val `hello-api` = (project in file("hello-api"))
   .settings(version := "1.0")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val PlayVersion = "2.5.18"
   val AkkaVersion = "2.4.20"
   val AkkaHttpVersion = "10.0.9"
-  val ScalaVersion = "2.11.11"
+  val ScalaVersion = "2.11.12"
   val AkkaPersistenceCassandraVersion = "0.30"
   val ScalaTestVersion = "3.0.1"
   val JacksonVersion = "2.7.8"


### PR DESCRIPTION
This is minor Scala version upgrade. `master` and `1.4.x` are using 2.11.12 already, but `1.3.x` was lagging behind.

Fixes #1149 