### PR TITLE
Adds javadoc for BehaviorBuilder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -728,7 +728,10 @@ lazy val `persistence-javadsl` = (project in file("persistence/javadsl"))
 
       // writeReplace method should never have been public, and it only throws an exception, so nothing
       // lost by hiding it.
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntityRef.writeReplace")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntityRef.writeReplace"),
+
+      // See https://github.com/lagom/lagom/pull/1302 was a `protected final class` and became a `public sealed trait`
+      ProblemFilters.exclude[IncompatibleTemplateDefProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity$BehaviorBuilder")
     ),
     Dependencies.`persistence-javadsl`
   )

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
@@ -270,6 +270,8 @@ abstract class PersistentEntity[Command, Event, State] {
      * Register an event handler for a given event class. The `handler` function
      * is supposed to return the new state after applying the event to the current state.
      * Current state can be accessed with the `state` method of the `PersistentEntity`.
+     *
+     * Invoking this method a second time for the same `eventClass` will override the existing `handler`.
      */
     def setEventHandler[A <: Event](eventClass: Class[A], handler: JFunction[A, State]): Unit
 
@@ -278,6 +280,8 @@ abstract class PersistentEntity[Command, Event, State] {
      * The `handler` function  is supposed to return the new behavior after applying the
      * event to the current state. Current behavior can be accessed with the `behavior`
      * method of the `PersistentEntity`.
+     *
+     * Invoking this method a second time for the same `eventClass` will override the existing `handler`.
      */
     def setEventHandlerChangingBehavior[A <: Event](eventClass: Class[A], handler: JFunction[A, Behavior]): Unit
 
@@ -302,6 +306,8 @@ abstract class PersistentEntity[Command, Event, State] {
      *
      * The `handler` function may validate the incoming command and reject it by
      * sending a `reply` and returning `ctx.done()`.
+     *
+     * Invoking this method a second time for the same `commandClass` will override the existing `handler`.
      */
     def setCommandHandler[R, A <: Command with ReplyType[R]](
       commandClass: Class[A],
@@ -318,6 +324,8 @@ abstract class PersistentEntity[Command, Event, State] {
      *  handler does not persist events (i.e. it does not change state) but it may perform side
      *  effects, such as replying to the request. Replies are sent with the `reply` method of the
      *  context that is passed to the command handler function.
+     *
+     * Invoking this method a second time for the same `commandClass` will override the existing `handler`.
      */
     def setReadOnlyCommandHandler[R, A <: Command with ReplyType[R]](
       commandClass: Class[A],

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
@@ -259,7 +259,7 @@ abstract class PersistentEntity[Command, Event, State] {
 
   /**
    * Mutable builder that is used for defining the event and command handlers.
-   * Use [#build] to create the immutable [[Behavior]].
+   * Use [#build] to create the immutable [[PersistentEntity.Behavior]].
    */
   // In order to provide javadoc preventing isntantiantiation or extension this sealed trait is added
   // to hold docs and BehaviorBuilderImpl is made private to hold implementation


### PR DESCRIPTION
Fixes #1299

`BehaviorBuilder` only exists for Lagom's Java DSL but was implemented in `scala` as a protected class which made it unreachable for `javadoc` (with Lagom's javadoc settings).

This PR splits `BehaviorBuilder` into a pubic sealed trait `BehaviorBuilder` and  a `private[lagom] final class BehaviorBuilderImpl extends BehaviorBuilder` so javadocs are created and published.

I checked MiMa and there's no alert raised.