### PR TITLE
[WIP] Support Lagom-specific gRPC generators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1069,7 +1069,7 @@ lazy val `sbt-build-tool-support` = (project in file("dev") / "build-tool-suppor
 lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
   .settings(common: _*)
   .settings(scriptedSettings: _*)
-  .enablePlugins(SbtPluginPlugins)
+  .enablePlugins(SbtPluginPlugins, SbtTwirl)
   .settings(
     name := "lagom-sbt-plugin",
     sbtPlugin := true,
@@ -1077,13 +1077,11 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
     scalaVersion := Dependencies.SbtScalaVersions.head,
     sbtVersion in pluginCrossBuild := defineSbtVersion(scalaBinaryVersion.value),
     Dependencies.`sbt-plugin`,
-    libraryDependencies ++= Seq(
-      Defaults.sbtPluginExtra(
-        "com.typesafe.play" % "sbt-plugin" % Dependencies.PlayVersion,
-        CrossVersion.binarySbtVersion((sbtVersion in pluginCrossBuild).value),
-        CrossVersion.binaryScalaVersion(scalaVersion.value)
-      ).exclude("org.slf4j", "slf4j-simple")
-    ),
+    libraryDependencies ++= Dependencies.sbtPluginDeps(
+      (sbtVersion in pluginCrossBuild).value,
+      scalaVersion.value
+    )
+    ,
     scriptedDependencies := {
       val () = scriptedDependencies.value
       val () = publishLocal.value

--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/akka/grpc/sbt/lagom/LagomGrpcPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/akka/grpc/sbt/lagom/LagomGrpcPlugin.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.grpc.sbt.lagom
+
+import com.lightbend.lagom.sbt.{ LagomJava, LagomScala }
+import sbt.{ AllRequirements, AutoPlugin, Compile, File, PluginTrigger, Plugins, Test }
+import akka.grpc.sbt.AkkaGrpcPlugin
+import sbt.Keys.sourceManaged
+
+object LagomScalaGrpcPlugin extends LagomGrpcPlugin[LagomScala.type] {
+  import AkkaGrpcPlugin.autoImport._
+  override lazy val defaultLagomLanguage: AkkaGrpc.Language = AkkaGrpc.Scala
+  override lazy val requiredLagomPlugin: AutoPlugin = LagomScala
+}
+
+object LagomJavaGrpcPlugin extends LagomGrpcPlugin[LagomScala.type] {
+  import AkkaGrpcPlugin.autoImport._
+  override lazy val defaultLagomLanguage: AkkaGrpc.Language = AkkaGrpc.Java
+  override lazy val requiredLagomPlugin: AutoPlugin = LagomJava
+}
+
+trait LagomGrpcPlugin[ThePlugin <: AutoPlugin] extends AutoPlugin {
+  import AkkaGrpcPlugin.autoImport._
+  def defaultLagomLanguage: AkkaGrpc.Language
+  def requiredLagomPlugin: AutoPlugin
+
+  //  override def trigger: PluginTrigger = AllRequirements
+  override def trigger = noTrigger
+
+  override def requires: Plugins = requiredLagomPlugin && AkkaGrpcPlugin
+
+  override def projectSettings: Seq[sbt.Setting[_]] = defaultSettings
+
+  private def defaultSettings =
+    Seq(
+      akkaGrpcGeneratedLanguages := Seq(defaultLagomLanguage),
+      privateExtraGrpcTargets := lagomTargets
+    )
+
+  private val lagomTargets: (File, Seq[String]) => Seq[protocbridge.Target] = { (targetPath, settings) =>
+    Seq(
+      protocbridge.Target(
+        LagomGenerator.generator(LagomScalaClientCodeGenerator),
+        targetPath,
+        settings
+      )
+    )
+  }
+
+}
+
+// This hack give us visiblity over `ProtocBridgeSbtPluginCodeGenerator` which is `private[akka]`
+object LagomGenerator {
+  def generator(impl: akka.grpc.gen.CodeGenerator) = gen(impl)
+  private[akka] def gen(impl: akka.grpc.gen.CodeGenerator) = protocbridge.JvmGenerator(
+    impl.name,
+    new akka.grpc.sbt.AkkaGrpcPlugin.ProtocBridgeSbtPluginCodeGenerator(impl)
+  )
+}
+
+import scalapb.compiler.GeneratorParams
+import protocbridge.Artifact
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse
+import akka.grpc.gen.scaladsl.Service
+import akka.grpc.gen.scaladsl.ScalaCodeGenerator
+
+object LagomScalaClientCodeGenerator extends ScalaCodeGenerator {
+  override def name = "lagom-grpc-scaladsl-client"
+
+  // This generator MUST be run next to ScalaClientCodeGenerator as
+  // it assumes the code generated there will exist.
+  override def perServiceContent = Set(generateStub)
+
+  import templates.ScalaLagomClient.txt.LagomClient
+
+  def generateStub(service: Service): CodeGeneratorResponse.File = {
+    val b = CodeGeneratorResponse.File.newBuilder()
+    b.setContent(LagomClient(service).body)
+    b.setName(s"${service.packageName.replace('.', '/')}/${service.name}LagomClient.scala")
+    b.build
+  }
+
+  override val suggestedDependencies =
+    // TODO: remove grpc-stub dependency once we have a akka-http based client #193
+    Artifact("io.grpc", "grpc-stub", scalapb.compiler.Version.grpcJavaVersion) +: super.suggestedDependencies
+
+  private def parseParameters(params: String): GeneratorParams = {
+    params.split(",").map(_.trim).filter(_.nonEmpty).foldLeft[GeneratorParams](GeneratorParams()) {
+      case (p, "java_conversions")      => p.copy(javaConversions = true)
+      case (p, "flat_package")          => p.copy(flatPackage = true)
+      case (p, "grpc")                  => p.copy(grpc = true)
+      case (p, "single_line_to_string") => p.copy(singleLineToProtoString = true)
+      case (x, _)                       => x
+    }
+  }
+
+}
+

--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/akka/grpc/sbt/lagom/LagomGrpcPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/akka/grpc/sbt/lagom/LagomGrpcPlugin.scala
@@ -25,8 +25,7 @@ trait LagomGrpcPlugin[ThePlugin <: AutoPlugin] extends AutoPlugin {
   def defaultLagomLanguage: AkkaGrpc.Language
   def requiredLagomPlugin: AutoPlugin
 
-  //  override def trigger: PluginTrigger = AllRequirements
-  override def trigger = noTrigger
+  override def trigger: PluginTrigger = AllRequirements
 
   override def requires: Plugins = requiredLagomPlugin && AkkaGrpcPlugin
 

--- a/dev/sbt-plugin/src/main/twirl/templates/ScalaLagomClient/LagomClient.scala.txt
+++ b/dev/sbt-plugin/src/main/twirl/templates/ScalaLagomClient/LagomClient.scala.txt
@@ -1,0 +1,26 @@
+@*
+ * Copyright (C) 2018 Lightbend Inc. <https://www.lightbend.com>
+ *@
+
+@(service: akka.grpc.gen.scaladsl.Service)
+
+package @service.packageName
+
+import akka.NotUsed
+import akka.grpc.internal.{ Marshaller, NettyClientUtils }
+import akka.grpc.internal.{ ScalaUnaryRequestBuilder, ScalaClientStreamingRequestBuilder }
+import akka.grpc.internal.{ ScalaServerStreamingRequestBuilder, ScalaBidirectionalStreamingRequestBuilder }
+import akka.grpc.scaladsl.{ SingleResponseRequestBuilder, StreamResponseRequestBuilder }
+import akka.grpc.GrpcClientSettings
+import akka.stream.{ Materializer, OverflowStrategy }
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+import akka.stream.Materializer
+import scala.concurrent.{ ExecutionContext, Future }
+
+import io.grpc._
+import io.grpc.stub.{ ClientCalls, StreamObserver }
+import @{service.name}Client._
+
+final class @{service.name}LagomClient(settings: GrpcClientSettings)(implicit mat: Materializer, ex: ExecutionContext) extends @{service.name} {
+
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   // Also be sure to update AkkaVersion in docs/build.sbt.
   val AkkaVersion = "2.5.13"
   val AkkaHttpVersion = "10.0.13"
+  val AkkaGrpcVersion = "0.1+31-8ae8c6da+20180615-1624"
   // Also be sure to update ScalaVersion in docs/build.sbt.
   val ScalaVersions = Seq("2.12.6", "2.11.12")
   val SbtScalaVersions = Seq("2.10.6", "2.12.6")
@@ -656,6 +657,28 @@ object Dependencies {
     "org.slf4j" % "slf4j-nop" % "1.7.14",
     scalaTest % Test
   )
+
+  // Computes some dynamic deps depending on the sbt version. This deps
+  // are Defaults.sbtPluginExtra in all cases.
+  def sbtPluginDeps(sbtVersion: String, scalaVersion: String) = {
+    Seq(
+      Defaults.sbtPluginExtra(
+        "com.typesafe.play" % "sbt-plugin" % Dependencies.PlayVersion,
+        CrossVersion.binarySbtVersion(sbtVersion),
+        CrossVersion.binaryScalaVersion(scalaVersion)
+      ).exclude("org.slf4j", "slf4j-simple")) ++ {
+      if (sbtVersion.contains("0.13")) {
+        Nil
+      } else {
+        Seq(
+          Defaults.sbtPluginExtra(
+            "com.lightbend.akka.grpc" % "sbt-akka-grpc" % Dependencies.AkkaGrpcVersion,
+            CrossVersion.binarySbtVersion(sbtVersion),
+            CrossVersion.binaryScalaVersion(scalaVersion))
+        )
+      }
+    }
+  }
 
   val `maven-plugin` = libraryDependencies ++= Seq(
     "org.apache.maven" % "maven-plugin-api" % MavenVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.11")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.3.14")


### PR DESCRIPTION
The initial investigations to support gRPC in Lagom usually indicated that some 
code generation tooling could be of use. Considering `akka-grpc` already provides
that attempting to reuse it and solve the `.proto`-to-code generation using the
same approach sounds reasonable.

Using gRPC from `akka-grpc` in `sbt` is currently limited to `sbt-1.0` which means any improvement is limited to that version too. This PR uses `scala-sbt-1.0` folder overwrites so that only `sbt-1.0` will have the new `AutoPlugin`s.

This PR requires https://github.com/akka/akka-grpc/pull/237