### PR TITLE
Remove unnecessary workarounds in ServiceTestSpec

### DIFF
--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTestSpec.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTestSpec.scala
@@ -55,16 +55,11 @@ trait TestService extends Service {
 
   import Service._
 
-  // Requires at least one method due to https://github.com/lagom/lagom/issues/1185
-  def noop: ServiceCall[NotUsed, Done]
-
   override final def descriptor: Descriptor = named("test")
 
 }
 
-class TestServiceImpl extends TestService {
-  override def noop: ServiceCall[NotUsed, Done] = ServiceCall { _ => Future.successful(Done) }
-}
+class TestServiceImpl extends TestService
 
 class TestApplication(context: LagomApplicationContext) extends LagomApplication(context)
   with LocalServiceLocator


### PR DESCRIPTION
Issue #1185 was fixed in #1257, so this can be simplified to match the Java version.

This removes the workaround added in #1186.

Backport to 1.4.x isn't really required, but might as well.