### PR TITLE
Prevent SaveSnapshotSuccess from showing up in unhandled messages (#1…

### DIFF
--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistentEntityActor.scala
@@ -9,9 +9,7 @@ import java.util.Optional
 import scala.util.control.NonFatal
 import akka.actor.ActorRef
 import akka.actor.Props
-import akka.persistence.PersistentActor
-import akka.persistence.RecoveryCompleted
-import akka.persistence.SnapshotOffer
+import akka.persistence.{ PersistentActor, RecoveryCompleted, SaveSnapshotSuccess, SnapshotOffer }
 import akka.util.ByteString
 
 import scala.concurrent.duration.Duration
@@ -194,6 +192,13 @@ private[lagom] class PersistentEntityActor[C, E, S](
 
     case PersistentEntityActor.Stop =>
       context.stop(self)
+
+    // The actor will receive a SaveSnapshotSuccess message when a snapshot
+    // was successfully saved. There's no need to do anything, but if we don't
+    // handle it, it will pollute the event stream with UnhandledMessage
+    // notifications
+    case SaveSnapshotSuccess(_) => () // nothing to do
+
   }
 
   private def tag(event: Any): Any = {

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
@@ -8,9 +8,8 @@ import scala.concurrent.duration._
 import java.util.Optional
 
 import akka.testkit.{ ImplicitSender, TestProbe }
-import akka.actor.Actor
+import akka.actor.{ Actor, Props, UnhandledMessage }
 import akka.cluster.sharding.ShardRegion
-import akka.actor.Props
 import com.lightbend.lagom.internal.javadsl.persistence.PersistentEntityActor
 import org.scalatest.WordSpecLike
 import com.lightbend.lagom.persistence.ActorSystemSpec
@@ -107,10 +106,17 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
     "save snapshots" in {
       val p = system.actorOf(PersistentEntityActor.props("test", Optional.of("4"),
         () => new TestEntity(system), Optional.of(3), 10.seconds))
+
+      val unhandledProbe = TestProbe()
+      system.eventStream.subscribe(unhandledProbe.ref, classOf[UnhandledMessage])
+
       for (n <- 1 to 10) {
         p ! TestEntity.Add.of(n.toString)
         expectMsg(new TestEntity.Appended("4", n.toString))
       }
+
+      unhandledProbe.expectNoMessage(300.milliseconds)
+      system.eventStream.unsubscribe(unhandledProbe.ref)
 
       // start another with same persistenceId should recover state
       // awaitAssert because it is not guaranteed that we will see the snapshot immediately

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
@@ -7,7 +7,7 @@ import java.net.URLDecoder
 
 import akka.actor.{ Props, ReceiveTimeout }
 import akka.cluster.sharding.ShardRegion
-import akka.persistence.{ PersistentActor, RecoveryCompleted, SnapshotOffer }
+import akka.persistence.{ PersistentActor, RecoveryCompleted, SaveSnapshotSuccess, SnapshotOffer }
 import akka.persistence.journal.Tagged
 import akka.util.ByteString
 import com.lightbend.lagom.scaladsl.persistence.{ AggregateEvent, AggregateEventShards, AggregateEventTag, PersistentEntity }
@@ -201,6 +201,12 @@ private[lagom] class PersistentEntityActor(
 
     case PersistentEntityActor.Stop =>
       context.stop(self)
+
+    // The actor will receive a SaveSnapshotSuccess message when a snapshot
+    // was successfully saved. There's no need to do anything, but if we don't
+    // handle it, it will pollute the event stream with UnhandledMessage
+    // notifications
+    case SaveSnapshotSuccess(_) => () // nothing to do
   }
 
   private def tag(event: Any): Any = {


### PR DESCRIPTION

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes
Fixes #1209 

## Purpose

PersistentEntityActor now handles SaveSnapshotSuccess messages (by ignoring them).
 
## Background Context

SaveSnapshotSuccess messages are currently showing up in the event stream as unhandled messages, as PersistentEntityActor doesn't handle them. This isn't a big problem, but it pollutes the stream - when monitoring unhandled messages to detect actual problems, these will greatly distort the output. 

## References

Are there any relevant issues / PRs / mailing lists discussions?

https://gitter.im/lagom/lagom?at=5a71d0e298927d57455d62c1

