### PR TITLE
Improve Whitesource automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ jdk:
   - oraclejdk8
 env:
   global:
-  - WHITESOURCE_PROJECT_NAME: lagom-master
-  - WHITESOURCE_PROJECT_TOKEN: b47efd29-4a67-4ece-94d5-a7f38c362d8a
-  - secure: "qr/+kdqj2bdXRlsDR+akjsKTq8WJe0bBX+TKWaYCGcaGrqarOdCZcLteRxrE/uXmYD3rWJKhXkasUmUwEF45nTNX7X780nllFVA/AKUk3REDkLCpDkiwryMwdu/owx1xlK8dGyzPwrQhVulYotaK2tzv5r1bttemqBWcBOAgY7+HrnVhFNwS9tSrWp9CuDZotGANGd9JZBX+nITY2Ud59DcK5UFhfB4FJlqnIeCe201hD3Z9e6yWevPmu1vvV5qGlJ7h46jQvpXdvcNIlDDZ8e0oFqULjaUx6CPGUX5h9dQ9ZHvQgJJb2ALpTfR/Dxv/iM2dx3imGdjzklvJ8jcHX44jOQNucEwOxQk7dCGs+ie0L4KXrBqRxu0OwSC9U87CtliaC25Y35isfvOfNRgzL8mvzzZ+jSTy5s9wqBQZa9C04WIml4Azq8vL5ur26F1nxyZgHJBdQFJIBtR5m4av3oQLFEjCWwsVwYLR3JOP3wzrliT4BzNpeqppXzEJR2jt7MNgNmHH4am6suB8VS+7oxkn0R3GyRqMVEwqivj3ciisYBZZYGVn/SxmdSS3IhVgUivcLaCOA3gUh6Ww7bdTik7zB2AfCFYK5Lis0+STGXt9xaCf7Tp2+RxAGVFBP5K4QeFzzREG0aIlEgF5v2pn7wewve/p59NucPdxQE4c7x0="
+    # the following `secure` is WHITESOURCE_PASSWORD which is the same for all branches.
+    - secure: "A4xDS51pB8ERJPR/a5Lui//E//1L9pJ9Eg1kcRm/OR2izg7rx7p8Wemfp9gRhz8trn1mIrXDSMSK9iwENsfIP1bc/6AgtTWKBPm9DKjG0HW3swFFMBzzd6gxmOi4JD8rOtVc62Cf4qnURz+hsPRcI5C8aAW1fNi/5x1Q3HcAMtxE8EdPR7tU6Ve8utieOFPpqNQMktcL1aFusu+QddO14ZpQ944uAg0YdRRYFMG9SCbTkNDLt66AHTF4rKyZfkbM1tadqvvDez7Uo2eGK+KoQxTyrjct8W4Gqh+obOTyj1ngaPZEKvgbIJowFCrBzY5W+oNl6S+qa6PyAwq1MWKFqyUZt4P9fk3N9MDOYvuaS+YJCQd3VS4qCL9MEWahXNc3ZT+m8u5HT5axuPy+2qiKL/wrGzAXd74K9gNKuZJD7s+79Pwn34ZEbNMZ13AxyF6QkavU+Xcr5tQNwwZ+8P+k5OGoVsJOqZ3J7M+igGDRZh0fD693Wdp+mfORQqIvJFKED4daJYgTLufwt4tBLUxPUvlUZOWZFPn8DSQqTE7vsE9VPdpKSXTv1MyHxeMTiAX+XPabEWoazB8/4rljkC/EPxAButPD+AtUatfa6fIXpyGxHIvX8CFa2UnOQe9YbTRnxqa8TYvyMsWNQn1Q1eQMkvXCetqoefW5hA0UHTU5Zy4="
   matrix:
     - SCRIPT=test-2.11
     - SCRIPT=test-2.12
@@ -46,7 +45,3 @@ notifications:
         - https://webhooks.gitter.im/e/773aba95141768c32dae
     on_success: always
     on_failure: always
-branches:
-  only:
-  - master
-  - 1.3.x

--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -5,6 +5,8 @@
 set -e
 set -o pipefail
 
+# Travis uses a detached HEAD during builds
+# CURRENT_BRANCH is used when updating Whitesource to determine the correct project name
 export CURRENT_BRANCH=${TRAVIS_BRANCH}
 
 runSbt() {

--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -5,6 +5,8 @@
 set -e
 set -o pipefail
 
+export CURRENT_BRANCH=${TRAVIS_BRANCH}
+
 runSbt() {
   sbt --warn -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
 }

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -2,7 +2,7 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-runSbt scalariformFormat test:scalariformFormat multi-jvm:scalariformFormat validateDependencies mimaCheckOneAtATime whitesourceUpdate
+runSbt scalariformFormat test:scalariformFormat multi-jvm:scalariformFormat validateDependencies mimaCheckOneAtATime
 
 git diff --exit-code || (
   echo "ERROR: Scalariform check failed, see differences above."
@@ -11,3 +11,8 @@ git diff --exit-code || (
   false
 )
 
+# Only update Whitesource if WHITESOURCE_PASSWORD is defined
+# Encrypted environment variables are not available to pull requests for security reasons
+if [[ -n "${WHITESOURCE_PASSWORD}" ]]; then
+  runSbtNoisy whitesourceUpdate
+fi

--- a/build.sbt
+++ b/build.sbt
@@ -44,10 +44,7 @@ def common: Seq[Setting[_]] = releaseSettings ++ bintraySettings ++ Seq(
   ),
 
   pomExtra := {
-    <scm>
-      <url>https://github.com/lagom/lagom</url>
-      <connection>scm:git:git@github.com:lagom/lagom.git</connection>
-    </scm>
+    // scm metadata is added by the sbt-git plugin
     <developers>
       <developer>
         <id>lagom</id>

--- a/build.sbt
+++ b/build.sbt
@@ -366,17 +366,7 @@ lazy val root = (project in file("."))
   )
   .enablePlugins(lagom.UnidocRoot)
   .settings(UnidocRoot.settings(javadslProjects.map(Project.projectToRef), scaladslProjects.map(Project.projectToRef)): _*)
-  .settings(
-    whitesourceProduct in ThisBuild               := "Lightbend Reactive Platform",
-    whitesourceAggregateProjectName in ThisBuild  := sys.env.getOrElse("WHITESOURCE_PROJECT_NAME", default = "invalid"),
-    whitesourceAggregateProjectToken in ThisBuild := sys.env.getOrElse("WHITESOURCE_PROJECT_TOKEN", default = "invalid")
-  )
   .aggregate((javadslProjects ++ scaladslProjects ++ coreProjects ++ otherProjects ++ sbtScriptedProjects).map(Project.projectToRef): _*)
-
-  credentials += Credentials(realm = "whitesource",
-      host = "whitesourcesoftware.com",
-      userName = "",
-      passwd = sys.env.getOrElse("WHITESOURCE_PASSWORD", default = "invalid"))
 
 def RuntimeLibPlugins = AutomateHeaderPlugin && Sonatype && PluginsAccessor.exclude(BintrayPlugin)
 def SbtPluginPlugins = AutomateHeaderPlugin && BintrayPlugin && PluginsAccessor.exclude(Sonatype)

--- a/project/Whitesource.scala
+++ b/project/Whitesource.scala
@@ -1,0 +1,49 @@
+import com.typesafe.sbt.SbtGit.GitKeys._
+import sbt.Keys._
+import sbt._
+import sbtwhitesource.WhiteSourcePlugin
+import sbtwhitesource.WhiteSourcePlugin.autoImport._
+
+object Whitesource extends AutoPlugin {
+  override def requires: Plugins = WhiteSourcePlugin
+
+  override def trigger = allRequirements
+
+  override lazy val projectSettings = Seq(
+    whitesourceProduct := "Lightbend Reactive Platform",
+    whitesourceAggregateProjectName := {
+      (moduleName in LocalRootProject).value + "-" +
+      whitesourceProjectSuffix(isSnapshot.value, currentBranch.value, (version in LocalRootProject).value)
+    },
+    whitesourceForceCheckAllDependencies := true,
+    whitesourceFailOnError := true
+  )
+
+  private lazy val currentBranch = Def.setting {
+    sys.env.getOrElse("CURRENT_BRANCH", gitCurrentBranch.value)
+  }
+
+  private val StableBranch = """(\d+)\.(\d+)\.x""".r
+  private val FinalVersion = """(\d+)\.(\d+)\.(\d+)""".r // no -M1, -RC1, etc. suffix
+
+  def whitesourceProjectSuffix(isSnapshot: Boolean, currentBranch: String, version: String): String = {
+    if (isSnapshot) {
+      // There are three scenarios:
+      currentBranch match {
+        // 1. It is the master branch
+        case "master" => "master"
+        // 2. It is a stable branch (1.3.x, 1.4.x, etc.)
+        case StableBranch(major, minor) => s"$major.$minor-snapshot"
+        // 3. It is some other branch
+        case _ => "adhoc"
+      }
+    } else {
+      // Building a release tag
+      version match {
+        case FinalVersion(major, minor, _) => s"$major.$minor-stable"
+        // Milestone or RC
+        case _ => "adhoc"
+      }
+    }
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,3 +22,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+
+// Used to detect the current branch for Whitesource
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.10")

--- a/project/whitesource.sbt
+++ b/project/whitesource.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.3")


### PR DESCRIPTION
- Detect the current branch based on an environment variable (Travis CI) or using git.
- Determine the Whitesource project name from the branch and version number, so we won't have to update the configuration whenever a stable branch is created.
- Build all branches in CI (required to test this change).
- Run Whitesource update with full info-level logging (which includes useful output).
- Only update Whitesource when the WHITESOURCE_PASSWORD encrypted environment variable is set (i.e., not for pull requests).
- Update to the latest sbt-whitesource plugin, which includes support for reading WHITESOURCE_PASSWORD from the environment directly.
- Stop using project tokens, which are not required when the project name is provided.
- Update "*-stable" projects in Whitesource for final release builds.

## Purpose

Improves automation of [Whitesource](https://www.whitesourcesoftware.com/) report updates (used internally by Lightbend for license and security checks).

## Background Context

The current approach has a few flaws:

- It doesn't run automatically on release builds, requiring a manual step after each release
- It requires manually updating each stable branch to specify the correct Whitesource project name (easy to forget and continue updating the wrong project)
- It tries to run on pull requests, leaving an ugly error in the build logs
- It is missing useful logging in builds where it does run
- Although we don't often push feature branches to the main lagom/lagom repository, when we do, the current handling updates the wrong Whitesource project

## References

Based on similar approaches used in [Play](https://github.com/playframework/interplay/blob/fb8b7ee32c0ae8790e8f40947daace445fe5cd7d/src/main/scala/interplay/PlayBuildBase.scala#L312-L345) and [Akka](https://github.com/akka/akka/blob/eede5533ace5a9598e0e5974cc78c51ba3e3eaed/project/Whitesource.scala).

## Backport

We should backport this change to the 1.4.x and 1.3.x stable branches.