### PR TITLE
Remove APIs that depends on deprecated play.Configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -390,7 +390,11 @@ lazy val `api-javadsl` = (project in file("service/javadsl/api"))
   .settings(mimaSettings(since10): _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
-    Dependencies.`api-javadsl`
+    Dependencies.`api-javadsl`,
+    mimaBinaryIssueFilters ++= Seq(
+      // play.Configuration removal in https://github.com/lagom/lagom/pull/1402
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.javadsl.api.ConfigurationServiceLocator.this")
+    )
   ).dependsOn(api)
 
 lazy val `api-scaladsl` = (project in file("service/scaladsl/api"))
@@ -475,7 +479,11 @@ lazy val `client-javadsl` = (project in file("service/javadsl/client"))
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-javadsl-client",
-    Dependencies.`client-javadsl`
+    Dependencies.`client-javadsl`,
+    mimaBinaryIssueFilters ++= Seq(
+      // play.Configuration removal in https://github.com/lagom/lagom/pull/1402
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.javadsl.client.ConfigurationServiceLocator.this")
+    )
   )
   .dependsOn(client, `api-javadsl`, jackson)
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/src/main/java/impl/Module.java
@@ -40,7 +40,7 @@ class OnStart {
 
     try(FileWriter writer = new FileWriter(environment.getFile("target/injected-cassandra.conf"), true)) {
       for(String key: keys) {
-        String value = config.getString(key);
+        String value = configuration.getString(key);
         writer.write(key + "="+value+"\n");
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/src/main/java/impl/Module.java
@@ -10,6 +10,8 @@ import java.io.*;
 import java.util.Arrays;
 import java.util.ArrayList;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -25,19 +27,18 @@ class OnStart {
   public static String CASSANDRA_SNAPSHOT_STORE_PORT     = "cassandra-snapshot-store.port";
   public static String LAGOM_CASSANDRA_READ_KEYSPACE     = "lagom.persistence.read-side.cassandra.keyspace";
   public static String LAGOM_CASSANDRA_READ_PORT         = "lagom.persistence.read-side.cassandra.port";
-  
+
   @Inject
-  public OnStart(Application app) {
+  public OnStart(Environment environment, Config configuration) {
   	dumpInjectedCassandraConfig(app);
   }
 
-  private void dumpInjectedCassandraConfig(Application app) {
-    Configuration config = app.configuration();
-    ArrayList<String> keys = new ArrayList<>(Arrays.asList(CASSANDRA_JOURNAL_KEYSPACE, CASSANDRA_JOURNAL_PORT, 
+  private void dumpInjectedCassandraConfig(Environment environment, Config configuration) {
+    ArrayList<String> keys = new ArrayList<>(Arrays.asList(CASSANDRA_JOURNAL_KEYSPACE, CASSANDRA_JOURNAL_PORT,
       CASSANDRA_SNAPSHOT_STORE_KEYSPACE, CASSANDRA_SNAPSHOT_STORE_PORT,
       LAGOM_CASSANDRA_READ_KEYSPACE, LAGOM_CASSANDRA_READ_PORT));
 
-    try(FileWriter writer = new FileWriter(app.getFile("target/injected-cassandra.conf"), true)) {
+    try(FileWriter writer = new FileWriter(environment.getFile("target/injected-cassandra.conf"), true)) {
       for(String key: keys) {
         String value = config.getString(key);
         writer.write(key + "="+value+"\n");

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/src/main/java/impl/Module.java
@@ -30,7 +30,7 @@ class OnStart {
 
   @Inject
   public OnStart(Environment environment, Config configuration) {
-  	dumpInjectedCassandraConfig(app);
+    dumpInjectedCassandraConfig(environment, configuration);
   }
 
   private void dumpInjectedCassandraConfig(Environment environment, Config configuration) {

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/src/main/java/impl/Module.java
@@ -10,6 +10,8 @@ import java.io.*;
 import java.util.Arrays;
 import java.util.ArrayList;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -25,14 +27,13 @@ class OnStart {
 
   public static String INTERNAL_ACTOR_SYSTEM_NAME        = "lagom.akka.dev-mode.actor-system.name";
   public static String APPLICATION_ACTOR_SYSTEM_NAME     = "play.akka.actor-system";
-  
+
   @Inject
-  public OnStart(Application app) {
-  	dumpInjectedConfig(app);
+  public OnStart(Environment environment, Config configuration) {
+  	dumpInjectedConfig(environment, configuration);
   }
 
-  private void dumpInjectedConfig(Application app) {
-    Configuration config = app.configuration();
+  private void dumpInjectedConfig(Environment environment, Config configuration) {
     ArrayList<String> keys = new ArrayList<>(Arrays.asList(
             CASSANDRA_JOURNAL_PORT,
             CASSANDRA_SNAPSHOT_STORE_PORT,
@@ -41,7 +42,7 @@ class OnStart {
             APPLICATION_ACTOR_SYSTEM_NAME
     ));
 
-    try(FileWriter writer = new FileWriter(app.getFile("target/injected-config.conf"), true)) {
+    try(FileWriter writer = new FileWriter(environment.getFile("target/injected-config.conf"), true)) {
       for(String key: keys) {
         String value = config.getString(key);
         writer.write(key + "="+value+"\n");

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/src/main/java/impl/Module.java
@@ -44,7 +44,7 @@ class OnStart {
 
     try(FileWriter writer = new FileWriter(environment.getFile("target/injected-config.conf"), true)) {
       for(String key: keys) {
-        String value = config.getString(key);
+        String value = configuration.getString(key);
         writer.write(key + "="+value+"\n");
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/a/impl/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/a/impl/src/main/java/impl/Module.java
@@ -8,6 +8,8 @@ import javax.inject.Inject;
 import java.util.Date;
 import java.io.*;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -19,18 +21,18 @@ public class Module extends AbstractModule implements ServiceGuiceSupport {
 class OnStart {
 
   @Inject
-  public OnStart(Application app) {
-  	doOnStart(app);
+  public OnStart(Environment environment, Config configuration) {
+  	doOnStart(environment, configuration);
   }
 
-  private void doOnStart(Application app) {
+  private void doOnStart(Environment environment, Config configuration) {
   	try {
   	  // open for append
-      FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+      FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
       writer.write(new Date() + " - reloaded\n");
       writer.close();
 
-      if (app.configuration().getBoolean("fail", false)) {
+      if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
         throw new RuntimeException();
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/b/impl/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/b/impl/src/main/java/impl/Module.java
@@ -9,6 +9,8 @@ import javax.inject.Inject;
 import java.util.Date;
 import java.io.*;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -21,18 +23,18 @@ public class Module extends AbstractModule implements ServiceGuiceSupport {
 class OnStart {
 
   @Inject
-  public OnStart(Application app) {
-  	doOnStart(app);
+  public OnStart(Environment environment, Config configuration) {
+  	doOnStart(environment, configuration);
   }
 
-  private void doOnStart(Application app) {
+  private void doOnStart(Environment environment, Config configuration) {
   	try {
   	  // open for append
-      FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+      FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
       writer.write(new Date() + " - reloaded\n");
       writer.close();
 
-      if (app.configuration().getBoolean("fail", false)) {
+      if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
         throw new RuntimeException();
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/c/src-c/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/c/src-c/main/java/impl/Module.java
@@ -8,6 +8,8 @@ import javax.inject.Inject;
 import java.util.Date;
 import java.io.*;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -19,18 +21,18 @@ public class Module extends AbstractModule implements ServiceGuiceSupport {
 class OnStart {
 
   @Inject
-  public OnStart(Application app) {
-  	doOnStart(app);
+  public OnStart(Environment environment, Config configuration) {
+  	doOnStart(environment, configuration);
   }
 
-  private void doOnStart(Application app) {
+  private void doOnStart(Environment environment, Config configuration) {
   	try {
   	  // open for append
-      FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+      FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
       writer.write(new Date() + " - reloaded\n");
       writer.close();
 
-      if (app.configuration().getBoolean("fail", false)) {
+      if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
         throw new RuntimeException();
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/src/main/java/impl/Module.java
@@ -8,6 +8,8 @@ import javax.inject.Inject;
 import java.util.Date;
 import java.io.*;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -19,18 +21,18 @@ public class Module extends AbstractModule implements ServiceGuiceSupport {
 class OnStart {
 
   @Inject
-  public OnStart(Application app) {
-  	doOnStart(app);
+  public OnStart(Environment environment, Config configuration) {
+  	doOnStart(environment, configuration);
   }
 
-  private void doOnStart(Application app) {
+  private void doOnStart(Environment environment, Config configuration) {
   	try {
   	  // open for append
-      FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+      FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
       writer.write(new Date() + " - reloaded\n");
       writer.close();
 
-      if (app.configuration().getBoolean("fail", false)) {
+      if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
         throw new RuntimeException();
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/src/main/java/impl/Module.java
@@ -8,6 +8,8 @@ import javax.inject.Inject;
 import java.util.Date;
 import java.io.*;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -19,18 +21,18 @@ public class Module extends AbstractModule implements ServiceGuiceSupport {
 class OnStart {
 
   @Inject
-  public OnStart(Application app) {
-  	doOnStart(app);
+  public OnStart(Environment environment, Config configuration) {
+  	doOnStart(environment, configuration);
   }
 
-  private void doOnStart(Application app) {
+  private void doOnStart(Environment environment, Config configuration) {
   	try {
   	  // open for append
-      FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+      FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
       writer.write(new Date() + " - reloaded\n");
       writer.close();
 
-      if (app.configuration().getBoolean("fail", false)) {
+      if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
         throw new RuntimeException();
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/bar/impl/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/bar/impl/src/main/java/impl/Module.java
@@ -8,6 +8,8 @@ import javax.inject.Inject;
 import java.util.Date;
 import java.io.*;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport {
 	@Override
 	protected void configure() {
@@ -19,18 +21,18 @@ public class Module extends AbstractModule implements ServiceGuiceSupport {
 class OnStart {
 
   @Inject
-  public OnStart(Application app) {
-  	doOnStart(app);
+  public OnStart(Environment environment, Config configuration) {
+  	doOnStart(environment, configuration);
   }
 
-  private void doOnStart(Application app) {
+  private void doOnStart(Environment environment, Config configuration) {
   	try {
   	  // open for append
-      FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+      FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
       writer.write(new Date() + " - reloaded\n");
       writer.close();
 
-      if (app.configuration().getBoolean("fail", false)) {
+      if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
         throw new RuntimeException();
       }
     }

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/foo/impl/src/main/java/impl/Module.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/foo/impl/src/main/java/impl/Module.java
@@ -10,6 +10,8 @@ import javax.inject.Inject;
 import java.util.Date;
 import java.io.*;
 
+import com.typesafe.config.Config;
+
 public class Module extends AbstractModule implements ServiceGuiceSupport, ServiceClientGuiceSupport {
 	@Override
 	protected void configure() {
@@ -22,18 +24,18 @@ public class Module extends AbstractModule implements ServiceGuiceSupport, Servi
 class OnStart {
 
   @Inject
-  public OnStart(Application app) {
-  	doOnStart(app);
+  public OnStart(Environment environment, Config configuration) {
+  	doOnStart(environment, configuration);
   }
 
-  private void doOnStart(Application app) {
+  private void doOnStart(Environment environment, Config configuration) {
   	try {
   	  // open for append
-      FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+      FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
       writer.write(new Date() + " - reloaded\n");
       writer.close();
 
-      if (app.configuration().getBoolean("fail", false)) {
+      if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
         throw new RuntimeException();
       }
     }

--- a/dev/sbt-scripted-library/src/main/java/impl/FooModule.java
+++ b/dev/sbt-scripted-library/src/main/java/impl/FooModule.java
@@ -6,6 +6,7 @@ package impl;
 import com.google.inject.AbstractModule;
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
 import api.FooService;
+import com.typesafe.config.Config;
 import play.*;
 import javax.inject.Inject;
 import java.util.Date;
@@ -22,18 +23,18 @@ public class FooModule extends AbstractModule implements ServiceGuiceSupport {
 class FooOnStart {
 
     @Inject
-    public FooOnStart(Application app) {
-        doOnStart(app);
+    public FooOnStart(Environment environment, Config configuration) {
+        doOnStart(environment, configuration);
     }
 
-    private void doOnStart(Application app) {
+    private void doOnStart(Environment environment, Config configuration) {
         try {
             // open for append
-            FileWriter writer = new FileWriter(app.getFile("target/reload.log"), true);
+            FileWriter writer = new FileWriter(environment.getFile("target/reload.log"), true);
             writer.write(new Date() + " - reloaded\n");
             writer.close();
 
-            if (app.configuration().getBoolean("fail", false)) {
+            if (configuration.hasPathOrNull("fail") && configuration.getBoolean("fail")) {
                 throw new RuntimeException();
             }
         }

--- a/docs/src/test/java/docs/home/persistence/CqrsIntegrationTest.java
+++ b/docs/src/test/java/docs/home/persistence/CqrsIntegrationTest.java
@@ -83,7 +83,7 @@ public class CqrsIntegrationTest {
 
   @AfterClass
   public static void teardown() {
-    application.getWrappedApplication().stop();
+    application.asScala().stop();
     application = null;
     system = null;
     injector = null;

--- a/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
+++ b/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
@@ -69,7 +69,7 @@ public class PersistentEntityRefTest {
 
   @AfterClass
   public static void teardown() {
-    application.getWrappedApplication().stop();
+    application.asScala().stop();
     CassandraLauncher.stop();
   }
 

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/ConfigurationServiceLocator.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/ConfigurationServiceLocator.java
@@ -7,7 +7,6 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
-import play.Configuration;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -50,14 +49,6 @@ public class ConfigurationServiceLocator implements ServiceLocator {
             }
         }
         this.services = HashTreePMap.from(services);
-    }
-
-    /**
-     * @deprecated use {@link ConfigurationServiceLocator(Config)} instead.
-     */
-    @Deprecated
-    public ConfigurationServiceLocator(Configuration configuration) {
-        this(configuration.underlying());
     }
 
     @Override

--- a/service/javadsl/client/src/main/java/com/lightbend/lagom/javadsl/client/ConfigurationServiceLocator.java
+++ b/service/javadsl/client/src/main/java/com/lightbend/lagom/javadsl/client/ConfigurationServiceLocator.java
@@ -3,15 +3,12 @@
  */
 package com.lightbend.lagom.javadsl.client;
 
-import com.lightbend.lagom.internal.client.CircuitBreakers;
 import com.lightbend.lagom.internal.client.ConfigExtensions;
-import com.lightbend.lagom.internal.javadsl.client.CircuitBreakersPanelImpl;
 import com.lightbend.lagom.javadsl.api.Descriptor;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
-import play.Configuration;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -29,16 +26,6 @@ public class ConfigurationServiceLocator extends CircuitBreakingServiceLocator {
 
     private static final String LAGOM_SERVICES_KEY = "lagom.services";
     private final PMap<String, List<URI>> services;
-
-
-    /**
-     * @param circuitBreakers
-     * @deprecated Use constructor accepting {@link CircuitBreakersPanel} instead
-     */
-    @Deprecated
-    public ConfigurationServiceLocator(Configuration configuration, CircuitBreakers circuitBreakers) {
-        this(configuration.underlying(), new CircuitBreakersPanelImpl(circuitBreakers));
-    }
 
     @Inject
     public ConfigurationServiceLocator(Config config, CircuitBreakersPanel circuitBreakersPanel) {

--- a/service/javadsl/integration-tests/src/test/scala/com/lightbend/lagom/it/ServiceSupport.scala
+++ b/service/javadsl/integration-tests/src/test/scala/com/lightbend/lagom/it/ServiceSupport.scala
@@ -42,7 +42,7 @@ trait ServiceSupport extends WordSpecLike with Matchers with Inside {
     }
     val jBlock = new Procedure[TestServer] {
       override def apply(server: TestServer): Unit = {
-        block(server.app.getWrappedApplication)
+        block(server.app.asScala())
       }
     }
     val setup = ServiceTest.defaultSetup.configureBuilder(jConfigureBuilder).withCluster(false)

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -242,7 +242,7 @@ object ServiceTest {
      * by `withServer`.
      */
     def stop(): Unit = {
-      Try(Play.stop(app.getWrappedApplication))
+      Try(Play.stop(app.asScala()))
       Try(server.stop())
     }
   }
@@ -335,10 +335,10 @@ object ServiceTest {
 
     val application = setup.configureBuilder(finalBuilder).build()
 
-    Play.start(application.getWrappedApplication)
+    Play.start(application.asScala())
 
     val serverConfig = ServerConfig(port = Some(0), mode = Mode.Test)
-    val srv = ServerProvider.defaultServerProvider.createServer(serverConfig, application.getWrappedApplication)
+    val srv = ServerProvider.defaultServerProvider.createServer(serverConfig, application.asScala())
     val assignedPort = srv.httpPort.orElse(srv.httpsPort).get
     port.success(assignedPort)
 


### PR DESCRIPTION
## Purpose

Remove all places where `play.Configuration` is used.

This includes calls to `play.Application.configuration`. Additionally, removed calls to `play.Application.getFile` since it was deprecated too.