### PR TITLE
Increase default timeouts for expectations and persisten entity asks

### DIFF
--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -47,7 +47,7 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       akka.test.single-expect-default = 11s
       ## use 9s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
       ## Also, make the Akka expect() timeouts higher since this tests often expect over an ask operation.
- |
+
       # Don't terminate the actor system when doing a coordinated shutdown
       # See http://doc.akka.io/docs/akka/2.5.0/project/migration-guide-2.4.x-2.5.x.html#Coordinated_Shutdown
       akka.coordinated-shutdown.terminate-actor-system = off

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -46,8 +46,8 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       # 5s to 10s
       akka.test.single-expect-default = 11s
       ## use 9s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
-      ## Also, make the expectation higher since this tests often expects over an ask operation.
-
+      ## Also, make the Akka expect() timeouts higher since this tests often expect over an ask operation.
+ |
       # Don't terminate the actor system when doing a coordinated shutdown
       # See http://doc.akka.io/docs/akka/2.5.0/project/migration-guide-2.4.x-2.5.x.html#Coordinated_Shutdown
       akka.coordinated-shutdown.terminate-actor-system = off
@@ -153,8 +153,8 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       // beginning of the test to ensure it's run.
       enterBarrier("before-1")
 
-      val ref1 = registry.refFor(classOf[TestEntity], "1").withAskTimeout(remaining)
-      val ref2 = registry.refFor(classOf[TestEntity], "2").withAskTimeout(remaining)
+      val ref1 = registry.refFor(classOf[TestEntity], "1")
+      val ref2 = registry.refFor(classOf[TestEntity], "2")
 
       // STEP 1: send some commands from all nodes of the test to ref1 and ref2
       // note that this is done on node1, node2 and node 3 !!
@@ -220,12 +220,12 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
 
       runOn(node1) {
         within(35.seconds) {
-          val ref1 = registry.refFor(classOf[TestEntity], "1").withAskTimeout(remaining)
+          val ref1 = registry.refFor(classOf[TestEntity], "1")
           val r1: CompletionStage[TestEntity.Evt] = ref1.ask(TestEntity.Add.of("a"))
           r1.pipeTo(testActor)
           expectMsg(new TestEntity.Appended("1", "A"))
 
-          val ref2 = registry.refFor(classOf[TestEntity], "2").withAskTimeout(remaining)
+          val ref2 = registry.refFor(classOf[TestEntity], "2")
           val r2: CompletionStage[TestEntity.Evt] = ref2.ask(TestEntity.Add.of("b"))
           r2.pipeTo(testActor)
           expectMsg(new TestEntity.Appended("2", "B"))

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -38,8 +38,15 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       lagom.persistence.read-side.run-on-role = "read-side"
       terminate-system-after-member-removed = 60s
 
-      # increase default barrier-timeout from 30s to 60s to leave wider margin for Travis.
+      # increase default timeouts to leave wider margin for Travis.
+      # 30s to 60s
       akka.testconductor.barrier-timeout=60s
+      # 5s to 10s
+      lagom.persistence.ask-timeout = 9s
+      # 5s to 10s
+      akka.test.single-expect-default = 11s
+      ## use 9s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
+      ## Also, make the expectation higher since this tests often expects over an ask operation.
 
       # Don't terminate the actor system when doing a coordinated shutdown
       # See http://doc.akka.io/docs/akka/2.5.0/project/migration-guide-2.4.x-2.5.x.html#Coordinated_Shutdown

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -148,13 +148,13 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
 
   "A PersistentEntity in a Cluster" must {
 
-    "send commands to target entity" in within(20.seconds) {
+    "send commands to target entity" in within(75.seconds) {
       // this barrier at the beginning of the test will be run on all nodes and should be at the
       // beginning of the test to ensure it's run.
       enterBarrier("before-1")
 
       val ref1 = registry.refFor(classOf[TestEntity], "1").withAskTimeout(remaining)
-      val ref2 = registry.refFor(classOf[TestEntity], "2")
+      val ref2 = registry.refFor(classOf[TestEntity], "2").withAskTimeout(remaining)
 
       // STEP 1: send some commands from all nodes of the test to ref1 and ref2
       // note that this is done on node1, node2 and node 3 !!
@@ -219,7 +219,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       enterBarrier("node2-left")
 
       runOn(node1) {
-        within(15.seconds) {
+        within(35.seconds) {
           val ref1 = registry.refFor(classOf[TestEntity], "1").withAskTimeout(remaining)
           val r1: CompletionStage[TestEntity.Evt] = ref1.ask(TestEntity.Add.of("a"))
           r1.pipeTo(testActor)

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -43,7 +43,7 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       # 5s to 11s
       akka.test.single-expect-default = 11s
       ## use 9s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
-      ## Also, make the expectation higher since this tests often expects over an ask operation.
+      ## Also, make the Akka expect() timeouts higher since this tests often expect over an ask operation.
 
       # Don't terminate the actor system when doing a coordinated shutdown
       # See http://doc.akka.io/docs/akka/2.5.0/project/migration-guide-2.4.x-2.5.x.html#Coordinated_Shutdown
@@ -155,8 +155,8 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       // beginning of the test to ensure it's run.
       enterBarrier("before-1")
 
-      val ref1 = registry.refFor[TestEntity]("1").withAskTimeout(remaining)
-      val ref2 = registry.refFor[TestEntity]("2").withAskTimeout(remaining)
+      val ref1 = registry.refFor[TestEntity]("1")
+      val ref2 = registry.refFor[TestEntity]("2")
 
       // STEP 1: send some commands from all nodes of the test to ref1 and ref2
       // note that this is done on node1, node2 and node 3 !!
@@ -224,12 +224,12 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
 
       runOn(node1) {
         within(35.seconds) {
-          val ref1 = registry.refFor[TestEntity]("1").withAskTimeout(remaining)
+          val ref1 = registry.refFor[TestEntity]("1")
           val r1: Future[TestEntity.Evt] = ref1.ask(TestEntity.Add("a"))
           r1.pipeTo(testActor)
           expectMsg(TestEntity.Appended("A"))
 
-          val ref2 = registry.refFor[TestEntity]("2").withAskTimeout(remaining)
+          val ref2 = registry.refFor[TestEntity]("2")
           val r2: Future[TestEntity.Evt] = ref2.ask(TestEntity.Add("b"))
           r2.pipeTo(testActor)
           expectMsg(TestEntity.Appended("B"))

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -150,13 +150,13 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
 
   "A PersistentEntity in a Cluster" must {
 
-    "send commands to target entity" in within(21.seconds) {
+    "send commands to target entity" in within(75.seconds) {
       // this barrier at the beginning of the test will be run on all nodes and should be at the
       // beginning of the test to ensure it's run.
       enterBarrier("before-1")
 
       val ref1 = registry.refFor[TestEntity]("1").withAskTimeout(remaining)
-      val ref2 = registry.refFor[TestEntity]("2")
+      val ref2 = registry.refFor[TestEntity]("2").withAskTimeout(remaining)
 
       // STEP 1: send some commands from all nodes of the test to ref1 and ref2
       // note that this is done on node1, node2 and node 3 !!
@@ -223,7 +223,7 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       enterBarrier("node2-left")
 
       runOn(node1) {
-        within(15.seconds) {
+        within(35.seconds) {
           val ref1 = registry.refFor[TestEntity]("1").withAskTimeout(remaining)
           val r1: Future[TestEntity.Evt] = ref1.ask(TestEntity.Add("a"))
           r1.pipeTo(testActor)

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -35,8 +35,15 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       lagom.persistence.read-side.run-on-role = "read-side"
       terminate-system-after-member-removed = 60s
 
-      # increase default barrier-timeout from 30s to 60s to leave wider margin for Travis.
+      # increase default timeouts to leave wider margin for Travis.
+      # 30s to 60s
       akka.testconductor.barrier-timeout=60s
+      # 5s to 9s
+      lagom.persistence.ask-timeout = 9s
+      # 5s to 11s
+      akka.test.single-expect-default = 11s
+      ## use 9s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
+      ## Also, make the expectation higher since this tests often expects over an ask operation.
 
       # Don't terminate the actor system when doing a coordinated shutdown
       # See http://doc.akka.io/docs/akka/2.5.0/project/migration-guide-2.4.x-2.5.x.html#Coordinated_Shutdown


### PR DESCRIPTION
Related #260 #1366

This PR tries to fix the flakyness of the tests following the hypethesis described in https://github.com/lagom/lagom/issues/260#issuecomment-392463727