### PR TITLE
Remove "or higher" from JDK requirements

### DIFF
--- a/docs/manual/java/gettingstarted/JavaPrereqs.md
+++ b/docs/manual/java/gettingstarted/JavaPrereqs.md
@@ -12,7 +12,7 @@ Reference these sections for help with:
 
 ## JDK
 
-Before installing a build tool, verify that you have a Java Development Kit (JDK), version 8 or higher and that your machine is configured correctly.
+Before installing a build tool, verify that you have a Java Development Kit (JDK), version 8 and that your machine is configured correctly.
 
 Check the JDK version by running `java` and `javac` from the command line:
 

--- a/docs/manual/java/guide/build/EclipseMavenInt.md
+++ b/docs/manual/java/guide/build/EclipseMavenInt.md
@@ -10,17 +10,17 @@ If you have a Maven project created from an archetype (as described in [[Creatin
 Before attempting to create a Lagom Maven project in Eclipse, ensure that Eclipse is configured with the following:
 
 * An [m2eclipse](https://www.eclipse.org/m2e/documentation/m2e-documentation.html) plugin compatible with Maven 3.3 or higher.
-* A JDK 1.8 or higher.
+* A JDK 1.8
 
 # Import the project
 
 1. From the **File** menu, select **Import**.
-   The **Select** screen opens. 
+   The **Select** screen opens.
 1. Expand **Maven** and select **Existing Maven Projects**.
     [[EclSelectImportType.png]]
 1. Click **Next**.
 1. For **Root Directory**, click **Browse** and select the top-level project folder.
-    [[EclBrowseMvnImp.png]]  
+    [[EclBrowseMvnImp.png]]
 1. Verify that the **Projects** list includes all subprojects and click **Finish**.
 1. Run the project:
     1. Right-click the parent project folder.
@@ -28,12 +28,12 @@ Before attempting to create a Lagom Maven project in Eclipse, ensure that Eclips
     1. Optionally, change the name.
     1. Select **Run as ...** > **Maven Build**.
     1. In the **Goals** field, enter `lagom:runAll`.
-    1. Select the **JRE** tab and make sure it is pointing at a JRE associated with a JDK. 
+    1. Select the **JRE** tab and make sure it is pointing at a JRE associated with a JDK.
     1. Click **Run**.
-    
-    
-The console should report that the services started. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser: 
-    
+
+
+The console should report that the services started. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser:
+
     ```
     http://localhost:9000/api/hello/World
     ```

--- a/docs/manual/java/guide/build/EclipseMavenNew.md
+++ b/docs/manual/java/guide/build/EclipseMavenNew.md
@@ -10,7 +10,7 @@ The Lagom Maven archetype allows you to quickly create a project for development
 Before attempting to create a Lagom Maven project in Eclipse, ensure that Eclipse is configured with the following:
 
 * An [m2eclipse](https://www.eclipse.org/m2e/documentation/m2e-documentation.html) plugin compatible with Maven 3.3 or higher.
-* A JDK 1.8 or higher.
+* A JDK 1.8
 
 ## Create an Eclipse project
 
@@ -18,42 +18,42 @@ The screen shots on this page reflect Eclipse Neon (4.6.2) with M2E (Maven Integ
 
 In Eclipse, follow these steps to create a project using the Lagom Maven archetype:
 
-1. From the **File** menu, select **New > Project**.  
-    The **New Project** screen opens. 
-1. Expand **Maven**, select **Maven Project**, and click **Next**. 
+1. From the **File** menu, select **New > Project**.
+    The **New Project** screen opens.
+1. Expand **Maven**, select **Maven Project**, and click **Next**.
     The **New Maven project** wizard opens. [[EclNewMavenProj.png]]
-1. Leave the default, **Use default Workspace location** box selected and click **Next**. 
+1. Leave the default, **Use default Workspace location** box selected and click **Next**.
     The **Select an archetype** page opens.[[EclSelectArch.png]]
 1. If the Lagom archetype appears in the list, select it. If not, click **Add Archetype** and supply the following values:
     * **Archetype Group Id:** com.lightbend.lagom
     * **Archetype Artifact Id:** maven-archetype-lagom-java
-    * **Version:** The Lagom version number. Be sure to use the [current stable release](https://www.lagomframework.com/documentation/). 
+    * **Version:** The Lagom version number. Be sure to use the [current stable release](https://www.lagomframework.com/documentation/).
     * **Repository URL:** Leave blank
     [[EclAddArchetype.png]]
-    
-1. Click **OK**.    
+
+1. Click **OK**.
     The next page of the wizard opens, providing fields to identify the project and displaying the `hello` and `stream` properties from the archetype.
-    
+
 1. To identify your project, enter the following:
     * **Group Id**  - Usually a reversed domain name, such as `com.example.hello`.
-    * **Artifact Id** - Maven also uses this value as the name for the top-level project folder. You might want to use a value such as `my-first-system`. 
+    * **Artifact Id** - Maven also uses this value as the name for the top-level project folder. You might want to use a value such as `my-first-system`.
     * **Version** - A version number for your project.
-    * **Package** - By default, the same as the `groupId`. 
-    
-1. Click **Finish** and the projects created by the archetype display in the **Package Explorer**. 
+    * **Package** - By default, the same as the `groupId`.
+
+1. Click **Finish** and the projects created by the archetype display in the **Package Explorer**.
 
 1. Run the project:
     1. Right-click the parent project folder.
     Eclipse puts all of the Maven project folders at the same level, so be sure to select the correct one. For example, if you used `my-first-system` as the Maven artifact ID, right-click `my-first-system`.
     1. Select **Run as ...** > **Maven Build**.
     1. In the **Goals** field, enter `lagom:runAll`.
-    1. Select the **JRE** tab and make sure it is pointing at a JRE associated with a JDK. 
+    1. Select the **JRE** tab and make sure it is pointing at a JRE associated with a JDK.
     1. Click **Run**.
-    
-The console should report that the services started. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser: 
-    
+
+The console should report that the services started. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser:
+
 ```
 http://localhost:9000/api/hello/World
 ```
 The request returns the message `Hello, World!`.
-  
+

--- a/docs/manual/java/guide/build/IntellijMaven.md
+++ b/docs/manual/java/guide/build/IntellijMaven.md
@@ -3,7 +3,7 @@
 If you worked through the command line example for [[Maven|GettingStartedMaven]], you have a Maven project that you can integrate into Intellij IDEA Using built in [IntelliJ Maven](https://www.jetbrains.com/help/idea/2016.3/getting-started-with-maven.html) support. Before integrating your project, make sure that your IntelliJ **Settings** use the following:
 
 * Maven 3.3 or higher
-* A JDK 1.8 or higher
+* A JDK 1.8
 
 > **Note** When developing with Lagom you will often run several services in a single Java Virtual Machine. See how to [[increase Memory for Maven|JVMMemoryOnDev]].
 
@@ -13,14 +13,14 @@ To integrate an existing Maven Java project into IDEA, follow these steps:
 
 1. From the `Welcome` screen, click **Import Project**.
     The `Select File or Directory to Import` dialog opens.
-    
+
 1. Navigate to your Maven project and select the top-level folder. For example, with a project named `my-first-system`:
     [[IDEASelectMavenFolder.png]]
-    
+
 1. Click **OK**.
     The **Import Project** screen opens:
     [[IDEAImportProject.png]]
-    
+
 1. For the **Import project from external model** value, select **Maven** and click **Next**.
 
 1. Select **Import Maven projects automatically** and leave the other fields with default values.
@@ -28,10 +28,10 @@ To integrate an existing Maven Java project into IDEA, follow these steps:
 1. Click **Next**.
     Your Maven project should be selected for import:
     [[IDEAProjSelected.png]]
-    
+
 1. Click **Next**.
     The **Please select project SDK** screen opens.
-    
+
 1. Make sure the correct JDC is selected and click **Next**.
 
 1. Change the project name and location if you like, and click **Finish**.
@@ -46,13 +46,13 @@ To integrate an existing Maven Java project into IDEA, follow these steps:
     1. Give your configuration a name.
     1. In the **Comand line:** field, enter `lagom:runAll`.
     1. Click **OK**.
-    
-1. Build your project and run it using the configuration you created. 
+
+1. Build your project and run it using the configuration you created.
     The console displays the following when Lagom is running:
     [[IDEASuccessMavenRun.png]]
-    
-1. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser: 
-    
+
+1. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser:
+
     ```
     http://localhost:9000/api/hello/World
     ```

--- a/docs/manual/java/guide/build/IntellijSbtJava.md
+++ b/docs/manual/java/guide/build/IntellijSbtJava.md
@@ -21,10 +21,10 @@ To verify or add the JetBrains Scala plugin, follow these steps:
     * Otherwise, from the **Welcome** page **Configure** menu, select **Settings**.
     The **Settings** (or **Plugins**) dialog will open. If you open the **Settings**, select **Plugins**.
 1. In the search box, enter `Scala`.
-    * If you have it installed, you will see an option to uninstall it. 
-    * If you do not have it installed and it does not show in the list, click **Browse repositories...**. Scroll to find the appropriate plugin and click **Install**. 
+    * If you have it installed, you will see an option to uninstall it.
+    * If you do not have it installed and it does not show in the list, click **Browse repositories...**. Scroll to find the appropriate plugin and click **Install**.
     The dialog prompts you to restart IDEA.
-    
+
 Now you are ready to import your project.
 
 ## Import an sbt project
@@ -34,35 +34,35 @@ After you have an sbt build -- one you created yourself or from a template -- fo
 1. From the **Welcome Screen** or **File** menu, select **Open**.
 1. Browse to and select the top-level folder of your sbt project, and click **OK**.
     The **Import Project from SBT** dialog opens.
-    
+
 1. For import options:
     1. Enable **use auto-import**.
     1. For **Download** options, enable **Sources** and disable **Javadocs** and **Sources for SBT and plugins**.
-    1. For **Project SDK**, verify the version (JDK 1.8 or higher). 
+    1. For **Project SDK**, verify the version (JDK 1.8).
     1. Leave **Project format:** at the default, **.idea (directory based)**. The screen should look something like this:
         [[IDEAImportOpts.png]]
-    1. Click **OK**. 
+    1. Click **OK**.
         The first time you import an sbt project, the **SBT Project Data To Import** screen opens and asks you to confirm the import. IDEA opens the project. The status bar shows sbt downloading dependencies and refreshing the project:
-    [[IDEAStatusBar.png]] 
+    [[IDEAStatusBar.png]]
 1. You can build and run the project from the **Terminal** or create a **Run Configuration** as follows:
     1. From the **Run** menu, select **Run**.
     1. Click **Edit Configurations...**.
     1. Click **+** (Add New Configuration).
     1. Select **SBT Task**.
-    1. Name your configuration. 
+    1. Name your configuration.
     1. In the **Tasks** field, enter `runAll`.
     1. Click **Run**.
         A **Run** tab opens and you should see messages from the build, with the services starting up at the end:
         [[IDEAsbtRunning.png]]
-    1. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser: 
-        
+    1. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser:
+
         ```
         http://localhost:9000/api/hello/World
         ```
         The request returns the message `Hello, World!`.
-        
 
-         
-    
 
-  
+
+
+
+

--- a/docs/manual/scala/gettingstarted/Installation.md
+++ b/docs/manual/scala/gettingstarted/Installation.md
@@ -1,6 +1,6 @@
 # Introduction and prerequisites
 
-Lagom exposes two APIs, Java and Scala, and provides a framework and development environment as a set of libraries and build tool plugins. While the libraries can be consumed from any build tool, you can only take advantage of Lagom's high productivity development environment by using one of the supported build tools, Maven or sbt. 
+Lagom exposes two APIs, Java and Scala, and provides a framework and development environment as a set of libraries and build tool plugins. While the libraries can be consumed from any build tool, you can only take advantage of Lagom's high productivity development environment by using one of the supported build tools, Maven or sbt.
 
 We recommend using [sbt](https://www.scala-sbt.org/) as the build tool for the Lagom Scala API. The sbt build tool provides dependency management, which downloads the Lagom libraries and plugins for you. When you create an sbt build, Lagom tool plugins will run your services and the associated Lagom infrastructure with a single command and hot reload when the tool detects code changes.
 
@@ -8,14 +8,14 @@ Factoring or re-factoring functionality into right-sized services will be critic
 
 > One microservice is no microservice - they come in systems.
 
-The template also gives you a quick way to verify that your project and build tool are set up correctly. Later, you can download more complex [[Lagom examples|LagomExamples]] that demonstrate Lagom functionality. 
- 
-We also suggest that you start from the command line. After using the template to create an sbt build, you can integrate it into any IDE. The documentation provides tips to help you with Eclipse or IntelliJ, two popular IDEs. 
- 
+The template also gives you a quick way to verify that your project and build tool are set up correctly. Later, you can download more complex [[Lagom examples|LagomExamples]] that demonstrate Lagom functionality.
+
+We also suggest that you start from the command line. After using the template to create an sbt build, you can integrate it into any IDE. The documentation provides tips to help you with Eclipse or IntelliJ, two popular IDEs.
+
 Before trying the template, make sure that your environment conforms to Lagom prerequisites:
 
-* Java Development Kit (JDK), version 8 or higher. 
-* sbt 1.x 
+* Java Development Kit (JDK), version 8
+* sbt 1.x
 * Internet access (If using a proxy, verify that an HTTP_PROXY environment variable points to the correct location)
 
 For more details on verifying or installing prerequisites see the following sections:

--- a/docs/manual/scala/guide/build/IntellijSbt.md
+++ b/docs/manual/scala/guide/build/IntellijSbt.md
@@ -24,10 +24,10 @@ To verify or add the JetBrains Scala plugin, follow these steps:
     * Otherwise, from the **Welcome** page **Configure** menu, select **Settings**.
     The **Settings** (or **Plugins**) dialog will open. If you open the **Settings**, select **Plugins**.
 1. In the search box, enter `Scala`.
-    * If you have it installed, you will see an option to uninstall it. 
-    * If you do not have it installed and it does not show in the list, click **Browse repositories...**. Scroll to find the appropriate plugin and click **Install**. 
+    * If you have it installed, you will see an option to uninstall it.
+    * If you do not have it installed and it does not show in the list, click **Browse repositories...**. Scroll to find the appropriate plugin and click **Install**.
     The dialog prompts you to restart IDEA.
-    
+
 Now you are ready to import your project.
 
 ## Import an sbt project
@@ -38,35 +38,35 @@ After you have an sbt build -- one you created yourself or from a template -- fo
 1. From the **Welcome Screen** or **File** menu, select **Open**.
 1. Browse to and select the top-level folder of your sbt project, and click **OK**.
     The **Import Project from SBT** dialog opens.
-    
+
 1. For import options:
     1. Enable **use auto-import**.
     1. For **Download** options, enable **Sources** and disable **Javadocs** and **Sources for SBT and plugins**.
-    1. For **Project SDK**, verify the version (JDK 1.8 or higher). 
+    1. For **Project SDK**, verify the version (JDK 1.8).
     1. Leave **Project format:** at the default, **.idea (directory based)**. The screen should look something like this:
         [[IDEAImportOpts.png]]
-    1. Click **OK**. 
+    1. Click **OK**.
         The first time you import an sbt project, the **SBT Project Data To Import** screen opens and asks you to confirm the import. IDEA opens the project. The status bar shows sbt downloading dependencies and refreshing the project:
-    [[IDEAStatusBar.png]] 
+    [[IDEAStatusBar.png]]
 1. You can build and run the project from the **Terminal** or create a **Run Configuration** as follows:
     1. From the **Run** menu, select **Run**.
     1. Click **Edit Configurations...**.
     1. Click **+** (Add New Configuration).
     1. Select **SBT Task**.
-    1. Name your configuration. 
+    1. Name your configuration.
     1. In the **Tasks** field, enter `runAll`.
     1. Click **Run**.
         A **Run** tab opens and you should see messages from the build, with the services starting up at the end:
         [[IDEAsbtRunning.png]]
-  1. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser: 
-      
+  1. Verify that the services are indeed up and running by invoking the `hello` service endpoint from any HTTP client, such as a browser:
+
   ```
   http://localhost:9000/api/hello/World
   ```
       The request returns the message `Hello, World!`.
-        
 
-         
-    
 
-  
+
+
+
+


### PR DESCRIPTION
Lagom only supports Java 8, not 9 or 10 currently.