### PR TITLE
[1.3.x] Restore tests from #1210

### DIFF
--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractPersistentEntityActorSpec.scala
@@ -8,9 +8,8 @@ import scala.concurrent.duration._
 import java.util.Optional
 
 import akka.testkit.{ ImplicitSender, TestProbe }
-import akka.actor.Actor
+import akka.actor.{ Actor, Props, UnhandledMessage }
 import akka.cluster.sharding.ShardRegion
-import akka.actor.Props
 import com.lightbend.lagom.internal.javadsl.persistence.PersistentEntityActor
 import org.scalatest.WordSpecLike
 import com.lightbend.lagom.persistence.ActorSystemSpec
@@ -107,10 +106,17 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
     "save snapshots" in {
       val p = system.actorOf(PersistentEntityActor.props("test", Optional.of("4"),
         () => new TestEntity(system), Optional.of(3), 10.seconds))
+
+      val unhandledProbe = TestProbe()
+      system.eventStream.subscribe(unhandledProbe.ref, classOf[UnhandledMessage])
+
       for (n <- 1 to 10) {
         p ! TestEntity.Add.of(n.toString)
         expectMsg(new TestEntity.Appended("4", n.toString))
       }
+
+      unhandledProbe.expectNoMsg(300.milliseconds)
+      system.eventStream.unsubscribe(unhandledProbe.ref)
 
       // start another with same persistenceId should recover state
       // awaitAssert because it is not guaranteed that we will see the snapshot immediately

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractPersistentEntityActorSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractPersistentEntityActorSpec.scala
@@ -3,7 +3,7 @@
  */
 package com.lightbend.lagom.scaladsl.persistence
 
-import akka.actor.{ Actor, Props }
+import akka.actor.{ Actor, Props, UnhandledMessage }
 import akka.cluster.sharding.ShardRegion
 import akka.testkit.TestProbe
 import com.lightbend.lagom.internal.scaladsl.persistence.PersistentEntityActor
@@ -103,10 +103,17 @@ trait AbstractPersistentEntityActorSpec { spec: ActorSystemSpec =>
     "save snapshots" in {
       val p = system.actorOf(PersistentEntityActor.props("test", Some("4"),
         () => new TestEntity(system), Some(3), 10.seconds))
+
+      val unhandledProbe = TestProbe()
+      system.eventStream.subscribe(unhandledProbe.ref, classOf[UnhandledMessage])
+
       for (n <- 1 to 10) {
         p ! TestEntity.Add(n.toString)
         expectMsg(TestEntity.Appended(n.toString))
       }
+
+      unhandledProbe.expectNoMsg(300.milliseconds)
+      system.eventStream.unsubscribe(unhandledProbe.ref)
 
       // start another with same persistenceId should recover state
       // awaitAssert because it is not guaranteed that we will see the snapshot immediately


### PR DESCRIPTION
Originally committed to 1.3.x in 979a2368a04a311636464258f76712c5de14f714 using the `expectNoMessage` name that is available in Akka 2.5.

This broke the build until the test changes were reverted in 8ae144a969f46597bd593a0aacac3f2a7d448e3e.

This restores the tests, but changed to use the Akka 2.4 method name: `expectNoMsg`

Thanks, @lutzh for the tip. References #1210.