### PR TITLE
Document required behaviour of flow to message broker subscriber

### DIFF
--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/Subscriber.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/broker/Subscriber.java
@@ -86,8 +86,15 @@ public interface Subscriber<Payload> {
    * Whether the stream is automatically restarted depends on the Lagom message
    * broker implementation in use. If the Kafka Lagom message broker module is
    * being used, then by default the stream is automatically restarted when a
-   * failure occurs.  
-   * 
+   * failure occurs.
+   *
+   * The <code>flow</code> may pull more elements from upstream but it must emit
+   * exactly one <code>Done</code> message for each message that it receives. It
+   * must also emit them in the same order that the messages were received. This
+   * means that the <code>flow</code> must not filter or collect a subset of the
+   * messages, instead it must split the messages into separate streams and map
+   * those that would have been dropped to <code>Done</code>.
+   *
    * @param flow The flow to apply to each received message.
    * @return A <code>CompletionStage</code> that may never complete if messages
    *         go through the passed <code>flow</code> flawlessly. However, the

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Subscriber.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/broker/Subscriber.scala
@@ -49,6 +49,11 @@ trait Subscriber[Payload] {
    * Kafka Lagom message broker module is being used, then by default the stream is automatically restarted when a
    * failure occurs.
    *
+   * The `flow` may pull more elements from upstream but it must emit exactly one `Done` message for each message that
+   * it receives. It must also emit them in the same order that the messages were received. This means that the `flow`
+   * must not filter or collect a subset of the messages, instead it must split the messages into separate streams and
+   * map those that would have been dropped to `Done`.
+   *
    * @param flow The flow to apply to each received message.
    * @return A `Future` that will be completed if the `flow` completes.
    */


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #1274

## Purpose

Adds documentation to describe that the `flow` that is passed to `Subscriber.atLeastOnce` must handle every event exactly once.

## Background Context

I was not aware of these requirements when using `Subscriber.atLeastOnce` and it leads to a bug where the offset would get further and further behind.

## References

https://github.com/lagom/lagom.github.io/issues/129