### PR TITLE
Remove netty-transport-native-epoll dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -410,10 +410,7 @@ object Dependencies {
     "junit" % "junit" % JUnitVersion,
 
     // Without an binding, slf4j will print warnings when running tests
-    "org.slf4j" % "slf4j-nop" % Slf4jVersion % Test,
-
-    // Upgrades needed to match whitelist
-    "io.netty" % "netty-transport-native-epoll" % NettyVersion
+    "org.slf4j" % "slf4j-nop" % Slf4jVersion % Test
   )
 
   val `testkit-scaladsl` = libraryDependencies ++= Seq(
@@ -424,29 +421,20 @@ object Dependencies {
     "junit" % "junit" % JUnitVersion,
 
     // Without an binding, slf4j will print warnings when running tests
-    "org.slf4j" % "slf4j-nop" % Slf4jVersion % Test,
-
-    // Upgrades needed to match whitelist
-    "io.netty" % "netty-transport-native-epoll" % NettyVersion
+    "org.slf4j" % "slf4j-nop" % Slf4jVersion % Test
   )
 
   val `integration-tests-javadsl` = libraryDependencies ++= Seq(
     playNettyServer,
     playAkkaHttpServer,
     "com.novocode" % "junit-interface" % "0.11" % Test,
-    scalaTest,
-
-    // Upgrades needed to match whitelist
-    "io.netty" % "netty-transport-native-epoll" % NettyVersion
+    scalaTest
   )
 
   val `integration-tests-scaladsl` = libraryDependencies ++= Seq(
     playAkkaHttpServer,
     "com.novocode" % "junit-interface" % "0.11" % Test,
-    scalaTest,
-
-    // Upgrades needed to match whitelist
-    "io.netty" % "netty-transport-native-epoll" % NettyVersion
+    scalaTest
   )
 
   val `cluster-core` = libraryDependencies ++= Seq(
@@ -669,10 +657,7 @@ object Dependencies {
   val `service-locator` = libraryDependencies ++= Seq(
     playAkkaHttpServer,
     akkaHttpCore,
-    scalaTest % Test,
-
-    // Upgrades needed to match whitelist
-    "io.netty" % "netty-transport-native-epoll" % NettyVersion
+    scalaTest % Test
   )
 
   val `service-registry-client-javadsl` = libraryDependencies ++= Nil


### PR DESCRIPTION
These were only used to match the whitelist, but these modules no longer have transitive dependencies on netty-transport-native-epoll. As a result, this had the undesired effect of adding a dependency on netty-transport-native-epoll where it otherwise wouldn't have one.

Please backport to 1.4.x after merging.