### PR TITLE
Update Akka Persistence Cassandra to 0.60

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   // Also be sure to update ScalaVersion in docs/build.sbt.
   val ScalaVersions = Seq("2.12.4", "2.11.12")
   val SbtScalaVersions = Seq("2.10.6", "2.12.4")
-  val AkkaPersistenceCassandraVersion = "0.59"
+  val AkkaPersistenceCassandraVersion = "0.60"
   val AkkaPersistenceJdbcVersion = "3.1.0"
   // Also be sure to update ScalaTestVersion in docs/build.sbt.
   val ScalaTestVersion = "3.0.4"


### PR DESCRIPTION
This updates the bundled Cassandra server to 3.11.2, fixing an incompatibility with recent JDK 8 versions:

https://issues.apache.org/jira/browse/CASSANDRA-14173

Fixes #1204

## Testing notes

If you want to see the before/after, you can test this by creating a new Lagom project (e.g., with `sbt new lagom/lagom-scala.g8`) and running `sbt runAll` with `java version "1.8.0_162"` (I use [jEnv](http://www.jenv.be/) to switch between multiple installed JDKs).

Using Lagom 1.4.0, you'll see errors reported when it launches Cassandra:

```
[info] Starting Cassandra
.Exception (java.lang.AbstractMethodError) encountered during startup: org.apache.cassandra.utils.JMXServerUtils$Exporter.exportObject(Ljava/rmi/Remote;ILjava/rmi/server/RMIClientSocketFactory;Ljava/rmi/server/RMIServerSocketFactory;Lsun/misc/ObjectInputFilter;)Ljava/rmi/Remote;
java.lang.AbstractMethodError: org.apache.cassandra.utils.JMXServerUtils$Exporter.exportObject(Ljava/rmi/Remote;ILjava/rmi/server/RMIClientSocketFactory;Ljava/rmi/server/RMIServerSocketFactory;Lsun/misc/ObjectInputFilter;)Ljava/rmi/Remote;
	at javax.management.remote.rmi.RMIJRMPServerImpl.export(RMIJRMPServerImpl.java:150)
	at javax.management.remote.rmi.RMIJRMPServerImpl.export(RMIJRMPServerImpl.java:135)
	at javax.management.remote.rmi.RMIConnectorServer.start(RMIConnectorServer.java:405)
	at org.apache.cassandra.utils.JMXServerUtils.createJMXServer(JMXServerUtils.java:104)
	at org.apache.cassandra.service.CassandraDaemon.maybeInitJmx(CassandraDaemon.java:144)
	at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:189)
	at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:601)
	at org.apache.cassandra.service.CassandraDaemon.main(CassandraDaemon.java:735)
```

If you checkout this branch, `sbt publishLocal`, update your test project to `addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-SNAPSHOT")`, then `sbt clean runAll`, it should work normally.

Note that it is required to `clean`, or at least to delete the `target/embedded-cassandra/cassandra-bundle.jar` file, due to https://github.com/akka/akka-persistence-cassandra/issues/327. Otherwise, it will continue using the old version.

## Backports

This should be backported to 1.4.x, but the 1.3.x branch is unaffected (because it's using an older version of Cassandra that doesn't have this incompatibility).