### PR TITLE
Document how to skip messages when consuming and publishing events

### DIFF
--- a/docs/manual/java/guide/broker/code/docs/javadsl/mb/AnotherServiceImpl.java
+++ b/docs/manual/java/guide/broker/code/docs/javadsl/mb/AnotherServiceImpl.java
@@ -2,7 +2,14 @@ package docs.javadsl.mb;
 
 import akka.Done;
 import akka.NotUsed;
+import akka.stream.FlowShape;
+import akka.stream.Graph;
+import akka.stream.UniformFanInShape;
+import akka.stream.UniformFanOutShape;
 import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.GraphDSL;
+import akka.stream.javadsl.Merge;
+import akka.stream.javadsl.Partition;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
 import com.lightbend.lagom.javadsl.api.broker.Message;
 import com.lightbend.lagom.javadsl.broker.kafka.KafkaMetadataKeys;
@@ -54,5 +61,20 @@ public class AnotherServiceImpl implements AnotherService {
             }));
         //#subscribe-to-topic-with-metadata
 
+    }
+
+    private void skipMessages() {
+        //#subscribe-to-topic-skip-messages
+        helloService.greetingsTopic()
+            .subscribe()
+            .atLeastOnce(Flow.fromFunction((GreetingMessage message) -> {
+                if (message.getMessage().equals("Kia ora")) {
+                    return doSomethingWithTheMessage(message);
+                } else {
+                    // Skip all messages where the message is not "Kia ora".
+                    return Done.getInstance();
+                }
+            }));
+        //#subscribe-to-topic-skip-messages
     }
 }

--- a/docs/manual/java/guide/broker/code/docs/javadsl/mb/FilteredServiceImpl.java
+++ b/docs/manual/java/guide/broker/code/docs/javadsl/mb/FilteredServiceImpl.java
@@ -1,0 +1,54 @@
+package docs.javadsl.mb;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.japi.Pair;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+
+import com.lightbend.lagom.javadsl.api.broker.Topic;
+import com.lightbend.lagom.javadsl.broker.TopicProducer;
+import com.lightbend.lagom.javadsl.persistence.Offset;
+import com.lightbend.lagom.javadsl.persistence.PersistentEntityRegistry;
+
+import docs.javadsl.mb.HelloEvent.AbstractGreetingMessageChanged;
+
+public class FilteredServiceImpl extends HelloServiceImpl {
+
+    private final PersistentEntityRegistry persistentEntityRegistry;
+
+    @Inject
+    public FilteredServiceImpl(PersistentEntityRegistry persistentEntityRegistry) {
+        super(persistentEntityRegistry);
+        this.persistentEntityRegistry = persistentEntityRegistry;
+    }
+
+    @Override
+    //#filter-events
+    public Topic<GreetingMessage> greetingsTopic() {
+        return TopicProducer.singleStreamWithOffset(offset -> {
+            return persistentEntityRegistry
+                .eventStream(HelloEventTag.INSTANCE, offset)
+                .mapConcat(this::filterHelloGreetings);
+        });
+    }
+
+    private List<Pair<GreetingMessage, Offset>> filterHelloGreetings(Pair<HelloEvent, Offset> pair) {
+        if (pair.first() instanceof AbstractGreetingMessageChanged) {
+            AbstractGreetingMessageChanged msg = (AbstractGreetingMessageChanged) pair.first();
+            // Only publish greetings where the message is "Hello".
+            if (msg.getMessage().equals("Hello")) {
+                return Arrays.asList(convertEvent(pair));
+            }
+        }
+        return Collections.emptyList();
+    }
+    //#filter-events
+
+    private Pair<GreetingMessage, Offset> convertEvent(Pair<HelloEvent, Offset> pair) {
+        return new Pair<>(new GreetingMessage(pair.first().getId(), pair.first().getMessage()), pair.second());
+    }
+}

--- a/docs/manual/scala/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/scala/guide/broker/MessageBrokerApi.md
@@ -32,7 +32,15 @@ Here's an example of publishing a single, non sharded event stream:
 
 @[implement-topic](code/docs/scaladsl/mb/HelloServiceImpl.scala)
 
-Note that the read-side event stream you passed to the topic producer is "activated" as soon as the service is started. That means all events persisted by your services will eventually be published to the connected topic. Also, you will generally want to map your domain events into some other type, so that other service won't be tightly coupled to another service's domain model events. In other words, domain model events are an implementation detail of the service, and should not be leaked.
+Note that the read-side event stream you passed to the topic producer is "activated" as soon as the service is started. That means that in the previous example, all events persisted by your services will eventually be published to the connected topic. Also, you will generally want to map your domain events into some other type, so that other service won't be tightly coupled to another service's domain model events. In other words, domain model events are an implementation detail of the service, and should not be leaked.
+
+### Filtering events
+
+You may not want all events persisted by your services to be published. If that is the case then you can filter the event stream:
+
+@[filter-events](code/docs/scaladsl/mb/FilteredServiceImpl.scala)
+
+When an event is filtered, the `TopicProducer` does not publish the event. It also does not advance the offset. If the `TopicProducer` restarts then it will resume from the last offset. If a large number of events are filtered then the last offset could be quite far behind, and so all those events will be reprocessed and filtered out again. You need to be aware that this may occur and keep the number of consecutively filtered elements relatively low and also minimise the time and resources required to perform the filtering.
 
 ### Offset storage
 
@@ -55,6 +63,14 @@ Your broker implementation may provide additional metadata with messages which y
 @[subscribe-to-topic-with-metadata](code/docs/scaladsl/mb/AnotherServiceImpl.scala)
 
 The [`messageKeyAsString`](api/com/lightbend/lagom/scaladsl/api/broker/Message.html#messageKeyAsString:String) method is provided as a convenience for accessing the message key. Other properties can be accessed using the [`get`](api/com/lightbend/lagom/scaladsl/api/broker/Message.html#get\(com.lightbend.lagom.scaladsl.api.broker.MetadataKey[Metadata]\):Metadata) method. A full list of the metadata keys available for Kafka can be found [here](api/com/lightbend/lagom/scaladsl/broker/kafka/KafkaMetadataKeys$.html).
+
+### Skipping messages
+
+You may only want to apply your logic to a subset of the messages that the topic publishes and skip the others. The `Flow` that is passed to [`Subscriber.atLeastOnce`](api/com/lightbend/lagom/scaladsl/api/broker/Subscriber.html#atLeastOnce\(flow:akka.stream.scaladsl.Flow[Payload,akka.Done,_]\):scala.concurrent.Future[akka.Done]) must emit exactly one `Done` element for each element that it receives. It must also emit them in the same order that the elements were received. This means that you must not use methods such as `filter` or `collect` on the `Flow` which would drop elements.
+
+The easiest way to achieve this is to use a total function which returns `Done` for the elements that should be skipped. For example:
+
+@[subscribe-to-topic-skip-messages](code/docs/scaladsl/mb/AnotherServiceImpl.scala)
 
 ## Polymorphic event streams
 

--- a/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/FilteredServiceImpl.scala
+++ b/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/FilteredServiceImpl.scala
@@ -1,0 +1,36 @@
+package docs.scaladsl.mb
+
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+import com.lightbend.lagom.scaladsl.persistence.{EventStreamElement, PersistentEntityRegistry}
+import com.lightbend.lagom.scaladsl.api.broker.Topic
+import com.lightbend.lagom.scaladsl.broker.TopicProducer
+import scala.collection.immutable
+
+/**
+  * Implementation of the HelloService.
+  */
+class FilteredServiceImpl(persistentEntityRegistry: PersistentEntityRegistry)
+  extends HelloServiceImpl(persistentEntityRegistry) {
+
+  //#filter-events
+  override def greetingsTopic(): Topic[GreetingMessage] =
+    TopicProducer.singleStreamWithOffset {
+      fromOffset =>
+        persistentEntityRegistry.eventStream(HelloEventTag.INSTANCE, fromOffset)
+          .mapConcat(filterEvents)
+    }
+
+  private def filterEvents(ev: EventStreamElement[HelloEvent]) = ev match {
+    // Only publish greetings where the message is "Hello".
+    case ev@EventStreamElement(_, GreetingMessageChanged("Hello"), offset) =>
+      immutable.Seq((convertEvent(ev), offset))
+    case _ => Nil
+  }
+  //#filter-events
+
+  private def convertEvent(helloEvent: EventStreamElement[HelloEvent]): GreetingMessage = {
+    helloEvent.event match {
+      case GreetingMessageChanged(msg) => GreetingMessage(msg)
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #1294 

## Purpose

- Adds section Message Broker API / Implementing a topic / Filtering events which describes by example how to filter events before they are published.
- Adds section Message Broker API / Subscribe to a topic / Skipping messages which shows two examples of how to skip messages. More importantly it describes what you need to watch out for when skipping messages.

## Background Context

There was some discussion on lagom/lagom.github.io/issues/129 about where the best place was to add this.

I was also discussing this in the [Akka forums](https://discuss.lightbend.com/t/splitting-messages-into-separate-streams-and-maintaining-order/517) to make sure we covered all the caveats and used the correct language. I'm not sure we have really nailed it yet. My goal was to try and keep it simple and yet still give enough information for users to avoid potential bugs.

## References

This relates to #1274 