### PR TITLE
Standardize on US spelling

### DIFF
--- a/docs/manual/common/concepts/PolyglotSystems.md
+++ b/docs/manual/common/concepts/PolyglotSystems.md
@@ -4,7 +4,7 @@ Lagom does not expect that every service in your system will be a Lagom microser
 
 Lagom service calls map down to standard HTTP for synchronous communication and WebSockets for streaming and asynchronous messaging. Any language or framework that supports these protocols can easily consume a Lagom service.  Conversely, a Lagom service can easily talk to any service that exposes a REST API.
 
-A Lagom service's API specifies how that service uses HTTP. REST service calls are identified by an HTTP method and URI. Request and response headers can be customized. Lagom messages are serialised, by default, to ordinary JSON, using idiomatic mapping libraries that make it transparent how the JSON will be represented on the wire.
+A Lagom service's API specifies how that service uses HTTP. REST service calls are identified by an HTTP method and URI. Request and response headers can be customized. Lagom messages are serialized, by default, to ordinary JSON, using idiomatic mapping libraries that make it transparent how the JSON will be represented on the wire.
 
 
 <!--- Lagom uses the same interfaces in Lagom to Lagom service communication. --->

--- a/docs/manual/common/guide/devmode/DevEnvironment.md
+++ b/docs/manual/common/guide/devmode/DevEnvironment.md
@@ -54,7 +54,7 @@ Once the "Services started" message has appeared, if you make a change to your s
 
 ## Managing custom services
 
-By default, Lagom will, in addition to running your services, also start a service locator, a Cassandra server and a Kafka server. If using sbt, you can customise what Lagom starts, including adding other databases and infrastructure services.
+By default, Lagom will, in addition to running your services, also start a service locator, a Cassandra server and a Kafka server. If using sbt, you can customize what Lagom starts, including adding other databases and infrastructure services.
 
 > **Note:** Managing custom services is not currently supported in Maven, due to Maven's inability to arbitrarily add behaviour, such as the logic necessary to start and stop an external process, to a build. This is typically not a big problem, it simply means developers have to manually install, start and stop these services themselves.
 

--- a/docs/manual/java/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/java/guide/broker/MessageBrokerApi.md
@@ -16,7 +16,7 @@ Data flowing through a topic is serialized to JSON by default. Of course, it is 
 
 Kafka will distribute messages for a particular topic across many partitions, so that the topic can scale. Messages sent to different partitions may be processed out of order, so if the ordering of the messages you are publishing matters, you need to ensure that the messages are partitioned in such a way that order is preserved.  Typically, this means ensuring each message for a particular entity goes to the same partition.
 
-Lagom allows this by allowing you to configure a partition key strategy, which extracts the partition key out of a message. Kafka will then use this key to help decide what partition to send each message to. The partition can be selected using the [`partitionKeyStrategy`](api/index.html?com/lightbend/lagom/javadsl/api/broker/kafka/KafkaProperties.html#partitionKeyStrategy--) property, by passing a [`PartitionKeyStrategy`](api/index.html?com/lightbend/lagom/javadsl/api/broker/kafka/PartitionKeyStrategy.html) to it: 
+Lagom allows this by allowing you to configure a partition key strategy, which extracts the partition key out of a message. Kafka will then use this key to help decide what partition to send each message to. The partition can be selected using the [`partitionKeyStrategy`](api/index.html?com/lightbend/lagom/javadsl/api/broker/kafka/KafkaProperties.html#partitionKeyStrategy--) property, by passing a [`PartitionKeyStrategy`](api/index.html?com/lightbend/lagom/javadsl/api/broker/kafka/PartitionKeyStrategy.html) to it:
 
 @[withTopics](code/docs/javadsl/mb/BlogPostService.java)
 
@@ -40,7 +40,7 @@ You may not want all events persisted by your services to be published. If that 
 
 @[filter-events](code/docs/javadsl/mb/FilteredServiceImpl.java)
 
-When an event is filtered, the `TopicProducer` does not publish the event. It also does not advance the offset. If the `TopicProducer` restarts then it will resume from the last offset. If a large number of events are filtered then the last offset could be quite far behind, and so all those events will be reprocessed and filtered out again. You need to be aware that this may occur and keep the number of consecutively filtered elements relatively low and also minimise the time and resources required to perform the filtering.
+When an event is filtered, the `TopicProducer` does not publish the event. It also does not advance the offset. If the `TopicProducer` restarts then it will resume from the last offset. If a large number of events are filtered then the last offset could be quite far behind, and so all those events will be reprocessed and filtered out again. You need to be aware that this may occur and keep the number of consecutively filtered elements relatively low and also minimize the time and resources required to perform the filtering.
 
 ### Offset storage
 
@@ -84,7 +84,7 @@ For example, consider a situation where you have a blog post created event and a
 
 @[content](code/docs/javadsl/mb/BlogPostEvent.java)
 
-The `@JsonTypeInfo` annotation describes how the type of the event will be serialised. In this case, it's saying each event type will be identified by its name, and that name will go into a property called `type`. The `@JsonTypeName` on each event subclass says what the name of that event should be. And the `@JsonSubTypes` annotation is used to tell Jackson what the possible sub types of the event are, so that it knows where to look when deserializing.
+The `@JsonTypeInfo` annotation describes how the type of the event will be serialized. In this case, it's saying each event type will be identified by its name, and that name will go into a property called `type`. The `@JsonTypeName` on each event subclass says what the name of that event should be. And the `@JsonSubTypes` annotation is used to tell Jackson what the possible sub types of the event are, so that it knows where to look when deserializing.
 
 The resulting JSON for the `BlogPostCreated` event will look like this:
 
@@ -105,4 +105,4 @@ While the JSON for the `BlogPostPublished` event will look like this:
 }
 ```
 
-Finally, note the `defaultImpl = Void.class` in the `@JsonSubTypes` annotation. This tells Jackson that if it comes across an event type that it doesn't recognise the name for, to deserialize it as `null`. This is optional, but can be important for ensuring forwards compatibility in your services, if a service adds a new event subclass that it publishes, often you want your existing services that consume that event stream to just ignore it. Setting this will allow them to do that, otherwise, you'll have to upgrade all the services that consume that event stream to explicitly ignore it before you upgrade the producer that produces the events.
+Finally, note the `defaultImpl = Void.class` in the `@JsonSubTypes` annotation. This tells Jackson that if it comes across an event type that it doesn't recognize the name for, to deserialize it as `null`. This is optional, but can be important for ensuring forwards compatibility in your services, if a service adds a new event subclass that it publishes, often you want your existing services that consume that event stream to just ignore it. Setting this will allow them to do that, otherwise, you'll have to upgrade all the services that consume that event stream to explicitly ignore it before you upgrade the producer that produces the events.

--- a/docs/manual/java/guide/broker/MessageBrokerTesting.md
+++ b/docs/manual/java/guide/broker/MessageBrokerTesting.md
@@ -4,7 +4,7 @@ When decoupling communication via a Broker you can test from both ends of the `T
 
 A broker will not be started neither when writing publish nor consumption tests. Instead, Lagom provides in-memory implementations of the Broker API in order to make  tests faster. Integration tests with a complete broker should be later implemented but that is out of scope of this documentation. The provided in-memory implementation of the Broker API runs locally and provides exactly-once delivery. If you want to test your code under scenarios where there's message loss (`at-most-once`) or message duplicates (`at-least-once`) you will be responsible for writing such behaviour by injecting duplicates or skipping messages.
 
-The Lagom in-memory broker implementation will also help testing your message serialisation and deserialisation. That is only available in the tools to [[test publishing|MessageBrokerTesting#Testing-publish]] though since the publishing end is the one responsible to describe the messages being sent over the wire. When you test the consuming end of a topic, no de/serialisation will be run under the covers.
+The Lagom in-memory broker implementation will also help testing your message serialization and deserialization. That is only available in the tools to [[test publishing|MessageBrokerTesting#Testing-publish]] though since the publishing end is the one responsible to describe the messages being sent over the wire. When you test the consuming end of a topic, no de/serialization will be run under the covers.
 
 The following code samples use the `HelloService` and `AnotherService` already presented in previous sections. `HelloService` publishes `GreetingsMessage`s on the `"greetings"` topic and `AnotherService` subscribed to those messages using `atLeastOnce` semantics.
 
@@ -16,7 +16,7 @@ When a Service publishes data into a `Topic` the descriptor lists a `TopicCall` 
 
 Using a [`ServiceTest`](api/com/lightbend/lagom/javadsl/testkit/ServiceTest.html) you create a client to your Service. Using that client you can `subscribe` to the published topics. Finally, after interacting with the Service to cause the emission of some events you can assert events were published on the `Topic`.
 
-The producer end is responsible to describe the public API and provide the serialisable mappings for all messages exchanged (both in `ServiceCall`s and `TopicCall`s). The tests granting the proper behavior of the publishing operations should also test the serialisbility and deserilisability of the messages.
+The producer end is responsible to describe the public API and provide the serializable mappings for all messages exchanged (both in `ServiceCall`s and `TopicCall`s). The tests granting the proper behavior of the publishing operations should also test the serializability and deserializability of the messages.
 
 ## Testing subscription
 

--- a/docs/manual/java/guide/services/MessageSerializers.md
+++ b/docs/manual/java/guide/services/MessageSerializers.md
@@ -1,6 +1,6 @@
 # Message Serializers
 
-Out of the box, Lagom uses Jackson to serialize request and response messages.  However, you can define custom serializers on a per service call basis, as well register a serializer for a given type for the whole service, and finally you can also customise the serialization factory used by Lagom to completely change the serializers Lagom uses when no serializer is selected.
+Out of the box, Lagom uses Jackson to serialize request and response messages.  However, you can define custom serializers on a per service call basis, as well register a serializer for a given type for the whole service, and finally you can also customize the serialization factory used by Lagom to completely change the serializers Lagom uses when no serializer is selected.
 
 ## How Lagom selects a message serializer
 

--- a/docs/manual/scala/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/scala/guide/broker/MessageBrokerApi.md
@@ -40,7 +40,7 @@ You may not want all events persisted by your services to be published. If that 
 
 @[filter-events](code/docs/scaladsl/mb/FilteredServiceImpl.scala)
 
-When an event is filtered, the `TopicProducer` does not publish the event. It also does not advance the offset. If the `TopicProducer` restarts then it will resume from the last offset. If a large number of events are filtered then the last offset could be quite far behind, and so all those events will be reprocessed and filtered out again. You need to be aware that this may occur and keep the number of consecutively filtered elements relatively low and also minimise the time and resources required to perform the filtering.
+When an event is filtered, the `TopicProducer` does not publish the event. It also does not advance the offset. If the `TopicProducer` restarts then it will resume from the last offset. If a large number of events are filtered then the last offset could be quite far behind, and so all those events will be reprocessed and filtered out again. You need to be aware that this may occur and keep the number of consecutively filtered elements relatively low and also minimize the time and resources required to perform the filtering.
 
 ### Offset storage
 

--- a/docs/manual/scala/guide/broker/MessageBrokerTesting.md
+++ b/docs/manual/scala/guide/broker/MessageBrokerTesting.md
@@ -4,7 +4,7 @@ When decoupling communication via a Broker you can test from both ends of the `T
 
 A broker will not be started neither when writing publish nor consumption tests. Instead, Lagom provides in-memory implementations of the Broker API in order to make  tests faster. Integration tests with a complete broker should be later implemented but that is out of scope of this documentation. The provided in-memory implementation of the Broker API runs locally and provides exactly-once delivery. If you want to test your code under scenarios where there's message loss (`at-most-once`) or message duplicates (`at-least-once`) you will be responsible for writing such behaviour by injecting duplicates or skipping messages.
 
-The Lagom in-memory broker implementation will also help testing your message serialisation and deserialisation. That is only available in the tools to [[test publishing|MessageBrokerTesting#Testing-publish]] though since the publishing end is the one responsible to describe the messages being sent over the wire. When you test the consuming end of a topic, no de/serialisation will be run under the covers.
+The Lagom in-memory broker implementation will also help testing your message serialization and deserialization. That is only available in the tools to [[test publishing|MessageBrokerTesting#Testing-publish]] though since the publishing end is the one responsible to describe the messages being sent over the wire. When you test the consuming end of a topic, no de/serialization will be run under the covers.
 
 The following code samples use the `HelloService` and `AnotherService` already presented in previous sections. `HelloService` publishes `GreetingsMessage`s on the `"greetings"` topic and `AnotherService` subscribed to those messages using `atLeastOnce` semantics.
 
@@ -19,7 +19,7 @@ In order to start the application with a stubbed broker you will have to mixin a
 
 Use a [`ServiceTest`](api/com/lightbend/lagom/scaladsl/testkit/ServiceTest$.html) you to create a client to your Service and using that client you can `subscribe` to the published topics. Finally, after interacting with the Service to cause the emission of some events you can assert events were published on the `Topic`.
 
-The producer end is responsible to describe the public API and provide the serialisable mappings for all messages exchanged (both in `ServiceCall`s and `TopicCall`s). The tests granting the proper behavior of the publishing operations should also test the serialisbility and deserilisability of the messages.
+The producer end is responsible to describe the public API and provide the serializable mappings for all messages exchanged (both in `ServiceCall`s and `TopicCall`s). The tests granting the proper behavior of the publishing operations should also test the serializability and deserializability of the messages.
 
 
 ## Testing subscription

--- a/docs/manual/scala/guide/services/ServiceImplementation.md
+++ b/docs/manual/scala/guide/services/ServiceImplementation.md
@@ -6,7 +6,7 @@ For example, here's an implementation of the `HelloService` descriptor:
 
 @[hello-service-impl](code/ServiceImplementation.scala)
 
-As you can see, the `sayHello` method is implemented using the `apply` factory method on [`ServiceCall`](api/com/lightbend/lagom/scaladsl/api/ServiceCall$.html). This takes a function of `Request => Future[Response]` and returns a [`ServiceCall`](api/com/lightbend/lagom/scaladsl/api/ServiceCall.html) whose `invoke` method simply delegates to that function.  An important thing to realise here is that the invocation of `sayHello` itself does not execute the call, it only returns the service call to be executed.  The advantage here is that when it comes to composing the call with other cross cutting concerns, such as authentication, this can easily be done using ordinary function based composition.
+As you can see, the `sayHello` method is implemented using the `apply` factory method on [`ServiceCall`](api/com/lightbend/lagom/scaladsl/api/ServiceCall$.html). This takes a function of `Request => Future[Response]` and returns a [`ServiceCall`](api/com/lightbend/lagom/scaladsl/api/ServiceCall.html) whose `invoke` method simply delegates to that function.  An important thing to realize here is that the invocation of `sayHello` itself does not execute the call, it only returns the service call to be executed.  The advantage here is that when it comes to composing the call with other cross cutting concerns, such as authentication, this can easily be done using ordinary function based composition.
 
 Let's have a look at our [`ServiceCall`](api/com/lightbend/lagom/scaladsl/api/ServiceCall.html) interface again:
 


### PR DESCRIPTION
We want to standardize (not standardise) on US-style spelling, for consistency with the names in the API (e.g., "serializer" not "serialiser").

Forward port of #1388 and #1408, plus some extras in other files (which will need to be backported).

Thanks to @adelababinciuc for prompting us!