### PR TITLE
Removes deprecated usage of Global App in LagomReloadableDevServerStart

### DIFF
--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -8,13 +8,14 @@ import java.net.InetAddress
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import play.api.ApplicationLoader.DevContext
 import play.api._
 import play.core.{ ApplicationProvider, BuildLink, SourceMapper }
 import play.core.server.ReloadableServer
 import play.utils.Threads
 
 import scala.collection.JavaConverters._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{ Await, ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
@@ -94,7 +95,6 @@ object LagomReloadableDevServerStart {
         }
 
         val before = System.currentTimeMillis()
-        val address = InetAddress.getLocalHost
         val after = System.currentTimeMillis()
         if (after - before > startupWarningThreshold) {
           println(play.utils.Colors.red("WARNING: Retrieving local host name ${address} took more than ${startupWarningThreshold}ms, this can create problems at startup with Lagom"))
@@ -133,9 +133,14 @@ object LagomReloadableDevServerStart {
               // Let's load the application on another thread
               // as we are now on the Netty IO thread.
               //
-              // Because we are on DEV mode here, it doesn't really matter
-              // but it's more coherent with the way it works in PROD mode.
-              implicit val ec = play.core.Execution.internalContext
+              // this whole Await.result(Future{}) thing has been revisited in Play
+              // but the issue is not yet fully addressed there neither
+              // see issues:
+              // https://github.com/playframework/playframework/pull/7627
+              // and https://github.com/playframework/playframework/pull/7644
+              //
+              // we should reconsider if still need to have our own reloadable server
+              implicit val ec = ExecutionContext.global
               Await.result(scala.concurrent.Future {
 
                 val reloaded = buildLink.reload match {
@@ -171,7 +176,11 @@ object LagomReloadableDevServerStart {
                       }
 
                       val newApplication = Threads.withContextClassLoader(projectClassloader) {
-                        val context = ApplicationLoader.createContext(environment, dirAndDevSettings, Some(sourceMapper))
+                        val context = ApplicationLoader.Context.create(
+                          environment = environment,
+                          initialSettings = dirAndDevSettings,
+                          devContext = Some(DevContext(sourceMapper, buildLink))
+                        )
                         val loader = ApplicationLoader(context)
                         loader.load(context)
                       }
@@ -187,21 +196,20 @@ object LagomReloadableDevServerStart {
                         logExceptionAndGetResult(path, e, hint)
                         lastState
 
-                      case e: PlayException => {
+                      case e: PlayException =>
                         lastState = Failure(e)
                         logExceptionAndGetResult(path, e)
                         lastState
-                      }
-                      case NonFatal(e) => {
+
+                      case NonFatal(e) =>
                         lastState = Failure(UnexpectedException(unexpected = Some(e)))
                         logExceptionAndGetResult(path, e)
                         lastState
-                      }
-                      case e: LinkageError => {
+
+                      case e: LinkageError =>
                         lastState = Failure(UnexpectedException(unexpected = Some(e)))
                         logExceptionAndGetResult(path, e)
                         lastState
-                      }
                     }
                   }
 


### PR DESCRIPTION
Global App is now deprecated in Play 2.7.x. This PR make sure that we don't depend on it in the `LagomReloadableDevServerStart`