### PR TITLE
[WIP] disable java serialization in multi-jvm tests

### DIFF
--- a/persistence-cassandra/javadsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-cassandra/javadsl/src/multi-jvm/resources/reference.conf
@@ -1,0 +1,4 @@
+akka.actor.serialization-bindings {
+  "java.io.Serializable" = none
+  "akka.Done" = akka-misc
+}

--- a/persistence-cassandra/scaladsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-cassandra/scaladsl/src/multi-jvm/resources/reference.conf
@@ -1,0 +1,4 @@
+akka.actor.serialization-bindings {
+  "java.io.Serializable" = none
+  "akka.Done" = akka-misc
+}

--- a/persistence-jdbc/javadsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-jdbc/javadsl/src/multi-jvm/resources/reference.conf
@@ -1,6 +1,9 @@
 jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"
 
-
+akka.actor.serialization-bindings {
+  "java.io.Serializable" = none
+  "akka.Done" = akka-misc
+}
 
 # Aggressively restart and ensure the cluster-distributed, readside actors so tests don't take that long.
 lagom.persistence {

--- a/persistence-jdbc/scaladsl/src/main/resources/reference.conf
+++ b/persistence-jdbc/scaladsl/src/main/resources/reference.conf
@@ -1,5 +1,3 @@
-play.modules.enabled += com.lightbend.lagom.javadsl.persistence.jdbc.JdbcPersistenceModule
-
 akka.actor.serialization-bindings {
   "java.io.Serializable" = none
   "akka.Done" = akka-misc

--- a/persistence-jdbc/scaladsl/src/multi-jvm/resources/reference.conf
+++ b/persistence-jdbc/scaladsl/src/multi-jvm/resources/reference.conf
@@ -1,5 +1,10 @@
 jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"
 
+akka.actor.serialization-bindings {
+  "java.io.Serializable" = none
+  "akka.Done" = akka-misc
+}
+
 # Aggressively restart and ensure the cluster-distributed, readside actors so tests don't take that long.
 lagom.persistence {
   read-side.failure-exponential-backoff {

--- a/pubsub/javadsl/src/multi-jvm/resources/reference.conf
+++ b/pubsub/javadsl/src/multi-jvm/resources/reference.conf
@@ -1,0 +1,4 @@
+akka.actor.serialization-bindings {
+  "java.io.Serializable" = none
+  "akka.Done" = akka-misc
+}


### PR DESCRIPTION
This is a work-in-progress to disable java serialization in multi-jvm tests. 

[Reference](https://github.com/lagom/lagom/issues/1045)

Fixes #1045