### PR TITLE
Remove redundant code from Kafka specs

### DIFF
--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -190,9 +190,6 @@ class JavadslKafkaApiSpec extends WordSpecLike
       val initialOffset = offsetDao.loadedOffset
       initialOffset shouldBe NoOffset
 
-      // Fake setting an offset to simulate a topic that has been restarted
-      offsetDao.saveOffset(Sequence(1))
-
       // Put some messages in the stream
       test3EventJournal.append("firstMessage")
       test3EventJournal.append("secondMessage")

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -179,9 +179,6 @@ class ScaladslKafkaApiSpec extends WordSpecLike
       val initialOffset = offsetDao.loadedOffset
       initialOffset shouldBe NoOffset
 
-      // Fake setting an offset to simulate a topic that has been restarted
-      offsetDao.saveOffset(Sequence(1))
-
       // Put some messages in the stream
       test3EventJournal.append("firstMessage")
       test3EventJournal.append("secondMessage")


### PR DESCRIPTION
These specs were saving an offset to the offset store, but this occurred after the test application had already started the topic producer, so this stored offset was never accessed.

Thanks to @idoshamun for raising this in https://discuss.lightbend.com/t/kafka-scaladsl-possible-test-fix/717