### PR TITLE
Use the standard Travis CI sbt launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,6 @@ script: bin/$SCRIPT
 before_install:
     # See https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-239493916
     - rm ~/.m2/settings.xml
-    # Install sbt 1.0 so that we can use its launcher
-    - sudo apt-get install bc # see https://github.com/sbt/sbt/issues/3697
-    - echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-    - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
-    - sudo apt-get -qq update
-    - sudo apt-get install sbt -yq
 cache:
   directories:
     - $HOME/.ivy2/cache


### PR DESCRIPTION
We have seen a number of flaky builds when trying to install sbt via apt.