### PR TITLE
Check copyright headers explicitly

### DIFF
--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -2,7 +2,14 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-runSbt scalariformFormat test:scalariformFormat multi-jvm:scalariformFormat validateDependencies mimaCheckOneAtATime
+runSbt  scalariformFormat \
+	test:scalariformFormat \
+	multi-jvm:scalariformFormat \
+	checkHeaders \
+	test:checkHeaders \
+	multi-jvm:checkHeaders \
+	validateDependencies \
+	mimaCheckOneAtATime
 
 git diff --exit-code || (
   echo "ERROR: Scalariform check failed, see differences above."

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -3,13 +3,13 @@
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 runSbt  scalariformFormat \
-	test:scalariformFormat \
-	multi-jvm:scalariformFormat \
-	checkHeaders \
-	test:checkHeaders \
-	multi-jvm:checkHeaders \
-	validateDependencies \
-	mimaCheckOneAtATime
+        test:scalariformFormat \
+        multi-jvm:scalariformFormat \
+        checkHeaders \
+        test:checkHeaders \
+        multi-jvm:checkHeaders \
+        validateDependencies \
+        mimaCheckOneAtATime
 
 git diff --exit-code || (
   echo "ERROR: Scalariform check failed, see differences above."

--- a/dev/sbt-scripted-library/src/main/java/api/FooService.java
+++ b/dev/sbt-scripted-library/src/main/java/api/FooService.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 package api;
 
 import akka.NotUsed;

--- a/dev/sbt-scripted-library/src/main/java/impl/FooModule.java
+++ b/dev/sbt-scripted-library/src/main/java/impl/FooModule.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 package impl;
 
 import com.google.inject.AbstractModule;

--- a/dev/sbt-scripted-library/src/main/java/impl/FooServiceImpl.java
+++ b/dev/sbt-scripted-library/src/main/java/impl/FooServiceImpl.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 package impl;
 
 import akka.NotUsed;

--- a/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
+++ b/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
@@ -1,3 +1,6 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 package com.lightbend.lagom.sbt.scripted
 
 import java.io.{ BufferedReader, InputStreamReader }


### PR DESCRIPTION
Previously, this relied on an implicit header update running as part of the build, combined with the diff check at the end. This leaves some files out.

I expect the first commit (which adds the check) to fail. Once it does, I'll push another commit with the fixes.