### PR TITLE
Updates play to 2.6.15

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,10 +1,10 @@
 val ScalaVersion = "2.12.6"
 
-val AkkaVersion = "2.5.12"
+val AkkaVersion = "2.5.13"
 val JUnitVersion = "4.11"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion = "3.0.4"
-val PlayVersion = "2.6.13"
+val PlayVersion = "2.6.15"
 val Log4jVersion = "2.10.0"
 val MacWireVersion = "2.3.0"
 val LombokVersion = "1.16.20"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,9 +7,9 @@ object Dependencies {
 
   // If you update PlayVersion, you probably need to update the other Play*Version variables.
   // Also be sure to update PlayVersion in docs/build.sbt.
-  val PlayVersion = "2.6.13"
+  val PlayVersion = "2.6.15"
   val PlayJsonVersion = "2.6.9"
-  val PlayStandaloneWsVersion = "1.1.7"
+  val PlayStandaloneWsVersion = "1.1.9"
   val TwirlVersion = "1.3.14"
   val PlayFileWatchVersion = "1.1.7"
 
@@ -24,9 +24,12 @@ object Dependencies {
   // Also be sure to update ScalaTestVersion in docs/build.sbt.
   val ScalaTestVersion = "3.0.4"
   val JacksonVersion = "2.8.11"
+  val JacksonCoreVersion = JacksonVersion
+  val JacksonDatatypeVersion = JacksonVersion
+  val JacksonDatabindVersion = "2.8.11.1"
   val GuavaVersion = "22.0"
   val MavenVersion = "3.3.9"
-  val NettyVersion = "4.1.23.Final"
+  val NettyVersion = "4.1.25.Final"
   val NettyReactiveStreamsVersion = "2.0.0"
   val KafkaVersion = "0.11.0.1"
   val AkkaStreamKafkaVersion = "0.18"
@@ -112,9 +115,11 @@ object Dependencies {
   private val dropwizardMetricsCore = "io.dropwizard.metrics" % "metrics-core" % "3.2.2" excludeAll (excludeSlf4j: _*)
 
   private val jacksonFamily =
-    libraryFamily("com.fasterxml.jackson.core", JacksonVersion)(
-      "jackson-annotations", "jackson-core", "jackson-databind"
-    ) ++ libraryFamily("com.fasterxml.jackson.datatype", JacksonVersion)(
+    libraryFamily("com.fasterxml.jackson.core", JacksonCoreVersion)(
+      "jackson-annotations", "jackson-core"
+    ) ++ libraryFamily("com.fasterxml.jackson.core", JacksonDatabindVersion)(
+      "jackson-databind"
+    ) ++ libraryFamily("com.fasterxml.jackson.datatype", JacksonDatatypeVersion)(
       "jackson-datatype-jdk8", "jackson-datatype-jsr310", "jackson-datatype-guava", "jackson-datatype-pcollections"
     )
 
@@ -158,7 +163,7 @@ object Dependencies {
       akkaPersistenceCassandraLauncher,
       "com.typesafe.netty" % "netty-reactive-streams" % NettyReactiveStreamsVersion,
       "com.typesafe.netty" % "netty-reactive-streams-http" % NettyReactiveStreamsVersion,
-      "com.typesafe.play" %% "cachecontrol" % "1.1.2",
+      "com.typesafe.play" %% "cachecontrol" % "1.1.3",
       playJson,
       playFunctional,
       // play client libs
@@ -197,7 +202,7 @@ object Dependencies {
       "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final",
       "org.immutables" % "value" % "2.3.2",
       javassist,
-      "org.joda" % "joda-convert" % "1.7",
+      "org.joda" % "joda-convert" % "1.9.2",
       "org.hamcrest" % "hamcrest-core" % "1.3",
       "org.lmdbjava" % "lmdbjava" % "0.6.0",
       "org.pcollections" % "pcollections" % "2.1.2",
@@ -318,10 +323,10 @@ object Dependencies {
 
   val jackson = libraryDependencies ++= Seq(
     "com.fasterxml.jackson.module" % "jackson-module-parameter-names" % JacksonVersion,
-    "com.fasterxml.jackson.datatype" % "jackson-datatype-pcollections" % JacksonVersion,
-    "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % JacksonVersion,
-    "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % JacksonVersion,
-    "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-pcollections" % JacksonDatatypeVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-guava" % JacksonDatatypeVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % JacksonDatatypeVersion,
+    "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonDatatypeVersion,
     akkaTestkit % Test,
     scalaTest % Test,
     "com.novocode" % "junit-interface" % "0.11" % Test


### PR DESCRIPTION
Also bumps `docs/` version of Akka to same than main (`2.5.13`).

The relevant change is `jackson-databind` being release separately causing a small refactor.