### PR TITLE
Use explict timeouts to better control Flakiness of test

### DIFF
--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -38,6 +38,9 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       lagom.persistence.read-side.run-on-role = "read-side"
       terminate-system-after-member-removed = 60s
 
+      # increase default barrier-timeout from 30s to 60s since to leave wider margin for Travis.
+      akka.testconductor.barrier-timeout=60s
+
       # Don't terminate the actor system when doing a coordinated shutdown
       # See http://doc.akka.io/docs/akka/2.5.0/project/migration-guide-2.4.x-2.5.x.html#Coordinated_Shutdown
       akka.coordinated-shutdown.terminate-actor-system = off

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -38,7 +38,7 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       lagom.persistence.read-side.run-on-role = "read-side"
       terminate-system-after-member-removed = 60s
 
-      # increase default barrier-timeout from 30s to 60s since to leave wider margin for Travis.
+      # increase default barrier-timeout from 30s to 60s to leave wider margin for Travis.
       akka.testconductor.barrier-timeout=60s
 
       # Don't terminate the actor system when doing a coordinated shutdown

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -35,6 +35,9 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       lagom.persistence.read-side.run-on-role = "read-side"
       terminate-system-after-member-removed = 60s
 
+      # increase default barrier-timeout from 30s to 60s since to leave wider margin for Travis.
+      akka.testconductor.barrier-timeout=60s
+
       # Don't terminate the actor system when doing a coordinated shutdown
       # See http://doc.akka.io/docs/akka/2.5.0/project/migration-guide-2.4.x-2.5.x.html#Coordinated_Shutdown
       akka.coordinated-shutdown.terminate-actor-system = off

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -35,7 +35,7 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       lagom.persistence.read-side.run-on-role = "read-side"
       terminate-system-after-member-removed = 60s
 
-      # increase default barrier-timeout from 30s to 60s since to leave wider margin for Travis.
+      # increase default barrier-timeout from 30s to 60s to leave wider margin for Travis.
       akka.testconductor.barrier-timeout=60s
 
       # Don't terminate the actor system when doing a coordinated shutdown


### PR DESCRIPTION
Related to #1365 , #260