### PR TITLE
Wrong description for MaxMetaspaceSize

### DIFF
--- a/docs/manual/common/guide/build/JVMMemoryOnDev.md
+++ b/docs/manual/common/guide/build/JVMMemoryOnDev.md
@@ -13,7 +13,7 @@ You can start Maven with extra memory using `MAVEN_OPTS` environment variable.
 $ MAVEN_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" mvn lagom:runAll
 ```
 
-In this example we're setting an initial JVM Heap of 512Mb, a maximum Heap of 1024M, a thread stack of 2M and maximum Metaspace size of 2014M.
+In this example we're setting an initial JVM Heap of 512Mb, a maximum Heap of 1024M, a thread stack of 2M and maximum Metaspace size of 1024M.
 
 Stating the `MAVEN_OPTS` on every invocation is error prone and exporting it globally might not be possible if you need different settings for different projects. You may want to use [direnv](https://direnv.net/) to setup the environment variables per project.
 


### PR DESCRIPTION
In the Maven section, the value for MaxMetaspaceSize is set as `-XX:MaxMetaspaceSize=1024M`, but the description says "...a thread stack of 2M and maximum Metaspace size of 2014M".

# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
