### PR TITLE
Remove body parsers deprecations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -539,7 +539,11 @@ lazy val `server-scaladsl` = (project in file("service/scaladsl/server"))
       ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.server.LagomServer.router"),
 
       // changed signature of a method in a private class in https://github.com/lagom/lagom/pull/1109
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.scaladsl.server.ActorSystemProvider.start")
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.scaladsl.server.ActorSystemProvider.start"),
+
+      // injected body parsers to avoid access to global state in https://github.com/lagom/lagom/pull/1401
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.server.LagomServerBuilder.this"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.server.LagomServerComponents.playBodyParsers")
     )
   )
   .enablePlugins(RuntimeLibPlugins)

--- a/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
+++ b/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala
@@ -117,10 +117,10 @@ class ResolvedServicesProvider(bindings: Seq[ServiceGuiceSupport.ServiceBinding[
 }
 
 @Singleton
-class JavadslServicesRouter @Inject() (resolvedServices: ResolvedServices, httpConfiguration: HttpConfiguration)(implicit ec: ExecutionContext, mat: Materializer) extends SimpleRouter with LagomServiceRouter {
+class JavadslServicesRouter @Inject() (resolvedServices: ResolvedServices, httpConfiguration: HttpConfiguration, parsers: PlayBodyParsers)(implicit ec: ExecutionContext, mat: Materializer) extends SimpleRouter with LagomServiceRouter {
 
   private val serviceRouters = resolvedServices.services.map { service =>
-    new JavadslServiceRouter(service.descriptor, service.service, httpConfiguration)
+    new JavadslServiceRouter(service.descriptor, service.service, httpConfiguration, parsers)
   }
 
   override val routes: Routes =
@@ -129,8 +129,8 @@ class JavadslServicesRouter @Inject() (resolvedServices: ResolvedServices, httpC
   override def documentation: Seq[(String, String, String)] = serviceRouters.flatMap(_.documentation)
 }
 
-class JavadslServiceRouter(override protected val descriptor: Descriptor, service: Any, httpConfiguration: HttpConfiguration)(implicit ec: ExecutionContext, mat: Materializer)
-  extends ServiceRouter(httpConfiguration) with JavadslServiceApiBridge with LagomServiceRouter {
+class JavadslServiceRouter(override protected val descriptor: Descriptor, service: Any, httpConfiguration: HttpConfiguration, parsers: PlayBodyParsers)(implicit ec: ExecutionContext, mat: Materializer)
+  extends ServiceRouter(httpConfiguration, parsers) with JavadslServiceApiBridge with LagomServiceRouter {
 
   private class JavadslServiceRoute(override val call: Call[Any, Any]) extends ServiceRoute {
     override val path: Path = JavadslPath.fromCallId(call.callId)

--- a/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslErrorHandlingSpec.scala
+++ b/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslErrorHandlingSpec.scala
@@ -222,7 +222,7 @@ class ScaladslErrorHandlingSpec extends WordSpec with Matchers {
           ))
 
         // Custom server builder to inject our changeServer callback
-        override lazy val lagomServerBuilder = new LagomServerBuilder(httpConfiguration, new ServiceResolver {
+        override lazy val lagomServerBuilder = new LagomServerBuilder(httpConfiguration, playBodyParsers, new ServiceResolver {
           override def resolve(descriptor: Descriptor): Descriptor = changeServer(serviceResolver.resolve(descriptor))
         })(materializer, executionContext)
 

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
@@ -12,18 +12,17 @@ import com.lightbend.lagom.internal.server.ServiceRouter
 import com.lightbend.lagom.scaladsl.api.Descriptor
 import com.lightbend.lagom.scaladsl.api.Descriptor.RestCallId
 import com.lightbend.lagom.scaladsl.api.ServiceSupport.ScalaMethodServiceCall
-import com.lightbend.lagom.scaladsl.api.deser.StreamedMessageSerializer
 import com.lightbend.lagom.scaladsl.api.transport._
 import com.lightbend.lagom.scaladsl.server.{ LagomServiceRouter, PlayServiceCall }
 import play.api.Logger
 import play.api.http.HttpConfiguration
-import play.api.mvc.EssentialAction
+import play.api.mvc.{ EssentialAction, PlayBodyParsers }
 
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 
-class ScaladslServiceRouter(override protected val descriptor: Descriptor, service: Any, httpConfiguration: HttpConfiguration)(implicit ec: ExecutionContext, mat: Materializer)
-  extends ServiceRouter(httpConfiguration) with LagomServiceRouter with ScaladslServiceApiBridge {
+class ScaladslServiceRouter(override protected val descriptor: Descriptor, service: Any, httpConfiguration: HttpConfiguration, parsers: PlayBodyParsers)(implicit ec: ExecutionContext, mat: Materializer)
+  extends ServiceRouter(httpConfiguration, parsers) with LagomServiceRouter with ScaladslServiceApiBridge {
 
   private class ScaladslServiceRoute(override val call: Call[Any, Any]) extends ServiceRoute {
     override val path: Path = ScaladslPath.fromCallId(call.callId)

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStreamedServiceRouterSpec.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStreamedServiceRouterSpec.scala
@@ -18,7 +18,7 @@ import org.scalatest.{ Assertion, AsyncFlatSpec, BeforeAndAfterAll, Matchers }
 import play.api.http.HttpConfiguration
 import play.api.http.websocket.{ Message, TextMessage }
 import play.api.mvc
-import play.api.mvc.Handler
+import play.api.mvc.{ Handler, PlayBodyParsers }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -75,7 +75,8 @@ class ScaladslStreamedServiceRouterSpec extends AsyncFlatSpec with Matchers with
 
   private def runRequest(service: Service)(x: mvc.WebSocket => mvc.RequestHeader => Future[WSFlow])(block: => Assertion): Future[Assertion] = {
     val httpConfig = HttpConfiguration.createWithDefaults()
-    val router = new ScaladslServiceRouter(service.descriptor, service, httpConfig)
+    val parsers = PlayBodyParsers()
+    val router = new ScaladslServiceRouter(service.descriptor, service, httpConfig, parsers)
     val req: mvc.Request[NotUsed] = new FakeRequest(method = "GET", path = PathProvider.PATH)
     val handler = router.routes(req)
     val futureResult: Future[WSFlow] = Handler.applyStages(req, handler) match {

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStrictServiceRouterSpec.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/ScaladslStrictServiceRouterSpec.scala
@@ -16,7 +16,7 @@ import com.lightbend.lagom.scaladsl.server.testkit.FakeRequest
 import org.scalatest.{ AsyncFlatSpec, BeforeAndAfterAll, Matchers }
 import play.api.http.HttpConfiguration
 import play.api.mvc
-import play.api.mvc.Handler
+import play.api.mvc.{ Handler, PlayBodyParsers }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -137,7 +137,8 @@ class ScaladslStrictServiceRouterSpec extends AsyncFlatSpec with Matchers with B
 
   private def runRequest[T](service: Service)(x: mvc.EssentialAction => mvc.RequestHeader => Future[mvc.Result])(block: mvc.Result => T): Future[T] = {
     val httpConfig = HttpConfiguration.createWithDefaults()
-    val router = new ScaladslServiceRouter(service.descriptor, service, httpConfig)
+    val parsers = PlayBodyParsers()
+    val router = new ScaladslServiceRouter(service.descriptor, service, httpConfig, parsers)
     val req: mvc.Request[NotUsed] = new FakeRequest(method = "GET", path = PathProvider.PATH)
     val handler = router.routes(req)
     val futureResult: Future[mvc.Result] = Handler.applyStages(req, handler) match {


### PR DESCRIPTION
## Purpose

This removes access to the global state through BodyParsers. Now a PlayBodyParsers is injected or accessed through compile-time dependencies.