### PR TITLE
Update sbt-whitesource to 0.1.11

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,4 +22,4 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.10")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.11")


### PR DESCRIPTION
This updates the upstream Whitesource agent version transitively, which changes a problematic dependency of its own that was not available from Maven Central.

https://github.com/lightbend/sbt-whitesource/pull/37
https://github.com/whitesource/agents/commit/322de017f39abb86093c0564f6d2b0e65ad55984

This should be backported to 1.4.x and also 1.3.x if it applies cleanly.