### PR TITLE
Update Scala 2.12 to 2.12.6

### DIFF
--- a/bin/test-2.12
+++ b/bin/test-2.12
@@ -2,4 +2,4 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-runSbtNoisy "+++2.12.4 test"
+runSbtNoisy "+++2.12.6 test"

--- a/bin/test-sbt-1.0
+++ b/bin/test-sbt-1.0
@@ -2,7 +2,7 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-SCALA_VERSION="2.12.4"
+SCALA_VERSION="2.12.6"
 
 runSbt +publishLocal
 runSbtNoisy "++${SCALA_VERSION} scripted"

--- a/build.sbt
+++ b/build.sbt
@@ -1017,6 +1017,7 @@ lazy val `dev-environment` = (project in file("dev"))
     publish := {},
     PgpKeys.publishSigned := {}
   )
+  .disablePlugins(Unidoc)
 
 lazy val `reloadable-server` = (project in file("dev") / "reloadable-server")
   .settings(runtimeLibCommon: _*)
@@ -1039,6 +1040,7 @@ lazy val `build-tool-support` = (project in file("dev") / "build-tool-support")
     }.taskValue,
     Dependencies.`build-tool-support`
   )
+  .disablePlugins(Unidoc)
 
 // This is almost the same as `build-tool-support`, but targeting sbt
 // while `build-tool-support` targets Maven and possibly other build
@@ -1059,6 +1061,7 @@ lazy val `sbt-build-tool-support` = (project in file("dev") / "build-tool-suppor
     Dependencies.`build-tool-support`,
     target := target.value / "lagom-sbt-build-tool-support"
   )
+  .disablePlugins(Unidoc)
 
 lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
   .settings(common: _*)
@@ -1093,6 +1096,7 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
     },
     publishMavenStyle := isSnapshot.value
   ).dependsOn(`sbt-build-tool-support`)
+  .disablePlugins(Unidoc)
 
 lazy val `maven-plugin` = (project in file("dev") / "maven-plugin")
   .enablePlugins(lagom.SbtMavenPlugin)
@@ -1172,7 +1176,7 @@ def archetypeProject(archetypeName: String) =
       },
       // Don't force copyright headers in Maven archetypes
       HeaderKey.excludes := Seq("*")
-    ).disablePlugins(EclipsePlugin)
+    ).disablePlugins(EclipsePlugin, Unidoc)
 
 lazy val `maven-java-archetype` = archetypeProject("java")
 lazy val `maven-dependencies` = (project in file("dev") / "maven-dependencies")
@@ -1264,6 +1268,7 @@ lazy val `sbt-scripted-tools` = (project in file("dev") / "sbt-scripted-tools")
     scalaVersion := Dependencies.SbtScalaVersions.head,
     sbtVersion in pluginCrossBuild := defineSbtVersion(scalaBinaryVersion.value)
   ).dependsOn(`sbt-plugin`)
+  .disablePlugins(Unidoc)
 
 // This project also get aggregated, it is only executed by the sbt-plugin scripted dependencies
 lazy val `sbt-scripted-library` = (project in file("dev") / "sbt-scripted-library")

--- a/build.sbt
+++ b/build.sbt
@@ -369,7 +369,7 @@ lazy val root = (project in file("."))
   .settings(UnidocRoot.settings(javadslProjects.map(Project.projectToRef), scaladslProjects.map(Project.projectToRef)): _*)
   .aggregate((javadslProjects ++ scaladslProjects ++ coreProjects ++ otherProjects ++ sbtScriptedProjects).map(Project.projectToRef): _*)
 
-def RuntimeLibPlugins = AutomateHeaderPlugin && Sonatype && PluginsAccessor.exclude(BintrayPlugin)
+def RuntimeLibPlugins = AutomateHeaderPlugin && Sonatype && PluginsAccessor.exclude(BintrayPlugin) && Unidoc
 def SbtPluginPlugins = AutomateHeaderPlugin && BintrayPlugin && PluginsAccessor.exclude(Sonatype)
 
 lazy val api = (project in file("service/core/api"))
@@ -1017,7 +1017,6 @@ lazy val `dev-environment` = (project in file("dev"))
     publish := {},
     PgpKeys.publishSigned := {}
   )
-  .disablePlugins(Unidoc)
 
 lazy val `reloadable-server` = (project in file("dev") / "reloadable-server")
   .settings(runtimeLibCommon: _*)
@@ -1040,7 +1039,6 @@ lazy val `build-tool-support` = (project in file("dev") / "build-tool-support")
     }.taskValue,
     Dependencies.`build-tool-support`
   )
-  .disablePlugins(Unidoc)
 
 // This is almost the same as `build-tool-support`, but targeting sbt
 // while `build-tool-support` targets Maven and possibly other build
@@ -1061,7 +1059,6 @@ lazy val `sbt-build-tool-support` = (project in file("dev") / "build-tool-suppor
     Dependencies.`build-tool-support`,
     target := target.value / "lagom-sbt-build-tool-support"
   )
-  .disablePlugins(Unidoc)
 
 lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
   .settings(common: _*)
@@ -1096,7 +1093,6 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
     },
     publishMavenStyle := isSnapshot.value
   ).dependsOn(`sbt-build-tool-support`)
-  .disablePlugins(Unidoc)
 
 lazy val `maven-plugin` = (project in file("dev") / "maven-plugin")
   .enablePlugins(lagom.SbtMavenPlugin)
@@ -1176,7 +1172,7 @@ def archetypeProject(archetypeName: String) =
       },
       // Don't force copyright headers in Maven archetypes
       HeaderKey.excludes := Seq("*")
-    ).disablePlugins(EclipsePlugin, Unidoc)
+    ).disablePlugins(EclipsePlugin)
 
 lazy val `maven-java-archetype` = archetypeProject("java")
 lazy val `maven-dependencies` = (project in file("dev") / "maven-dependencies")
@@ -1268,7 +1264,6 @@ lazy val `sbt-scripted-tools` = (project in file("dev") / "sbt-scripted-tools")
     scalaVersion := Dependencies.SbtScalaVersions.head,
     sbtVersion in pluginCrossBuild := defineSbtVersion(scalaBinaryVersion.value)
   ).dependsOn(`sbt-plugin`)
-  .disablePlugins(Unidoc)
 
 // This project also get aggregated, it is only executed by the sbt-plugin scripted dependencies
 lazy val `sbt-scripted-library` = (project in file("dev") / "sbt-scripted-library")

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -375,7 +375,7 @@ object LagomPlugin extends AutoPlugin with LagomPluginCompat {
     .settings(IvyPlugin.projectSettings: _*)
     .settings(JvmPlugin.projectSettings: _*)
     .settings(
-      scalaVersion := "2.12.4",
+      scalaVersion := "2.12.6",
       libraryDependencies += LagomImport.component("lagom-service-locator"),
       lagomServiceLocatorStart in ThisBuild := startServiceLocatorTask.value,
       lagomServiceLocatorStop in ThisBuild := Servers.ServiceLocator.tryStop(new SbtLoggerProxy(state.value.log))
@@ -387,7 +387,7 @@ object LagomPlugin extends AutoPlugin with LagomPluginCompat {
     .settings(IvyPlugin.projectSettings: _*)
     .settings(JvmPlugin.projectSettings: _*)
     .settings(
-      scalaVersion := "2.12.4",
+      scalaVersion := "2.12.6",
       libraryDependencies += LagomImport.component("lagom-cassandra-server"),
       lagomCassandraStart in ThisBuild := startCassandraServerTask.value,
       lagomCassandraStop in ThisBuild := Servers.CassandraServer.tryStop(new SbtLoggerProxy(state.value.log))
@@ -399,7 +399,7 @@ object LagomPlugin extends AutoPlugin with LagomPluginCompat {
     .settings(IvyPlugin.projectSettings: _*)
     .settings(JvmPlugin.projectSettings: _*)
     .settings(
-      scalaVersion := "2.12.4",
+      scalaVersion := "2.12.6",
       libraryDependencies += LagomImport.component("lagom-kafka-server"),
       lagomKafkaStart in ThisBuild := startKafkaServerTask.value,
       lagomKafkaStop in ThisBuild := Servers.KafkaServer.tryStop(new SbtLoggerProxy(state.value.log))

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/build.sbt
@@ -5,7 +5,7 @@ lazy val `my-project` = (project in file(".")).enablePlugins(LagomJava)
     libraryDependencies ++= Seq(lagomJavadslPersistenceCassandra, lagomSbtScriptedLibrary)
   )
 
-scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6")
 
 interactionMode := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/build.sbt
@@ -7,13 +7,13 @@ lagomServicesPortRange in ThisBuild := PortRange(10000, 10001)
 lazy val a = (project in file("a")).enablePlugins(LagomJava)
   .settings(Seq(
     sourceDirectory := baseDirectory.value / "src-a",
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4")
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6")
   ))
 
 lazy val b = (project in file("b")).enablePlugins(LagomJava)
   .settings(Seq(
     sourceDirectory := baseDirectory.value / "src-b",
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4")
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6")
   ))
 
 InputKey[Unit]("verifyPortProjA") := {

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
@@ -1,7 +1,7 @@
 import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 import com.lightbend.lagom.sbt.Internal
 
-scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
@@ -1,6 +1,6 @@
 import play.sbt.PlayImport
 
-scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
@@ -1,6 +1,6 @@
 import play.sbt.PlayImport
 
-scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/http-backend-switch/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/http-backend-switch/build.sbt
@@ -2,7 +2,7 @@ organization in ThisBuild := "com.example"
 version in ThisBuild := "1.0-SNAPSHOT"
 
 // the Scala version that will be used for cross-compiled libraries
-scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 lazy val `server-backend-switch` = (project in file("."))
   .aggregate(

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/build.sbt
@@ -3,7 +3,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 lazy val `my-project` = (project in file(".")).enablePlugins(LagomJava)
   .settings(libraryDependencies ++= Seq(lagomJavadslPersistenceCassandra, lagomSbtScriptedLibrary))
 
-scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6")
 
 interactionMode := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
-scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 lazy val `a-api` = (project in file("a") / "api")
   .settings(

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
-scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
-scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 lazy val p = (project in file("p")).enablePlugins(PlayJava && LagomPlay)
   .settings(

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/build.sbt
@@ -2,7 +2,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 lazy val root = (project in file(".")).enablePlugins(LagomJava)
 
-scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6")
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/build.sbt
@@ -3,7 +3,7 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
 lazy val commonSettings = Seq(
-  scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4")
+  scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6")
 )
 
 lazy val fooApi = (project in file("foo/api"))

--- a/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
+++ b/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
@@ -107,7 +107,7 @@ object ScriptedTools extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.4")
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.6")
   )
 
   private def repeatUntilSuccessful[T](log: Logger, operation: => T, times: Int = 10): T = {

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,4 +1,4 @@
-val ScalaVersion = "2.12.4"
+val ScalaVersion = "2.12.6"
 
 val AkkaVersion = "2.5.12"
 val JUnitVersion = "4.11"

--- a/docs/manual/java/guide/build/code/lagom-build.sbt
+++ b/docs/manual/java/guide/build/code/lagom-build.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "X.Y.Z") // replace 'X
 //#add-sbt-plugin
 
 //#scala-version
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 //#scala-version
 
 //#hello-api

--- a/docs/manual/java/guide/build/code/multiple-builds.sbt
+++ b/docs/manual/java/guide/build/code/multiple-builds.sbt
@@ -12,7 +12,7 @@ bintrayOmitLicense in ThisBuild := false
 //#hello-build
 organization in ThisBuild := "com.example"
 
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 
 lazy val `hello-api` = (project in file("hello-api"))
   .settings(version := "1.0")

--- a/docs/manual/java/releases/Migration14.md
+++ b/docs/manual/java/releases/Migration14.md
@@ -59,7 +59,7 @@ and use it when declaring dependencies, for example:
 The Scala version can be updated by editing the `build.sbt` file, and updating the `scalaVersion` settings, for example:
 
 ```scala
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 ```
 
 ## Akka HTTP as the default server engine

--- a/docs/manual/scala/guide/build/code/lagom-build.sbt
+++ b/docs/manual/scala/guide/build/code/lagom-build.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "X.Y.Z")
 //#add-sbt-plugin
 
 //#scala-version
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 //#scala-version
 
 //#hello-api

--- a/docs/manual/scala/guide/build/code/multiple-builds.sbt
+++ b/docs/manual/scala/guide/build/code/multiple-builds.sbt
@@ -12,7 +12,7 @@ bintrayOmitLicense in ThisBuild := false
 //#hello-build
 organization in ThisBuild := "com.example"
 
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 
 lazy val `hello-api` = (project in file("hello-api"))
   .settings(version := "1.0")

--- a/docs/manual/scala/releases/Migration14.md
+++ b/docs/manual/scala/releases/Migration14.md
@@ -30,7 +30,7 @@ Lagom is now cross compiled to Scala 2.11 and 2.12. It's recommended to upgrade 
 The Scala version can be updated by editing the `build.sbt` file, and updating the `scalaVersion` settings, for example:
 
 ```scala
-scalaVersion in ThisBuild := "2.12.4"
+scalaVersion in ThisBuild := "2.12.6"
 ```
 
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,8 +17,8 @@ object Dependencies {
   val AkkaVersion = "2.5.12"
   val AkkaHttpVersion = "10.0.13"
   // Also be sure to update ScalaVersion in docs/build.sbt.
-  val ScalaVersions = Seq("2.12.4", "2.11.12")
-  val SbtScalaVersions = Seq("2.10.6", "2.12.4")
+  val ScalaVersions = Seq("2.12.6", "2.11.12")
+  val SbtScalaVersions = Seq("2.10.6", "2.12.6")
   val AkkaPersistenceCassandraVersion = "0.60"
   val AkkaPersistenceJdbcVersion = "3.3.0"
   // Also be sure to update ScalaTestVersion in docs/build.sbt.

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -157,7 +157,6 @@ object Unidoc extends AutoPlugin {
 
   lazy val GenjavadocCompilerPlugin = config("genjavadocplugin") hide
 
-  override def trigger = allRequirements
   override def requires = plugins.JvmPlugin
   override def projectConfigurations: Seq[Configuration] = Seq(Genjavadoc)
 

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -168,7 +168,7 @@ object Unidoc extends AutoPlugin {
   // down to two assuming https://github.com/typesafehub/genjavadoc/issues/66 is possible.
   override lazy val projectSettings = inConfig(Genjavadoc)(Defaults.configSettings) ++ Seq(
     ivyConfigurations += GenjavadocCompilerPlugin,
-    libraryDependencies += "com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.10" % "genjavadocplugin->default(compile)" cross CrossVersion.full,
+    libraryDependencies += "com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.11" % "genjavadocplugin->default(compile)" cross CrossVersion.full,
     scalacOptions in Genjavadoc ++= Seq(
       "-P:genjavadoc:out=" + (target.value / "java"),
       "-P:genjavadoc:fabricateParams=false"


### PR DESCRIPTION
- Requires updating genjavadoc to 0.11.
- This, in turn, requires disabling it in any projects that cross build with Scala 2.10.
