### PR TITLE
Remove sbt-git plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,10 @@ def common: Seq[Setting[_]] = releaseSettings ++ bintraySettings ++ Seq(
   ),
 
   pomExtra := {
-    // scm metadata is added by the sbt-git plugin
+    <scm>
+      <url>https://github.com/lagom/lagom</url>
+      <connection>scm:git:git@github.com:lagom/lagom.git</connection>
+    </scm>
     <developers>
       <developer>
         <id>lagom</id>

--- a/project/Whitesource.scala
+++ b/project/Whitesource.scala
@@ -1,4 +1,3 @@
-import com.typesafe.sbt.SbtGit.GitKeys._
 import sbt.Keys._
 import sbt._
 import sbtwhitesource.WhiteSourcePlugin
@@ -20,7 +19,7 @@ object Whitesource extends AutoPlugin {
   )
 
   private lazy val currentBranch = Def.setting {
-    sys.env.getOrElse("CURRENT_BRANCH", gitCurrentBranch.value)
+    sys.env.getOrElse("CURRENT_BRANCH", "")
   }
 
   private val StableBranch = """(\d+)\.(\d+)\.x""".r

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,7 +22,4 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
-
-// Used to detect the current branch for Whitesource
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.10")


### PR DESCRIPTION
This was added in #1218 (a1714f9) but conflicts with git worktree.
https://github.com/sbt/sbt/issues/2323

The use of sbt-git was only a convenience for running Whitesource update locally without specifying the CURRENT_BRANCH environment variable. Since worktree is a more important convenience, I'm reverting this part of the change.

Should be backported to 1.4.x and 1.3.x.