### PR TITLE
Build Maven plugin and support for Scala 2.12 only

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1024,9 +1024,8 @@ lazy val `build-tool-support` = (project in file("dev") / "build-tool-support")
   .settings(
     name := "lagom-build-tool-support",
     publishMavenStyle := true,
-    crossScalaVersions := Dependencies.SbtScalaVersions,
-    scalaVersion := Dependencies.SbtScalaVersions.head,
-    sbtVersion in pluginCrossBuild := defineSbtVersion(scalaBinaryVersion.value),
+    crossScalaVersions := Seq(Dependencies.ScalaVersions.head),
+    scalaVersion := Dependencies.ScalaVersions.head,
     crossPaths := false,
     sourceGenerators in Compile += Def.task {
       Generators.version(version.value, (sourceManaged in Compile).value)
@@ -1034,7 +1033,7 @@ lazy val `build-tool-support` = (project in file("dev") / "build-tool-support")
     Dependencies.`build-tool-support`
   )
 
-// This is almost the sabe as `build-tool-support`, but targeting sbt
+// This is almost the same as `build-tool-support`, but targeting sbt
 // while `build-tool-support` targets Maven and possibly other build
 // systems. We did something similar for routes compiler in Play:
 //
@@ -1096,6 +1095,8 @@ lazy val `maven-plugin` = (project in file("dev") / "maven-plugin")
     description := "Provides Lagom development environment support to maven.",
     Dependencies.`maven-plugin`,
     publishMavenStyle := true,
+    crossScalaVersions := Seq(Dependencies.ScalaVersions.head),
+    scalaVersion := Dependencies.ScalaVersions.head,
     crossPaths := false,
     mavenClasspath := (externalDependencyClasspath in (`maven-launcher`, Compile)).value.map(_.data),
     mavenTestArgs := Seq(


### PR DESCRIPTION
This is my attempt to fix the failure on Travis CI when building release tags (for example https://travis-ci.org/lagom/lagom/jobs/349686520)

The problem was caused by the `build-tool-support` and `maven-plugin` modules being published multiple times to the Maven repository in the same build. When building `SNAPSHOT` versions, this is fine, but when building a tag sbt prevents overwriting existing files.

I tested this locally by:

1.  Checking out the `1.4.1` tag and overlaying these changes
2.  Deleting existing artifacts with:
    ```bash
    rm -r ~/.m2/repository/com/lightbend/lagom
    ```
3.  Running
    ```bash
    sbt clean +publishM2 mavenTest
    ```