### PR TITLE
Update ConductR lib/sbt versions

### DIFF
--- a/docs/manual/common/guide/production/code/conductr.sbt
+++ b/docs/manual/common/guide/production/code/conductr.sbt
@@ -1,3 +1,3 @@
 //#sbt-conductr
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.5.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.6.0")
 //#sbt-conductr

--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -250,16 +250,16 @@ akka.actor.serialization-bindings {
 
 ## ConductR
 
-ConductR users must update to `conductr-lib` 2.1.1 for full compatibility with Lagom 1.4.0.
+ConductR users must update to `conductr-lib` 2.1.1 or later (2.2.0 recommended) for full compatibility with Lagom 1.4.0.
 
 You can find more information in the [`conductr-lib` README file](https://github.com/typesafehub/conductr-lib/blob/master/README.md).
 
 ### Updating ConductR with sbt
 
-Edit the `project/plugins.sbt` file to update `sbt-conductr` to version 2.5.1 or later:
+Edit the `project/plugins.sbt` file to update `sbt-conductr` to version 2.5.1 or later (2.6.0 recommended):
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.5.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.6.0")
 ```
 
 This automatically includes the correct version of `conductr-lib`.
@@ -272,7 +272,7 @@ Update each `pom.xml` that includes a dependency on `conductr-bundle-lib`:
 <dependency>
     <groupId>com.typesafe.conductr</groupId>
     <artifactId>lagom14-java-conductr-bundle-lib_2.12</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
 </dependency>
 ```
 

--- a/docs/manual/scala/releases/Migration14.md
+++ b/docs/manual/scala/releases/Migration14.md
@@ -227,14 +227,14 @@ akka.actor.serialization-bindings {
 
 ## ConductR
 
-ConductR users must update to `conductr-lib` 2.1.1 for full compatibility with Lagom 1.4.0.
+ConductR users must update to `conductr-lib` 2.1.1 or later (2.2.0 recommended) for full compatibility with Lagom 1.4.0.
 
 You can find more information in the [`conductr-lib` README file](https://github.com/typesafehub/conductr-lib/blob/master/README.md).
 
-Edit the `project/plugins.sbt` file to update `sbt-conductr` to version 2.5.1 or later:
+Edit the `project/plugins.sbt` file to update `sbt-conductr` to version 2.5.1 or later (2.6.0 recommended):
 
 ```scala
-addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.5.1")
+addSbtPlugin("com.lightbend.conductr" % "sbt-conductr" % "2.6.0")
 ```
 
 This automatically includes the correct version of `conductr-lib`.


### PR DESCRIPTION
These are the latest versions depending on the final release of Lagom 1.4.0.

The previous versions are believed to work with 1.4.0 final, but this brings the dependencies in line.