### PR TITLE
Adds  1.4.0 on the mima chain of versions under inspection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -286,7 +286,8 @@ def scalaVersionSince = Map(
 def since10 = Seq("1.0.0") ++ since11
 def since11 = Seq("1.1.0") ++ since12
 def since12 = Seq("1.2.2") ++ since13
-def since13 = Seq("1.3.3")
+def since13 = Seq("1.3.3") ++ since14
+def since14 = Seq("1.4.0")
 
 val javadslProjects = Seq[Project](
   `api-javadsl`,


### PR DESCRIPTION
While reviewing https://github.com/lagom/lagom/pull/1292 I noticed an API change that should have broken the build. We forgot to include `1.4.0` on the mima checks in `master`.