### PR TITLE
Make state available after persisting an event.

### DIFF
--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/PersistentEntityActor.scala
@@ -162,7 +162,7 @@ private[lagom] class PersistentEntityActor(
               try {
                 eventCount += 1
                 if (afterPersist != null)
-                  afterPersist(event)
+                  afterPersist(event, state)
                 if (snapshotAfter > 0 && eventCount % snapshotAfter == 0)
                   saveSnapshot(state)
               } catch {

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntity.scala
@@ -259,7 +259,7 @@ abstract class PersistentEntity {
      * that one event is to be persisted. External side effects can be
      * performed after successful persist in the `afterPersist` function.
      */
-    def thenPersist[B <: Event](event: B)(afterPersist: B => Unit = (_: B) => ()): Persist =
+    def thenPersist[B <: Event](event: B)(afterPersist: (B, State) => Unit = (_: B, _: State) => ()): Persist =
       PersistOne(event, afterPersist)
 
     /**
@@ -290,7 +290,7 @@ abstract class PersistentEntity {
   /**
    * INTERNAL API
    */
-  private[lagom] case class PersistOne[B <: Event](event: B, afterPersist: B => Unit) extends Persist
+  private[lagom] case class PersistOne[B <: Event](event: B, afterPersist: (B, State) => Unit) extends Persist
 
   /**
    * INTERNAL API

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/TestEntity.scala
@@ -162,8 +162,8 @@ class TestEntity(system: ActorSystem)
         case (ChangeMode(mode), ctx, state) => {
           mode match {
             case mode if state.mode == mode => ctx.done
-            case Mode.Append                => ctx.thenPersist(InAppendMode)(ctx.reply)
-            case Mode.Prepend               => ctx.thenPersist(InPrependMode)(ctx.reply)
+            case Mode.Append                => ctx.thenPersist(InAppendMode)((_, _) => ctx.reply _)
+            case Mode.Prepend               => ctx.thenPersist(InPrependMode)((_, _) => ctx.reply _)
           }
         }
       }
@@ -178,10 +178,10 @@ class TestEntity(system: ActorSystem)
         case (GetAddress, ctx, state) => ctx.reply(Cluster.get(system).selfAddress)
       }
       .onCommand[Clear.type, State] {
-        case (Clear, ctx, state) => ctx.thenPersist(Cleared)(_ => ctx.reply(state))
+        case (Clear, ctx, state) => ctx.thenPersist(Cleared)((_, _) => ctx.reply(state))
       }
       .onCommand[UnhandledEvtCmd.type, State] {
-        case (_, ctx, state) => ctx.thenPersist(Unhandled)(_ => ctx.reply(state))
+        case (_, ctx, state) => ctx.thenPersist(Unhandled)((_, _) => ctx.reply(state))
       }
       .onEvent {
         case (Cleared, _) => null
@@ -206,7 +206,7 @@ class TestEntity(system: ActorSystem)
           }
           val appended = Appended(elem.toUpperCase)
           if (times == 1)
-            ctx.thenPersist(appended)(ctx.reply)
+            ctx.thenPersist(appended)((_, _) => ctx.reply _)
           else
             ctx.thenPersistAll(List.fill(times)(appended): _*)(() => ctx.reply(appended))
       }
@@ -225,7 +225,7 @@ class TestEntity(system: ActorSystem)
           }
           val prepended = Prepended(elem.toLowerCase)
           if (times == 1)
-            ctx.thenPersist(prepended)(ctx.reply)
+            ctx.thenPersist(prepended)((_, _) => ctx.reply _)
           else
             ctx.thenPersistAll(List.fill(times)(prepended): _*)(() => ctx.reply(prepended))
       }

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriver.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/PersistentEntityTestDriver.scala
@@ -191,7 +191,7 @@ class PersistentEntityTestDriver[C, E, S](
               applyEvent(evt)
               issues ++= checkSerialization(state)
               if (afterPersist != null)
-                afterPersist(event)
+                afterPersist(event, state)
             } catch {
               case NonFatal(e) =>
                 ctx.commandFailed(e) // reply with failure


### PR DESCRIPTION
This PR makes the updated state available after persisting an event in the Scala Persistence API.

Resolve #1309.