### PR TITLE
[WIP] Complementary event log feature

### DIFF
--- a/persistence-jdbc/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jdbc/EventLogEntityType.java
+++ b/persistence-jdbc/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jdbc/EventLogEntityType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence.jdbc;
+
+import akka.event.Logging;
+import com.lightbend.lagom.javadsl.persistence.AggregateEvent;
+
+/**
+ * Entity type descriptor for a complementary event log.
+ *
+ * @param <Event>
+ */
+public interface EventLogEntityType<Event extends AggregateEvent<Event>> {
+  /**
+   * The name of the entity type.
+   */
+  default String entityTypeName() {
+    return Logging.simpleName(this);
+  }
+}

--- a/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaEventLog.java
+++ b/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaEventLog.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.javadsl.persistence.jpa;
+
+import com.lightbend.lagom.javadsl.persistence.AggregateEvent;
+import com.lightbend.lagom.javadsl.persistence.jdbc.EventLogEntityType;
+
+import javax.persistence.EntityManager;
+
+/**
+ * Exposes the event log for direct insertion of events within an existing JPA transaction.
+ * <p>
+ * This is provided to allow standard CRUD operations to be complemented with an event log, allowing events to be
+ * published atomically with the CRUD operations, which then allows read sides and topics to be published with
+ * guaranteed eventual consistency.
+ * <p>
+ * This must not be used to publish events to persistent entities that have been registered with the
+ * {@link com.lightbend.lagom.javadsl.persistence.PersistentEntityRegistry}. Doing so will undermine the persistent
+ * entities and result in failures.
+ */
+public interface JpaEventLog {
+
+  /**
+   * Create an entity event log for the given entity type.
+   *
+   * @param entityType The entity type.
+   * @return An entity event log for the given type of entity.
+   */
+  <Event extends AggregateEvent<Event>> EntityEventLog<Event> eventLogFor(Class<? extends EventLogEntityType<Event>> entityType);
+
+  /**
+   * An event log for a specific entity type.
+   */
+  interface EntityEventLog<Event extends AggregateEvent<Event>> {
+
+    /**
+     * Emit an event for the entity with the given id in the transaction associated with the passed in entity manager.
+     *
+     * @param em The entity manager.
+     * @param entityId The id of the entity to emit an event for.
+     * @param event The event to emit.
+     */
+    void emit(EntityManager em, String entityId, Event event);
+  }
+}

--- a/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaPersistenceModule.java
+++ b/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaPersistenceModule.java
@@ -3,6 +3,7 @@
  */
 package com.lightbend.lagom.javadsl.persistence.jpa;
 
+import com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaEventLogImpl;
 import com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaReadSideImpl;
 import com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaSessionImpl;
 import play.api.Configuration;
@@ -16,7 +17,8 @@ public class JpaPersistenceModule extends Module {
     public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
         return seq(
                 bind(JpaSession.class).to(JpaSessionImpl.class),
-                bind(JpaReadSide.class).to(JpaReadSideImpl.class)
+                bind(JpaReadSide.class).to(JpaReadSideImpl.class),
+                bind(JpaEventLog.class).to(JpaEventLogImpl.class)
         );
     }
 }

--- a/persistence-jpa/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaEventLogImpl.scala
+++ b/persistence-jpa/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaEventLogImpl.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.javadsl.persistence.jpa
+
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.serialization.{ SerializationExtension, SerializerWithStringManifest }
+import javax.inject.Inject
+import javax.persistence.EntityManager
+import com.lightbend.lagom.internal.javadsl.persistence.jdbc.SlickProvider
+import com.lightbend.lagom.javadsl.persistence.{ AggregateEvent, AggregateEventShards, AggregateEventTag }
+import com.lightbend.lagom.javadsl.persistence.jdbc.EventLogEntityType
+import com.lightbend.lagom.javadsl.persistence.jpa.JpaEventLog
+import play.api.inject.Injector
+
+class JpaEventLogImpl @Inject() (slickProvider: SlickProvider, injector: Injector, system: ActorSystem) extends JpaEventLog {
+
+  private val serialization = SerializationExtension(system)
+
+  override def eventLogFor[Event <: AggregateEvent[Event]](entityType: Class[_ <: EventLogEntityType[Event]]): JpaEventLog.EntityEventLog[Event] = {
+    val entityTypeName: String = injector.instanceOf(entityType).entityTypeName
+    new EntityEventLogImpl[Event](entityTypeName)
+  }
+
+  import slickProvider.profile.api._
+
+  private class EntityEventLogImpl[Event <: AggregateEvent[Event]](entityTypeName: String) extends JpaEventLog.EntityEventLog[Event] {
+    override def emit(em: EntityManager, entityId: String, event: Event): Unit = {
+      val serializer = serialization.findSerializerFor(event)
+      val bytes = serializer.toBinary(event)
+      val manifest = serializer match {
+        case stringManifest: SerializerWithStringManifest =>
+          stringManifest.manifest(event)
+        case _ if serializer.includeManifest =>
+          event.getClass.getName
+        case _ => ""
+      }
+      val tag = event.aggregateTag match {
+        case single: AggregateEventTag[_]     => single.tag
+        case sharded: AggregateEventShards[_] => sharded.forEntityId(entityId).tag
+      }
+      val statements = insertEvent(entityTypeName + entityId, tag, bytes, serializer.identifier, manifest).statements
+      statements.foreach { statement =>
+        // Most parameters will have already been directly substituted by Slick, the only one that hasn't is the byte
+        // array
+        em.createNativeQuery(statement)
+          .setParameter(1, bytes)
+          .executeUpdate()
+      }
+    }
+  }
+
+  private def maxSequenceNumber(fullEntityId: String): Rep[Long] = {
+    slickProvider.journalTables.JournalTable
+      .filter(_.persistenceId === fullEntityId)
+      .map(_.sequenceNumber)
+      .max
+      .ifNull(0L)
+  }
+
+  private def nextSequenceNumber(fullEntityId: String): Rep[Long] = {
+    // If two insert operations happen at the same time, they'll get the same
+    // next sequence number. That's ok, because the sequence number is part of
+    // the primary key, so one of them will fail. I don't think there is any
+    // other way to handle it other than failing though, this operation is
+    // likely to be combined with some other CRUD operation on the schema, if
+    // we're unable to insert the event, we need that CRUD operation to fail
+    // otherwise we can't guarantee the atomicity of the CRUD operation and the
+    // event insert.
+    maxSequenceNumber(fullEntityId) + 1L
+  }
+
+  private def insertEvent(fullEntityId: String, tag: String, serializedEvent: Array[Byte], serId: Int, manifest: String) = {
+    // This compiles to a single statement, along the lines of:
+    // insert into journal (persistenceId, sequenceNumber, message)
+    //   select <id>, coalesce(max(sequenceNumber), 0), <bytes>
+    //   from journal where persistenceId = <id>
+    slickProvider.journalTables.JournalTable
+      .map(t => (t.persistenceId, t.sequenceNumber, t.deleted, t.tags, t.event, t.eventManifest, t.serId, t.serManifest, t.writerUuid))
+      .forceInsertExpr((fullEntityId, nextSequenceNumber(fullEntityId), false, Some(tag), Some(serializedEvent), Some(""), Some(serId),
+        Some(manifest), Some(UUID.randomUUID().toString)))
+  }
+}

--- a/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaEventLogImplSpec.scala
+++ b/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaEventLogImplSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package com.lightbend.lagom.internal.javadsl.persistence.jpa
+
+import com.google.inject.Guice
+import com.lightbend.lagom.javadsl.persistence.{ AggregateEvent, AggregateEventTag }
+import com.lightbend.lagom.javadsl.persistence.jdbc.EventLogEntityType
+import play.api.inject.guice.GuiceInjector
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class JpaEventLogImplSpec extends JpaPersistenceSpec {
+
+  private lazy val injector = Guice.createInjector()
+  private lazy val jpaEventLog = new JpaEventLogImpl(slick, new GuiceInjector(injector), system)
+
+  "blah blah" should {
+    "blah blah blah" in {
+      import slick.profile.api._
+      jpa.withTransaction { em =>
+        jpaEventLog.eventLogFor(classOf[MyEntity])
+          .emit(em, "foo", MyActualEvent())
+      }.toCompletableFuture.get()
+      System.out.println(Await.result(slick.db.run(slick.journalTables.JournalTable.result), 5.seconds))
+      jpa.withTransaction { em =>
+        jpaEventLog.eventLogFor(classOf[MyEntity])
+          .emit(em, "foo", MyActualEvent())
+      }.toCompletableFuture.get()
+      System.out.println(Await.result(slick.db.run(slick.journalTables.JournalTable.result), 5.seconds))
+      jpa.withTransaction { em =>
+        jpaEventLog.eventLogFor(classOf[MyEntity])
+          .emit(em, "foo", MyActualEvent())
+      }.toCompletableFuture.get()
+      System.out.println(Await.result(slick.db.run(slick.journalTables.JournalTable.result), 5.seconds))
+    }
+  }
+}
+
+trait MyEvent extends AggregateEvent[MyEvent] {
+  override def aggregateTag = AggregateEventTag.of(classOf[MyEvent])
+}
+case class MyActualEvent() extends MyEvent
+class MyEntity extends EventLogEntityType[MyEvent]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,7 +20,7 @@ object Dependencies {
   val ScalaVersions = Seq("2.12.4", "2.11.12")
   val SbtScalaVersions = Seq("2.10.6", "2.12.4")
   val AkkaPersistenceCassandraVersion = "0.60"
-  val AkkaPersistenceJdbcVersion = "3.3.0"
+  val AkkaPersistenceJdbcVersion = "4.0.0-beta-jroper-1"
   // Also be sure to update ScalaTestVersion in docs/build.sbt.
   val ScalaTestVersion = "3.0.4"
   val JacksonVersion = "2.8.11"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.0-SNAPSHOT"
+version in ThisBuild := "1.5.0"


### PR DESCRIPTION
This shows how a complementary event log feature could be offered. It
writes events directly to the akka-persistence-jdbc event log, but in a
user supplied transaction, allowing them to be consumed by Lagom's
existing read side processors and topic publishers.

So far, only the minimum for supporting this in JPA has been
implemented.

Furthermore, these changes are dependent on
https://github.com/dnvriend/akka-persistence-jdbc/pull/180, the primary
reason being that without that change, Akka persistence JDBC reads the
sequence number, which this tries to generate in a single database call
by doing a subselect, from a serialized form of an Akka class, rather
than from the table row.