### PR TITLE
Stop application resources from being returned twice from getResources

### DIFF
--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/ClassLoaders.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/ClassLoaders.scala
@@ -6,6 +6,7 @@ package com.lightbend.lagom.dev
 import java.lang.reflect.Method
 import java.net.{ URL, URLClassLoader }
 import java.util
+import java.util.Collections
 
 /**
  * A ClassLoader with a toString() that prints name/urls.
@@ -53,10 +54,10 @@ class DelegatingClassLoader(commonLoader: ClassLoader, sharedClasses: Set[String
     } else if (!appResources.hasMoreElements) {
       superResources
     } else {
-      val resources = new util.HashSet[URL]
+      val resources = new util.LinkedHashSet[URL]
       while (appResources.hasMoreElements) resources.add(appResources.nextElement())
       while (superResources.hasMoreElements) resources.add(superResources.nextElement())
-      new util.Vector(resources).elements()
+      Collections.enumeration(resources)
     }
   }
 

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/ClassLoaders.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/ClassLoaders.scala
@@ -64,12 +64,12 @@ class DelegatingClassLoader(commonLoader: ClassLoader, sharedClasses: Set[String
 }
 
 /**
-  * A ClassLoader that only uses resources from its parent.
-  *
-  * The reason we only pull resources from our parent classloader is that the Delegating ClassLoader already uses
-  * this classloaders findResources method to locate the resources provided by this ClassLoader, and so our parent
-  * will already be returning our resources. Only pulling from the parent ensures we don't duplicate this.
-  */
+ * A ClassLoader that only uses resources from its parent.
+ *
+ * The reason we only pull resources from our parent classloader is that the Delegating ClassLoader already uses
+ * this classloaders findResources method to locate the resources provided by this ClassLoader, and so our parent
+ * will already be returning our resources. Only pulling from the parent ensures we don't duplicate this.
+ */
 class DelegatedResourcesClassLoader(name: String, urls: Array[URL], parent: ClassLoader) extends NamedURLClassLoader(name, urls, parent) {
   require(parent ne null)
   override def getResources(name: String): java.util.Enumeration[java.net.URL] = getParent.getResources(name)

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Reloader.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Reloader.scala
@@ -297,7 +297,7 @@ class Reloader(
                 val version = classLoaderVersion.incrementAndGet
                 val name = "ReloadableClassLoader(v" + version + ")"
                 val urls = Reloader.urls(classpath)
-                val loader = new NamedURLClassLoader(name, urls, baseLoader)
+                val loader = new DelegatedResourcesClassLoader(name, urls, baseLoader)
                 currentApplicationClassLoader = Some(loader)
                 loader
               } else {


### PR DESCRIPTION
The delegating classloader is a little odd - it makes the application classloader resources available to libraries which are in the parent classloader. However, this means when it loads resources, the resources it loads appear twice on the classpath because it both loads its own, and the parent, which includes its own. This ensures that it doesn't include its own resources in getResources, that it only gets the parent resources.

This bug was introduced when we pulled the code out of Play - Play already had this problem solved (in fact this specifci bug was fixed 6 years ago). Not sure how we reintroduced it, but what I've ensured is that our behaviour is now the same as Play - resources are deduped in the parent loader (I'm not sure that this is actually needed) and the application loader doesn't include its own resources in getResources directly.