### PR TITLE
Change BehaviorBuilder to an abstract class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -733,8 +733,12 @@ lazy val `persistence-javadsl` = (project in file("persistence/javadsl"))
       // lost by hiding it.
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntityRef.writeReplace"),
 
-      // See https://github.com/lagom/lagom/pull/1302 was a `protected final class` and became a `public sealed trait`
-      ProblemFilters.exclude[IncompatibleTemplateDefProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity$BehaviorBuilder")
+      // Was a `protected final class` and became a `public sealed abstract class`
+      // See https://github.com/lagom/lagom/pull/1302
+      ProblemFilters.exclude[AbstractClassProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity$BehaviorBuilder"),
+      ProblemFilters.exclude[DirectAbstractMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity#BehaviorBuilder.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity#BehaviorBuilder.this"),
+      ProblemFilters.exclude[ReversedAbstractMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity#BehaviorBuilder.*")
     ),
     Dependencies.`persistence-javadsl`
   )

--- a/build.sbt
+++ b/build.sbt
@@ -734,7 +734,7 @@ lazy val `persistence-javadsl` = (project in file("persistence/javadsl"))
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntityRef.writeReplace"),
 
       // Was a `protected final class` and became a `public sealed abstract class`
-      // See https://github.com/lagom/lagom/pull/1302
+      // See https://github.com/lagom/lagom/pull/1302 and https://github.com/lagom/lagom/pull/1395
       ProblemFilters.exclude[AbstractClassProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity$BehaviorBuilder"),
       ProblemFilters.exclude[DirectAbstractMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity#BehaviorBuilder.*"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity#BehaviorBuilder.this"),

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
@@ -265,6 +265,7 @@ abstract class PersistentEntity[Command, Event, State] {
   // to hold docs and BehaviorBuilderImpl is made private to hold implementation.
   // It is required to be an abstract class, not a trait, because it refers to type variables from the enclosing scope.
   // This would be legal in Scala, but causes inter-operation problems with some Java compilers (such as Eclipse).
+  // See https://github.com/lagom/lagom/pull/1395
   sealed abstract class BehaviorBuilder {
     def getState(): State
     def setState(state: State): Unit

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntity.scala
@@ -261,9 +261,11 @@ abstract class PersistentEntity[Command, Event, State] {
    * Mutable builder that is used for defining the event and command handlers.
    * Use [[BehaviorBuilder#build]] to create the immutable [[PersistentEntity.Behavior]].
    */
-  // In order to provide javadoc preventing instantiation or extension this sealed trait is added
-  // to hold docs and BehaviorBuilderImpl is made private to hold implementation
-  sealed trait BehaviorBuilder {
+  // In order to provide javadoc preventing instantiation or extension this sealed abstract class is added
+  // to hold docs and BehaviorBuilderImpl is made private to hold implementation.
+  // It is required to be an abstract class, not a trait, because it refers to type variables from the enclosing scope.
+  // This would be legal in Scala, but causes inter-operation problems with some Java compilers (such as Eclipse).
+  sealed abstract class BehaviorBuilder {
     def getState(): State
     def setState(state: State): Unit
     /**


### PR DESCRIPTION
As an inner trait, referencing type variables from the outer scope can cause interoperation problems with Java code.

This is similar to the issue described in: https://github.com/lagom/lagom/issues/396

Fixed in: https://github.com/lagom/lagom/pull/405

The change to make `BehaviorBuilder` a trait in the first place was introduced in https://github.com/lagom/lagom/pull/1302.