### PR TITLE
minor fixes to kafka message broker tests

### DIFF
--- a/service/javadsl/kafka/server/src/test/resources/application.conf
+++ b/service/javadsl/kafka/server/src/test/resources/application.conf
@@ -1,12 +1,12 @@
 # Disabled batching of messages on the consumer
-lagom.broker.kafka.consumer.batching-size = 1
+lagom.broker.kafka.client.consumer.batching-size = 1
 
 akka.loggers = [akka.testkit.TestEventListener]
 
-lagom.broker.kafka.producer.failure-exponential-backoff {
+lagom.broker.kafka.client.producer.failure-exponential-backoff {
   min = 100 milliseconds
   max = 200 milliseconds
 }
 
 #akka.kafka.consumer.wakeup-timeout = 3s
-akka.kafka.consumer.max-wakeups = 20
+akka.kafka.client.consumer.max-wakeups = 20

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -270,6 +270,7 @@ class JavadslKafkaApiSpec extends WordSpecLike
       val latch = new CountDownLatch(batchSize)
       testService.test6Topic()
         .subscribe()
+        .withGroupId("testservice6")
         .atLeastOnce {
           Flow[String].grouped(batchSize).mapConcat { messages =>
             messages.map { _ =>

--- a/service/scaladsl/kafka/server/src/test/resources/application.conf
+++ b/service/scaladsl/kafka/server/src/test/resources/application.conf
@@ -1,10 +1,10 @@
 # Disabled batching of messages on the consumer
-lagom.broker.kafka.consumer.batching-size = 1
+lagom.broker.kafka.client.consumer.batching-size = 1
 
-lagom.broker.kafka.producer.failure-exponential-backoff {
+lagom.broker.kafka.client.producer.failure-exponential-backoff {
   min = 100 milliseconds
   max = 200 milliseconds
 }
 
 #akka.kafka.consumer.wakeup-timeout = 3s
-akka.kafka.consumer.max-wakeups = 20
+akka.kafka.client.consumer.max-wakeups = 20

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -258,6 +258,7 @@ class ScaladslKafkaApiSpec extends WordSpecLike
       val latch = new CountDownLatch(batchSize)
       testService.test6Topic
         .subscribe
+        .withGroupId("testservice6")
         .atLeastOnce {
           Flow[String].grouped(batchSize).mapConcat { messages =>
             messages.map { _ =>


### PR DESCRIPTION
## Purpose

While developing the Google Pub/Sub Message Broker, I noticed some bugs and typos in the Kafka implementation tests:
* Fix config keys (`client` was missing).
* Add group id to some of the tests as they were missed.