### PR TITLE
Documents usage of sbt 1.x

### DIFF
--- a/docs/manual/common/guide/build/JVMMemoryOnDev.md
+++ b/docs/manual/common/guide/build/JVMMemoryOnDev.md
@@ -25,7 +25,7 @@ You can start sbt with extra memory using `SBT_OPTS` environment variable.
 $ SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" sbt
 ```
 
-Since version 0.13.13, sbt lets you list the JVM options you need to run your project on a file named `.jvmopts` in the root of your project.
+sbt lets you list the JVM options you need to run your project on a file named `.jvmopts` in the root of your project.
 
 ```
 $ cat .jvmopts

--- a/docs/manual/java/gettingstarted/GettingStartedSbt.md
+++ b/docs/manual/java/gettingstarted/GettingStartedSbt.md
@@ -21,7 +21,7 @@ To create your project, follow these steps:
 
 1. Enter the following command to invoke `sbt new` using the Lagom Giter8 template:
    ```
-   sbt -Dsbt.version=0.13.16 new https://github.com/lagom/lagom-java.g8
+   sbt new lagom/lagom-java.g8
    ```
 1. The sbt Lagom template prompts for the following parameters. Press `Enter` to accept the defaults or specify your own values:
 

--- a/docs/manual/java/gettingstarted/JavaPrereqs.md
+++ b/docs/manual/java/gettingstarted/JavaPrereqs.md
@@ -21,17 +21,22 @@ java -version
 javac -version
 
 ```
-For `java`, the console should respond with the major version number of 1.8, the following shows an example of what you would see in the shell with a 1.8.0_74-b02 build:
+For `java`, the console should respond with the major version number of 1.8, the following shows an example of what you would see in the shell with a 1.8.0_162-b12 build:
+
 ```
-java version "1.8.0_74"
-Java(TM) SE Runtime Environment (build 1.8.0_74-b02)
-Java HotSpot(TM) 64-Bit Server VM (build 25.74-b02, mixed mode)
+java version "1.8.0_162"
+Java(TM) SE Runtime Environment (build 1.8.0_162-b12)
+Java HotSpot(TM) 64-Bit Server VM (build 25.162-b12, mixed mode)
 ```
+
 for `javac`, the console should respond with something similar to:
+
 ```
-javac 1.8.0_74
+javac 1.8.0_162
 ```
+
 If you have the correct JDK and the console cannot find `java` or `javac`, search the web for information about setting environment variables on your system. For example, the following pages provide tips for configuring Java:
+
 * [On systems running Linux](https://stackoverflow.com/questions/33860560/how-to-set-java-environment-variables-using-shell-script)
 * [On MacOS](http://osxdaily.com/2015/07/28/set-enviornment-variables-mac-os-x/)
 * [On Windows systems](https://stackoverflow.com/questions/1672281/environment-variables-for-java-installation)
@@ -46,23 +51,22 @@ To check the Maven version from a command line, enter:
 
 `mvn -version` 
 
-
-
 To install Maven, see the official [Maven installation page](https://maven.apache.org/install.html).
 
 ## sbt
 
-[sbt](http://www.scala-sbt.org) is a build tool for Java and Scala. Lagom requires sbt 0.13.5 or higher. To create new projects using Lagom-supplied templates, use sbt 0.13.13 or higher, which contains the sbt new command.
+[sbt](http://www.scala-sbt.org) is a build tool for Java and Scala. Lagom recommends using sbt 1.0 or higher.
 
-In a console, check your version using the `sbt sbt-version`command:
+In a console, check your version using the `sbt sbtVersion`command:
 
 ```
-sbt sbt-version
+sbt sbtVersion
 ```
 The system should respond with something like the following:
+
 ```
 [info] Set current project to example (in build file:/home/example/)
-[info] 0.13.13
+[info] sbt server started at local:///home/alice/
 ```
 If you do not have the right version of sbt, download it from [the scala-sbt website](http://www.scala-sbt.org/download.html). The [documentation](http://www.scala-sbt.org/release/docs/Setup.html) contains installation instructions.
 

--- a/docs/manual/java/guide/build/LagomBuild.md
+++ b/docs/manual/java/guide/build/LagomBuild.md
@@ -200,7 +200,7 @@ A Lagom build must tell sbt to use the Lagom plugin.  This is done by creating a
 
 The plugin provides all the necessary support for building, running, and deploying your Lagom application.
 
-For more information on sbt plugins, see the sbt documentation on [Using Plugins](http://www.scala-sbt.org/0.13/docs/Using-Plugins.html).
+For more information on sbt plugins, see the sbt documentation on [Using Plugins](https://www.scala-sbt.org/1.x/docs/Using-Plugins.html).
 
 ### Defining a build
 
@@ -226,7 +226,7 @@ The first line defines the project itself, by declaring a `lazy val` of type `Pr
 
 The project is defined to be the `hello-api` directory, as indicated by `project in file("hello-api")`.  This means all the source code for this project will be under that directory, laid out according to the usual Maven structure (which sbt adopts as well).  So our main Java sources go in `hello-api/src/main/java`.
 
-More settings follow, in which we set the project version and add a library dependency.  The Lagom plugin provides some predefined values to make the Lagom libraries easy to add. In this case, we're using `lagomJavadslApi`. (You can add other dependencies using the usual sbt shorthand for specifying the library's `groupId`, `artifactId` and `version`; see [Library dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html) in the sbt documentation.)
+More settings follow, in which we set the project version and add a library dependency.  The Lagom plugin provides some predefined values to make the Lagom libraries easy to add. In this case, we're using `lagomJavadslApi`. (You can add other dependencies using the usual sbt shorthand for specifying the library's `groupId`, `artifactId` and `version`; see [Library dependencies](https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html) in the sbt documentation.)
 
 Now we need to define the implementation project:
 

--- a/docs/manual/java/guide/build/MultipleBuilds.md
+++ b/docs/manual/java/guide/build/MultipleBuilds.md
@@ -12,7 +12,7 @@ Even with multiple builds, you will still often want to run your services togeth
 
 Suppose you have a `hello` service that you want to publish and import into another build.  You can publish this to your local repository by running `mvn install` if using Maven, or by running `publishLocal` if using sbt.  This is the simplest way to publish a service, however it means every developer that wants to run a build that imports the service will need publish it to their own repository themselves, and they'll need to do that for each version that they want to import.
 
-More commonly, many developers can share a single Maven or Ivy repository that they can publish and pull artifacts from.  There are a few options for how to do this, if you're happy to use a hosted repository, [Bintray](https://bintray.com) is a good option, if you want to run the repository locally, [Artifactory](https://www.jfrog.com/open-source/) or [Nexus](https://www.sonatype.com/products-overview) are common solutions.  For information on how to configure these in sbt, see [how to publish artifacts](http://www.scala-sbt.org/0.13/docs/Publishing.html) .
+More commonly, many developers can share a single Maven or Ivy repository that they can publish and pull artifacts from.  There are a few options for how to do this, if you're happy to use a hosted repository, [Bintray](https://bintray.com) is a good option, if you want to run the repository locally, [Artifactory](https://www.jfrog.com/open-source/) or [Nexus](https://www.sonatype.com/products-overview) are common solutions.  For information on how to configure these in sbt, see [how to publish artifacts](https://www.scala-sbt.org/1.x/docs/Publishing.html).
 
 ### Publishing to Bintray
 

--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -19,13 +19,19 @@ The version of Lagom can be updated by editing the `project/plugins.sbt` file, a
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 ```
 
-Lagom 1.4.0 also requires Sbt 0.13.16 or later. If your existing project is using a previous version of Sbt, you will need to upgrade it by editing the `project/build.properties` file. For example:
+Lagom 1.4.0 also requires Sbt 0.13.16 or later (recommended 1.0+). If your existing project is using a previous version of Sbt, you will need to upgrade it by editing the `project/build.properties` file. For example:
 
 ```
 sbt.version=0.13.16
 ```
 
+We recommend you migrate your projects to Sbt 1.x by editing the `project/build.properties` file. For example:
 
+```
+sbt.version=1.1.4
+```
+
+We also recommend you [upgrade](https://www.scala-sbt.org/download.html) your `sbt` launcher.
 
 ## Scala 2.12 support
 

--- a/docs/manual/scala/gettingstarted/Installation.md
+++ b/docs/manual/scala/gettingstarted/Installation.md
@@ -15,7 +15,7 @@ We also suggest that you start from the command line. After using the template t
 Before trying the template, make sure that your environment conforms to Lagom prerequisites:
 
 * Java Development Kit (JDK), version 8 or higher. 
-* sbt 0.13.5 or higher (To create new projects using Lagom-supplied templates, use sbt 0.13.13 or higher, which contains the sbt new command.)
+* sbt 1.0 or higher 
 * Internet access (If using a proxy, verify that an HTTP_PROXY environment variable points to the correct location)
 
 For more details on verifying or installing prerequisites see the following sections:
@@ -35,16 +35,19 @@ You can check whether you have JDK 8 by running `java -version` and `javac -vers
 The `java -version` command should return messages similar to the following:
 
 ```
-java version "1.8.0_74"
-Java(TM) SE Runtime Environment (build 1.8.0_74-b02)
-Java HotSpot(TM) 64-Bit Server VM (build 25.74-b02, mixed mode)
+java version "1.8.0_162"
+Java(TM) SE Runtime Environment (build 1.8.0_162-b12)
+Java HotSpot(TM) 64-Bit Server VM (build 25.162-b12, mixed mode)
 ```
+
 The `javac -version` command should return a message similar to:
 
 ```
-javac 1.8.0_74
+javac 1.8.0_162
 ```
+
 If you have the correct JDK and the console cannot find `java` or `javac`, search the web for information about setting environment variables on your system. For example, the following pages provide tips for configuring Java:
+
 * [On systems running Linux](https://stackoverflow.com/questions/33860560/how-to-set-java-environment-variables-using-shell-script)
 * [On MacOS](http://osxdaily.com/2015/07/28/set-enviornment-variables-mac-os-x/)
 * [On Windows systems](https://stackoverflow.com/questions/1672281/environment-variables-for-java-installation)
@@ -53,15 +56,15 @@ If you don't have the correct version, you can get it from the [Oracle Java down
 
 ## sbt
 
-Lagom requires at least sbt 0.13.5, but if you want to create new projects using Lagom's supplied templates, you'll need at least sbt 0.13.13, which contains the sbt `new` command. (You'll need 0.13.13 to follow the steps in this getting started documentation.)
+Lagom requires recommends sbt 1.0 or higher.
 
 sbt can be downloaded from [here](http://www.scala-sbt.org/download.html), while instructions for installing it can be found [here](http://www.scala-sbt.org/release/docs/Setup.html)
 
-To check which version of sbt you are using, run `sbt sbt-version` from the command line. The console messages should look similar to the following :
+To check which version of sbt you are using, run `sbt sbtVersion` from the command line. The console messages should look similar to the following :
 
 ```
-[info] Set current project to example (in build file:/home/example/)
-[info] 0.13.13
+[info] Set current project to example (in build file:/home/alice/)
+[info] sbt server started at local:///home/alice/
 ```
 
 ## Proxy setup

--- a/docs/manual/scala/gettingstarted/IntroGetStarted.md
+++ b/docs/manual/scala/gettingstarted/IntroGetStarted.md
@@ -17,8 +17,9 @@ To create your project, follow these steps:
 1. Open a console and change into the directory you selected for your project.
 
 1. Enter the following command:
+
    ```
-   sbt -Dsbt.version=0.13.16 new https://github.com/lagom/lagom-scala.g8
+   sbt new https://github.com/lagom/lagom-scala.g8
    ```
 
 1. The template prompts for the following parameters. Press `Enter` to accept the defaults or specify your own values:

--- a/docs/manual/scala/guide/build/LagomBuild.md
+++ b/docs/manual/scala/guide/build/LagomBuild.md
@@ -30,7 +30,7 @@ A Lagom build must tell sbt to use the Lagom plugin.  This is done by creating a
 
 The plugin provides all the necessary support for building, running, and deploying your Lagom application.
 
-For more information on sbt plugins, see the sbt documentation on [Using Plugins](http://www.scala-sbt.org/0.13/docs/Using-Plugins.html).
+For more information on sbt plugins, see the sbt documentation on [Using Plugins](https://www.scala-sbt.org/1.x/docs/Using-Plugins.html).
 
 ### Defining a build
 
@@ -56,7 +56,7 @@ The first line defines the project itself, by declaring a `lazy val` of type `Pr
 
 The project is defined to be the `hello-api` directory, as indicated by `project in file("hello-api")`.  This means all the source code for this project will be under that directory, laid out according to the usual Maven structure (which sbt adopts as well).  So our main Scala sources go in `hello-api/src/main/scala`.
 
-More settings follow, in which we set the project version and add a library dependency.  The Lagom plugin provides some predefined values to make the Lagom libraries easy to add. In this case, we're using `lagomScaladslApi`. (You can add other dependencies using the usual sbt shorthand for specifying the library's `groupId`, `artifactId` and `version`; see [Library dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html) in the sbt documentation.)
+More settings follow, in which we set the project version and add a library dependency.  The Lagom plugin provides some predefined values to make the Lagom libraries easy to add. In this case, we're using `lagomScaladslApi`. (You can add other dependencies using the usual sbt shorthand for specifying the library's `groupId`, `artifactId` and `version`; see [Library dependencies](https://www.scala-sbt.org/1.x/docs/Library-Dependencies.html) in the sbt documentation.)
 
 Now we need to define the implementation project:
 

--- a/docs/manual/scala/guide/build/MultipleBuilds.md
+++ b/docs/manual/scala/guide/build/MultipleBuilds.md
@@ -12,7 +12,7 @@ Even with multiple builds, you will still often want to run your services togeth
 
 Suppose you have a `hello` service that you want to publish and import into another build.  You can publish this to your local repository by running `publishLocal` from sbt.  This is the simplest way to publish a service, however it means every developer that wants to run a build that imports the service will need publish it to their own repository themselves, and they'll need to do that for each version that they want to import.
 
-More commonly, many developers can share a single Maven or Ivy repository that they can publish and pull artifacts from.  There are a few options for how to do this, if you're happy to use a hosted repository, [Bintray](https://bintray.com) is a good option, if you want to run the repository locally, [Artifactory](https://www.jfrog.com/open-source/) or [Nexus](https://www.sonatype.com/products-overview) are common solutions.  For information on how to configure these in sbt, see [how to publish artifacts](http://www.scala-sbt.org/0.13/docs/Publishing.html) .
+More commonly, many developers can share a single Maven or Ivy repository that they can publish and pull artifacts from.  There are a few options for how to do this, if you're happy to use a hosted repository, [Bintray](https://bintray.com) is a good option, if you want to run the repository locally, [Artifactory](https://www.jfrog.com/open-source/) or [Nexus](https://www.sonatype.com/products-overview) are common solutions.  For information on how to configure these in sbt, see [how to publish artifacts](https://www.scala-sbt.org/1.x/docs/Publishing.html) .
 
 ### Publishing to Bintray
 

--- a/docs/manual/scala/releases/Migration14.md
+++ b/docs/manual/scala/releases/Migration14.md
@@ -13,11 +13,20 @@ The version of Lagom can be updated by editing the `project/plugins.sbt` file, a
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.0")
 ```
 
-Lagom 1.4.0 also requires Sbt 0.13.16 or later. If your existing project is using a previous version of Sbt, you will need to upgrade it by editing the `project/build.properties` file. For example:
+Lagom 1.4.0 also requires Sbt 0.13.16 or later (recommended 1.0+). If your existing project is using a previous version of Sbt, you will need to upgrade it by editing the `project/build.properties` file. For example:
 
 ```
 sbt.version=0.13.16
 ```
+
+We recommend you migrate your projects to Sbt 1.x by editing the `project/build.properties` file. For example:
+
+```
+sbt.version=1.1.4
+```
+
+We also recommend you [upgrade](https://www.scala-sbt.org/download.html) your `sbt` launcher.
+
 
 
 ## Scala 2.12 support


### PR DESCRIPTION
Since Lagom 1.4.x it's possible to create lagom projetcs using sbt 1.x. This was long overdue undocumented.