### PR TITLE
Update Migration Manager (MiMa) to 0.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -264,7 +264,7 @@ def mimaSettings(versions: Seq[String]): Seq[Setting[_]] = {
         organization.value % s"${moduleName.value}_${scalaBinaryVersion.value}" % version
       }.toSet
     },
-    mimaBinaryIssueFilters += ProblemFilters.excludePackage("com.lightbend.lagom.internal")
+    mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("com.lightbend.lagom.internal.*")
   )
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,7 +18,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.3.8")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.1")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
 addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")


### PR DESCRIPTION
https://github.com/lightbend/migration-manager/releases/tag/0.3.0

Update deprecated `excludePackage` call to `exclude[Problem]`.