### PR TITLE
Removes docs wrt the metrics service and its endpoints

### DIFF
--- a/docs/manual/java/guide/services/ServiceClients.md
+++ b/docs/manual/java/guide/services/ServiceClients.md
@@ -97,10 +97,4 @@ With the above "hello" example we could adjust the configuration by defining pro
       default.call-timeout = 5s
     }
 
-Information about the status of the circuit breakers and some metrics for throughput and latency are provided by the built in `MetricsService` that is available at the following paths of each service:
-
-* `/_status/circuit-breaker/current` - Snapshot of current circuit breaker status
-* `/_status/circuit-breaker/stream` - Stream of circuit breaker status
-
 [Lightbend Monitoring](https://www.lightbend.com/products/monitoring) will provide metrics for Lagom circuit breakers, including aggregated views of the information for all nodes in the cluster.
-

--- a/docs/manual/scala/guide/services/ScalaComponents.md
+++ b/docs/manual/scala/guide/services/ScalaComponents.md
@@ -7,7 +7,6 @@ This is a list of available Components you may use to build your application cak
 | -------------------- | ----------- |
 | [LagomServerComponents](api/com/lightbend/lagom/scaladsl/server/LagomServerComponents.html) | a main Component for any Lagom Service. See [[Defining your own components|DependencyInjection#Defining-your-own-components]].|
 | [LagomServiceClientComponents](api/com/lightbend/lagom/scaladsl/client/LagomServiceClientComponents.html) | a main Component for any Lagom Service or application consuming Lagom Services. See [[Dependency Injection in Lagom|DependencyInjection]] and  [[Binding a service client|ServiceClients#Binding-a-service-client]].|
-| [MetricsServiceComponents](api/com/lightbend/lagom/scaladsl/server/status/MetricsServiceComponents.html) | adds a `MetricsService` to your service so you can remotely track the status of the CircuitBreakers on your service. Using this only makes sense when you Application is consuming other services (hence using remote calls protected with Circuit Breakers). See [[Circuit Breaker Metrics|ServiceClients#Circuit-breaker-metrics]] |
 
 ##### Persistence and Cluster Components
 | -------------------- | ----------- |

--- a/docs/manual/scala/guide/services/ServiceClients.md
+++ b/docs/manual/scala/guide/services/ServiceClients.md
@@ -88,16 +88,4 @@ With the above "hello" example we could adjust the configuration by defining pro
       default.call-timeout = 5s
     }
 
-### Circuit breaker metrics
-
-
-Lagom allows you to publish metrics for circuit breakers via a metrics service. To enable this service, add `metricsServiceBinding` to your service bindings in your `lagomServer` declaration, like so:
-
-@[metrics-service](code/ServiceClients.scala)
-
-The service provides the following endpoints:
-
-* `/_status/circuit-breaker/current` - Snapshot of current circuit breaker status
-* `/_status/circuit-breaker/stream` - Stream of circuit breaker status
-
 [Lightbend Monitoring](https://www.lightbend.com/products/monitoring) will provide metrics for Lagom circuit breakers, including aggregated views of the information for all nodes in the cluster.


### PR DESCRIPTION
fixes #1241 (remove docs to metrics service endpoints and promote multi-service servers)

I'd remove `MetricsService` in a separate PR.