### PR TITLE
Upgrades Slick and akka-persistence-jdbc versions

### DIFF
--- a/docs/manual/java/guide/build/LagomBuild.md
+++ b/docs/manual/java/guide/build/LagomBuild.md
@@ -32,7 +32,7 @@ We recommend the usage of maven properties to define the Lagom Version and Scala
 ```xml
 <properties>
     <scala.binary.version>2.12</scala.binary.version>
-    <lagom.version>1.4.0</lagom.version>
+    <lagom.version>1.4.3</lagom.version>
 </properties>
 ```
 

--- a/persistence-jdbc/core/src/main/resources/reference.conf
+++ b/persistence-jdbc/core/src/main/resources/reference.conf
@@ -33,11 +33,11 @@ db.default {
     # 5 * number of cores
     numThreads = 20
 
-    # number of threads
+    # same as number number of threads
     minConnections = 20
 
-    # 5 * number of threads
-    maxConnections = 100
+    # same as number number of threads
+    maxConnections = 20
 
     # if true, a Mbean for AsyncExecutor will be registered
     registerMbeans = false

--- a/persistence-jdbc/core/src/main/resources/reference.conf
+++ b/persistence-jdbc/core/src/main/resources/reference.conf
@@ -33,10 +33,10 @@ db.default {
     # 5 * number of cores
     numThreads = 20
 
-    # same as number number of threads
+    # same as number of threads
     minConnections = 20
 
-    # same as number number of threads
+    # same as number of threads
     maxConnections = 20
 
     # if true, a Mbean for AsyncExecutor will be registered

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val ScalaVersions = Seq("2.12.4", "2.11.12")
   val SbtScalaVersions = Seq("2.10.6", "2.12.4")
   val AkkaPersistenceCassandraVersion = "0.60"
-  val AkkaPersistenceJdbcVersion = "3.1.0"
+  val AkkaPersistenceJdbcVersion = "3.3.0"
   // Also be sure to update ScalaTestVersion in docs/build.sbt.
   val ScalaTestVersion = "3.0.4"
   val JacksonVersion = "2.8.11"
@@ -33,7 +33,7 @@ object Dependencies {
 
   val ScalaJava8CompatVersion = "0.8.0"
   val ScalaXmlVersion = "1.0.6"
-  val SlickVersion = "3.2.1"
+  val SlickVersion = "3.2.3"
   // Also be sure to update JUnitVersion in docs/build.sbt.
   val JUnitVersion = "4.11"
   // Also be sure to update JUnitInterfaceVersion in docs/build.sbt.


### PR DESCRIPTION
Not yet ready for merge. Awaiting `akka-persistence-jdbc` release.

To backport on 1.4.x only.

Fixes #1250