### PR TITLE
Move akka.test.single-expect-default setting

### DIFF
--- a/bin/test-documentation
+++ b/bin/test-documentation
@@ -5,4 +5,4 @@
 runSbt unidoc
 
 cd docs
-runSbt -Dakka.test.single-expect-default=15s markdownValidateDocs test markdownEvaluateSbtFiles
+runSbt markdownValidateDocs test markdownEvaluateSbtFiles

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -111,7 +111,7 @@ lazy val immutables = ProjectRef(parentDir, "immutables")
 def forkedTests: Seq[Setting[_]] = Seq(
   fork in Test := true,
   concurrentRestrictions in Global += Tags.limit(Tags.Test, 1),
-  javaOptions in Test ++= Seq("-Xms256M", "-Xmx512M"),
+  javaOptions in Test ++= Seq("-Xms256M", "-Xmx512M", "-Dakka.test.single-expect-default=15s"),
   testGrouping in Test := (definedTests in Test map singleTestsGrouping).value
 )
 


### PR DESCRIPTION
Tests are forked, so it needs to be specified in the Java options for the forked test process, not for the sbt process.

Follow up to #1264, hopefully fixes #461.