### PR TITLE
Stop requiring squashed commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@
 
 * [ ] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
 * [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
-* [ ] Have you [squashed your commits](https://github.com/lagom/lagom/tree/master/WorkingWithGit.md)?
 * [ ] Have you added copyright headers to new files?
 * [ ] Have you updated the documentation?
 * [ ] Have you added tests for any changed functionality?

--- a/WorkingWithGit.md
+++ b/WorkingWithGit.md
@@ -13,41 +13,6 @@ Typically all work should be done in branches.  If you do work directly on maste
 
 It's up to you what you call your branches, some people like to include issue numbers in their branch name, others like to use a hierarchical structure.
 
-## Squashing commits
-
-We prefer that all pull requests be a single commit.  There are a few reasons for this:
-
-* It's much easier and less error prone to backport single commits to stable branches than backport groups of commits.  If the change is just in one commit, then there is no opportunity for error, either the whole change is cherry picked, or it isn't.
-* We aim to have our master branch to always be releasable, not just now, but also for all points in history.  If we need to back something out, we want to be confident that the commit before that is stable.
-* It's much easier to get a complete picture of what happened in history when changes are self contained in one commit.
-
-Of course, there are some situations where it's not appropriate to squash commits, this will be decided on a case by case basis, but examples of when we won't require commits to be squashed include:
-
-* When the pull request contains commits by more than one person.  In this case, we'd prefer, where it makes sense, to squash contiguous commits by the same person.
-* When the pull request is coming from a fork or branch that has been shared among the community, where rewriting history will cause issues for people that have pull changes from that fork or branch.
-* Where the pull request is a very large amount of work, and the commit log is useful in understanding the evolution of that work.
-
-However, for the general case, if your pull request contains more than one commit, then you will need to squash it.  To do this, or if you already have submitted a pull request and we ask you to squash it, then you should follow these steps:
-
-1. Ensure that you have all the changes from the core master branch in your repo:
-
-        git fetch origin
-
-2. Start an interactive rebase
-
-        git rebase -i origin/master
-
-3. This will open up a screen in your editor, allowing you to say what should be done with each commit.  If the commit message for the first commit is suitable for describing all of the commits, then leave it as is, otherwise, change the command for it from `pick` to `reword`.
-4. For each remaining commit, change the command from `pick` to `fixup`.  This tells git to merge that commit into the previous commit, using the commit message from the previous commit.
-5. Save the file and exit your editor.  Git will now start the rebase.  If you told it to reword the first commit, it will prompt you in a new editor for the wording for that commit.  If all goes well, then you're done, but it may be the case that there were conflicts when applying your changes to the most recent master branch.  If that's the case, fix the conflicts, stage the fixes, and then run:
-
-        git rebase --continue
-
-    This may need to be repeated if there are more changes that have conflicts.
-6. Now that you've rebased you can push your changes.  If you've already pushed this branch before (including if you've already created the pull request), then you will have to do a force push.  This can be done like so:
-
-        git push yourremote yourbranch --force
-
 ### Responding to reviews/build breakages
 
 If your pull request doesn't pass the CI build, if we review it and ask you to update your pull request, or if for any other reason you want to update your pull request, then rather than creating a new commit, amend the existing one.  This can be done by supplying the `--amend` flag when committing:
@@ -80,5 +45,3 @@ You may have heard it said that you shouldn't change git history once you publis
 There are definitely times when git history shouldn't be changed after being published.  The main times are when it's likely that other people have forked your repository, or pulled changes from your repository.  Changing history in those cases will make it impossible for them to safely merge changes from your repo into their repository.  For this reason, we never change history in the official Lagom Framework repository.
 
 However, when it comes to your personal fork, for branches that are just intended to be pull requests, then it's a different matter - the intent of the workflow is that your changes get "published" once they get merged into the master branch.  Before that, the history can be considered a work in progress.
-
-If however your branch is a collaboration of many people, and you believe that other people have pull from your branch for good reasons, please let us know, we won't force squashing commits where it doesn't make sense.

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -14,7 +14,6 @@ runSbt  scalariformFormat \
 git diff --exit-code || (
   echo "ERROR: Scalariform check failed, see differences above."
   echo "To fix, format your sources using sbt scalariformFormat test:scalariformFormat before submitting a    pull request."
-  echo "Additionally, please squash your commits (eg, use git commit --amend) if you're going to update this  pull request."
   false
 )
 


### PR DESCRIPTION
Ever since GitHub started offering a button to automatically squash and merge, we have stopped requiring pull request authors to squash their commits themselves. In fact, we encourage them to update pull requests with new commits to make it easier to review changes.