### PR TITLE
Sync error description between java ans scala DSLs

### DIFF
--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/Exceptions.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/Exceptions.scala
@@ -74,7 +74,7 @@ object TransportErrorCode {
   /**
    * A generic error to used to indicate that the end receiving the error message violated the remote ends policy.
    */
-  val PolicyViolation: TransportErrorCode = TransportErrorCode(404, 1008, "Policy Violation")
+  val PolicyViolation: TransportErrorCode = TransportErrorCode(404, 1008, "Policy Violation/Not Found")
   /**
    * A resource was not found, equivalent to policy violation.
    */
@@ -99,7 +99,7 @@ object TransportErrorCode {
    * A generic error used to indicate that the end sending the error message because it encountered an unexpected
    * condition.
    */
-  val UnexpectedCondition: TransportErrorCode = TransportErrorCode(500, 1011, "Unexpected Condition")
+  val UnexpectedCondition: TransportErrorCode = TransportErrorCode(500, 1011, "Unexpected Condition/Internal Server Error")
   /**
    * An internal server error, equivalent to Unexpected Condition.
    */


### PR DESCRIPTION
As pointed out in https://github.com/lagom/lagom/pull/1247#discussion_r175264761 the PR was merged with a change not properly implemented on `scaladsl`.

This change will need backporting to `1.4.x` (I think we can live without it on `1.3.x` but we did backport the original PR to `1.3.x`).