### PR TITLE
Fix Cassandra and JDBC conflicts in TestKit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -567,7 +567,8 @@ lazy val `testkit-javadsl` = (project in file("testkit/javadsl"))
     `broker-javadsl`,
     `persistence-core` % "compile;test->test",
     `persistence-cassandra-javadsl` % "test->test",
-    `jackson` % "test->test"
+    `jackson` % "test->test",
+    `persistence-jdbc-javadsl` % Test
   )
 
 lazy val `testkit-scaladsl` = (project in file("testkit/scaladsl"))
@@ -584,7 +585,8 @@ lazy val `testkit-scaladsl` = (project in file("testkit/scaladsl"))
     `broker-scaladsl`,
     `persistence-core` % "compile;test->test",
     `persistence-scaladsl` % "compile;test->test",
-    `persistence-cassandra-scaladsl` % "compile;test->test"
+    `persistence-cassandra-scaladsl` % "compile;test->test",
+    `persistence-jdbc-scaladsl` % Test
   )
 
 lazy val `integration-tests-javadsl` = (project in file("service/javadsl/integration-tests"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -392,16 +392,16 @@ object Dependencies {
   val `testkit-core` = libraryDependencies ++= Seq(
     akkaActor,
     akkaStream,
+    play,
+    akkaPersistenceCassandraLauncher,
 
     // Upgrades needed to match whitelist
-    scalaJava8Compat,
-    scalaParserCombinators
+    playJson
   )
 
   val `testkit-javadsl` = libraryDependencies ++= Seq(
     playAkkaHttpServer,
     akkaStreamTestkit,
-    akkaPersistenceCassandraLauncher,
     scalaTest % Test,
     "junit" % "junit" % JUnitVersion,
     h2 % Test,
@@ -413,7 +413,6 @@ object Dependencies {
   val `testkit-scaladsl` = libraryDependencies ++= Seq(
     playAkkaHttpServer,
     akkaStreamTestkit,
-    akkaPersistenceCassandraLauncher,
     scalaTest % Test,
     "junit" % "junit" % JUnitVersion,
     h2 % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -404,6 +404,7 @@ object Dependencies {
     akkaPersistenceCassandraLauncher,
     scalaTest % Test,
     "junit" % "junit" % JUnitVersion,
+    h2 % Test,
 
     // Without an binding, slf4j will print warnings when running tests
     "org.slf4j" % "slf4j-nop" % Slf4jVersion % Test
@@ -415,6 +416,7 @@ object Dependencies {
     akkaPersistenceCassandraLauncher,
     scalaTest % Test,
     "junit" % "junit" % JUnitVersion,
+    h2 % Test,
 
     // Without an binding, slf4j will print warnings when running tests
     "org.slf4j" % "slf4j-nop" % Slf4jVersion % Test

--- a/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/CassandraTestServer.scala
+++ b/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/CassandraTestServer.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.testkit
+
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+
+import akka.persistence.cassandra.testkit.CassandraLauncher
+import com.google.common.io.{ MoreFiles, RecursiveDeleteOption }
+import play.api.Logger
+import play.api.inject.ApplicationLifecycle
+
+import scala.concurrent.Future
+import scala.util.Try
+
+private[lagom] object CassandraTestServer {
+  private val LagomTestConfigResource: String = "lagom-test-embedded-cassandra.yaml"
+
+  private lazy val log = Logger(getClass)
+
+  def run(cassandraDirectoryPrefix: String, lifecycle: ApplicationLifecycle): Int = {
+    val cassandraPort = CassandraLauncher.randomPort
+    val cassandraDirectory = Files.createTempDirectory(cassandraDirectoryPrefix)
+
+    // Shut down Cassandra and delete its temporary directory when the application shuts down
+    lifecycle.addStopHook { () =>
+      import scala.concurrent.ExecutionContext.Implicits.global
+      Try(CassandraLauncher.stop())
+      // The ALLOW_INSECURE option is required to remove the files on OSes that don't support SecureDirectoryStream
+      // See http://google.github.io/guava/releases/snapshot-jre/api/docs/com/google/common/io/MoreFiles.html#deleteRecursively-java.nio.file.Path-com.google.common.io.RecursiveDeleteOption...-
+      Future(MoreFiles.deleteRecursively(cassandraDirectory, RecursiveDeleteOption.ALLOW_INSECURE))
+    }
+
+    val t0 = System.nanoTime()
+
+    CassandraLauncher.start(
+      cassandraDirectory.toFile,
+      LagomTestConfigResource,
+      clean = false,
+      port = cassandraPort,
+      CassandraLauncher.classpathForResources(LagomTestConfigResource)
+    )
+
+    log.debug(s"Cassandra started in ${TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0)} ms")
+
+    cassandraPort
+  }
+}

--- a/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/TestConfig.scala
+++ b/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/TestConfig.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.testkit
+
+import com.typesafe.config.{ Config, ConfigFactory }
+
+private[lagom] object TestConfig {
+  lazy val JdbcConfig: Config = ConfigFactory.parseString(
+    """
+      |db.default.driver=org.h2.Driver
+      |db.default.url="jdbc:h2:mem:service-test"
+      |
+      |jdbc-defaults.slick.profile = "slick.jdbc.H2Profile$"
+      |
+      |jdbc-journal.slick.profile = ${?jdbc-defaults.slick.profile}
+      |jdbc-read-journal.slick.profile = ${?jdbc-defaults.slick.profile}
+      |jdbc-snapshot-store.slick.profile = ${?jdbc-defaults.slick.profile}
+      |lagom.persistence.read-side.jdbc.slick.profile = ${?jdbc-defaults.slick.profile}
+      |
+      |akka.persistence.journal.plugin = jdbc-journal
+      |akka.persistence.snapshot-store.plugin = jdbc-snapshot-store
+    """.stripMargin
+  ).resolve()
+}

--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTestSpec.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTestSpec.scala
@@ -5,23 +5,26 @@ package com.lightbend.lagom.scaladsl.testkit
 
 import java.nio.file.{ Files, Path, Paths }
 
-import akka.{ Done, NotUsed }
-import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service, ServiceCall }
+import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service }
+import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraPersistenceComponents
+import com.lightbend.lagom.scaladsl.persistence.jdbc.JdbcPersistenceComponents
+import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry }
+import com.lightbend.lagom.scaladsl.playjson.{ EmptyJsonSerializerRegistry, JsonSerializerRegistry }
 import com.lightbend.lagom.scaladsl.server._
 import org.scalatest.{ Matchers, WordSpec }
+import play.api.db.HikariCPComponents
 import play.api.libs.ws.ahc.AhcWSComponents
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
 import scala.util.Properties
 
 class ServiceTestSpec extends WordSpec with Matchers {
   "ServiceTest" when {
-    "started" should {
+    "started with Cassandra" should {
       "create a temporary directory" in {
         val temporaryFileCountBeforeRun = listTemporaryFiles().size
 
-        ServiceTest.withServer(ServiceTest.defaultSetup.withCassandra())(new TestApplication(_)) { _ =>
+        ServiceTest.withServer(ServiceTest.defaultSetup.withCassandra())(new CassandraTestApplication(_)) { _ =>
           val temporaryFilesDuringRun = listTemporaryFiles()
 
           temporaryFilesDuringRun should have size (temporaryFileCountBeforeRun + 1)
@@ -33,11 +36,17 @@ class ServiceTestSpec extends WordSpec with Matchers {
       "remove its temporary directory" in {
         val temporaryFileCountBeforeRun = listTemporaryFiles().size
 
-        ServiceTest.withServer(ServiceTest.defaultSetup.withCassandra())(new TestApplication(_)) { _ => () }
+        ServiceTest.withServer(ServiceTest.defaultSetup.withCassandra())(new CassandraTestApplication(_)) { _ => () }
 
         val temporaryFilesAfterRun = listTemporaryFiles()
 
         temporaryFilesAfterRun should have size temporaryFileCountBeforeRun
+      }
+    }
+
+    "started with JDBC" should {
+      "start successfully" in {
+        ServiceTest.withServer(ServiceTest.defaultSetup.withJdbc())(new JdbcTestApplication(_)) { _ => () }
       }
     }
   }
@@ -59,12 +68,21 @@ trait TestService extends Service {
 
 }
 
-class TestServiceImpl extends TestService
+class TestServiceImpl(persistentEntityRegistry: PersistentEntityRegistry) extends TestService
 
 class TestApplication(context: LagomApplicationContext) extends LagomApplication(context)
   with LocalServiceLocator
-  with AhcWSComponents {
+  with AhcWSComponents { self: PersistenceComponents =>
 
-  override lazy val lagomServer: LagomServer = serverFor[TestService](new TestServiceImpl)
+  override lazy val jsonSerializerRegistry: JsonSerializerRegistry = EmptyJsonSerializerRegistry
+
+  override lazy val lagomServer: LagomServer = serverFor[TestService](new TestServiceImpl(persistentEntityRegistry))
 
 }
+
+class CassandraTestApplication(context: LagomApplicationContext) extends TestApplication(context)
+  with CassandraPersistenceComponents
+
+class JdbcTestApplication(context: LagomApplicationContext) extends TestApplication(context)
+  with JdbcPersistenceComponents
+  with HikariCPComponents


### PR DESCRIPTION
The previous implementation depends on classpath ordering and can result in Cassandra being used when JDBC is intended.

Fixes #1236