### PR TITLE
Sample changes to implement batching for read side offset in jpa

### DIFF
--- a/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImpl.java
+++ b/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImpl.java
@@ -27,10 +27,11 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import static scala.collection.JavaConversions.asJavaIterable;
 
@@ -88,6 +89,7 @@ public class JpaReadSideImpl implements JpaReadSide {
 
         private volatile AggregateEventTag<Event> tag;
         private volatile SlickOffsetDao offsetDao;
+        private BatchedOffsetUpdater batchUpdateOffsetUpdater;
 
         private JpaReadSideHandler(
                 String readSideId,
@@ -98,6 +100,7 @@ public class JpaReadSideImpl implements JpaReadSide {
             this.globalPrepare = globalPrepare;
             this.prepare = prepare;
             this.eventHandlers = eventHandlers;
+            batchUpdateOffsetUpdater = new BatchedOffsetUpdater();
         }
 
         @Override
@@ -127,6 +130,8 @@ public class JpaReadSideImpl implements JpaReadSide {
 
         @Override
         public Flow<Pair<Event, Offset>, Done, ?> handle() {
+            //This parameter shall be taken from configuration and will be global to this class (Not local to this method)
+	    boolean isBatchUpdateEnabled = true;
             return Flow.<Pair<Event, Offset>>create().mapAsync(1, eventAndOffset -> {
                 Event event = eventAndOffset.first();
                 Offset offset = eventAndOffset.second();
@@ -134,7 +139,7 @@ public class JpaReadSideImpl implements JpaReadSide {
                 @SuppressWarnings("unchecked") BiConsumer<EntityManager, Event> eventHandler =
                         (BiConsumer<EntityManager, Event>) eventHandlers.get(eventClass);
 
-                return jpa.withTransaction(entityManager -> {
+                CompletionStage<Done> result = jpa.withTransaction(entityManager -> {
                     if (log.isDebugEnabled())
                         log.debug("Starting handler for event {} at offset {} in JpaReadSideHandler: {}",
                             eventClass.getName(), offset, readSideId);
@@ -145,12 +150,22 @@ public class JpaReadSideImpl implements JpaReadSide {
                             log.debug("Unhandled event {} at offset {} in JpaReadSideHandler: {}",
                                 eventClass.getName(), offset, readSideId);
                     }
-                    updateOffset(entityManager, offset);
+                    if(!isBatchUpdateEnabled){
+			updateOffset(entityManager, offset);
+		    }
                     if (log.isDebugEnabled())
                         log.debug("Completed handler for event {} at offset {} in JpaReadSideHandler: {}",
                             eventClass.getName(), offset, readSideId);
                     return Done.getInstance();
                 });
+                if(isBatchUpdateEnabled){
+		        CompletionStage<Done> offsetUpdateResult = result.thenApply( r -> {
+			        batchUpdateOffsetUpdater.checkAndUpdateOffset(offset);
+			        return Done.getInstance();
+		        });
+		        return offsetUpdateResult;
+		}
+		return result;
             });
         }
 
@@ -227,5 +242,51 @@ public class JpaReadSideImpl implements JpaReadSide {
                     .setParameter(3, sequenceOffset)
                     .setParameter(4, timeUuidOffset);
         }
+        
+        private class BatchedOffsetUpdater {
+
+		private Long updateOffsetRequestCount = 0l;
+		private Long lastupdatedOffsetRequestCount = 0l;
+		private Offset offsetToBeUpdated = null;
+		private Object lock = new Object();
+
+		private Timer offsetUpdaterTimer = new Timer("offset-update-timer", true);
+
+		BatchedOffsetUpdater() {
+			offsetUpdaterTimer.schedule(new UpdateOffsetTask(), 5 * 1000);
+		}
+
+		public void checkAndUpdateOffset(Offset offset) {
+			synchronized (lock) {
+				updateOffsetRequestCount++;
+				if (updateOffsetRequestCount - lastupdatedOffsetRequestCount > 6) {
+					batchUpdateOffset(offset);
+				} else {
+					offsetToBeUpdated = offset;
+				}
+			}
+		}
+
+		private void batchUpdateOffset(Offset offset) {
+			jpa.withTransaction(entityManager -> {
+				updateOffset(entityManager, offset);
+				offsetToBeUpdated = null;
+				lastupdatedOffsetRequestCount = updateOffsetRequestCount;
+				return Done.getInstance();
+			});
+		}
+
+		class UpdateOffsetTask extends TimerTask {
+
+			public void run() {
+				synchronized (lock) {
+					if (offsetToBeUpdated != null) {
+						batchUpdateOffset(offsetToBeUpdated);
+					}
+					offsetUpdaterTimer.schedule(new UpdateOffsetTask(), 5 * 1000);
+				}
+			}
+		}
+	}
     }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes
Partial fixes for improvement "Offset tracking grouping #667". The fixes have been done only on jpa. These changes are not meant to be merged but only to review my approach. If the approach is okay i will make the necessary changes to cassandra and jdbc as well as their scaladsl impl.  

Fixes #667

## Purpose
Only for approach review of #667

What does this PR do?
The offset tracking of Read side Impl JPA has been changed to batch mode based on some configuration. Since the readside is no more exactly once there is no need to update the offset and handler in same transaction. The offset will be updated after every N number of updation.(N is taken from configuration), or after every 0.5 seconds.



## Background Context

Why did you take this approach?


## References

Are there any relevant issues / PRs / mailing lists discussions?
https://github.com/lagom/lagom/issues/667
