### PR TITLE
Read side actor restart

### DIFF
--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -29,17 +29,21 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
   import system.dispatcher
 
   protected lazy val slick = new SlickProvider(system)
-  protected lazy val offsetStore =
-    new JavadslJdbcOffsetStore(
-      slick,
-      system,
-      new OffsetTableConfiguration(
-        system.settings.config,
+
+  protected lazy val jdbcReadSide: JdbcReadSide = {
+    val offsetStore =
+      new JavadslJdbcOffsetStore(
+        slick,
+        system,
+        new OffsetTableConfiguration(
+          system.settings.config,
+          ReadSideConfig()
+        ),
         ReadSideConfig()
-      ),
-      ReadSideConfig()
-    )
-  protected lazy val jdbcReadSide: JdbcReadSide = new JdbcReadSideImpl(slick, offsetStore)
+      )
+
+    new JdbcReadSideImpl(slick, offsetStore)
+  }
 
   private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
 

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -30,20 +30,17 @@ abstract class JdbcPersistenceSpec(_system: ActorSystem) extends ActorSystemSpec
 
   protected lazy val slick = new SlickProvider(system)
 
-  protected lazy val jdbcReadSide: JdbcReadSide = {
-    val offsetStore =
-      new JavadslJdbcOffsetStore(
-        slick,
-        system,
-        new OffsetTableConfiguration(
-          system.settings.config,
-          ReadSideConfig()
-        ),
+  protected lazy val offsetStore =
+    new JavadslJdbcOffsetStore(
+      slick,
+      system,
+      new OffsetTableConfiguration(
+        system.settings.config,
         ReadSideConfig()
-      )
-
-    new JdbcReadSideImpl(slick, offsetStore)
-  }
+      ),
+      ReadSideConfig()
+    )
+  protected lazy val jdbcReadSide: JdbcReadSide = new JdbcReadSideImpl(slick, offsetStore)
 
   private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
 

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -36,7 +36,6 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
   import system.dispatcher
 
   protected lazy val slick = new SlickProvider(system)
-  protected lazy val session: JdbcSession = new JdbcSessionImpl(slick)
   protected lazy val jdbcReadSide: JdbcReadSide = new JdbcReadSideImpl(
     slick,
     new SlickOffsetStore(

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
@@ -4,7 +4,7 @@
 package com.lightbend.lagom.scaladsl.persistence.jdbc
 
 import akka.persistence.query.Sequence
-import com.lightbend.lagom.internal.scaladsl.persistence.jdbc.JdbcPersistentEntityRegistry
+import com.lightbend.lagom.internal.scaladsl.persistence.jdbc.{ JdbcPersistentEntityRegistry, JdbcSessionImpl }
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
 
@@ -17,6 +17,7 @@ class JdbcReadSideSpec extends JdbcPersistenceSpec(TestEntitySerializerRegistry)
   override def processorFactory(): ReadSideProcessor[Evt] =
     new JdbcTestEntityReadSide.TestEntityReadSideProcessor(jdbcReadSide)
 
+  lazy val session: JdbcSession = new JdbcSessionImpl(slick)
   lazy val readSide = new JdbcTestEntityReadSide(session)
 
   override def getAppendCount(id: String): Future[Long] = readSide.getAppendCount(id)

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
@@ -39,13 +39,15 @@ abstract class SlickPersistenceSpec private (_system: ActorSystem) extends Actor
   import system.dispatcher
 
   protected lazy val slick = new SlickProvider(system)
-  protected lazy val offsetStore =
-    new SlickOffsetStore(
-      system,
-      slick,
-      new OffsetTableConfiguration(system.settings.config, ReadSideConfig())
-    )
-  protected lazy val slickReadSide: SlickReadSide = new SlickReadSideImpl(slick, offsetStore)
+  protected lazy val slickReadSide: SlickReadSide = {
+    val offsetStore =
+      new SlickOffsetStore(
+        system,
+        slick,
+        new OffsetTableConfiguration(system.settings.config, ReadSideConfig())
+      )
+    new SlickReadSideImpl(slick, offsetStore)
+  }
 
   private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
 

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -3,7 +3,7 @@
  */
 package com.lightbend.lagom.internal.javadsl.persistence
 
-import akka.actor.{ Actor, ActorLogging, Props }
+import akka.actor.{ Actor, ActorLogging, Props, Status }
 import akka.cluster.sharding.ShardRegion.EntityId
 import akka.stream.javadsl.Source
 import akka.stream.scaladsl.{ Keep, RestartSource, Sink }
@@ -105,6 +105,11 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
 
     case Done =>
       throw new IllegalStateException("Stream terminated when it shouldn't")
+
+    case Status.Failure(cause) =>
+      // Crash if the globalPrepareTask or the event stream fail
+      // This actor will be restarted by ClusterDistribution
+      throw cause
 
   }
 

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
@@ -88,7 +88,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
         sender() ! Status.Failure(new RuntimeException("Simulated global prepare failure"))
         stats = stats.recordFailure()
 
-      case Mock.SwitchMode => context.become(successMode)
+      case Mock.BecomeSuccessful => context.become(successMode)
     }
 
     def getStats: Receive = {
@@ -102,7 +102,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
       def recordFailure() = copy(failureCount = failureCount + 1)
       def recordSuccess() = copy(successCount = successCount + 1)
     }
-    case object SwitchMode
+    case object BecomeSuccessful
     case object GetStats
   }
 
@@ -205,7 +205,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
       assertAppendCount("1", 5L)
 
       // switch mock to 'Success' mode
-      mockRef ! Mock.SwitchMode
+      mockRef ! Mock.BecomeSuccessful
       readSideActor.foreach(_ ! EnsureActive(tag.tag))
 
       eventually {

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -79,7 +79,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
           .map { _ => Done } pipeTo sender()
         stats = stats.recordSuccess()
 
-      case Mock.SwitchMode => context.become(failureMode)
+      case Mock.BecomeSuccessful => context.become(failureMode)
     }
 
     def failureMode: Receive = getStats.orElse {
@@ -87,7 +87,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
         sender() ! Status.Failure(new RuntimeException("Simulated global prepare failure"))
         stats = stats.recordFailure()
 
-      case Mock.SwitchMode => context.become(successMode)
+      case Mock.BecomeSuccessful => context.become(successMode)
     }
 
     def getStats: Receive = {
@@ -101,7 +101,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
       def recordFailure() = copy(failureCount = failureCount + 1)
       def recordSuccess() = copy(successCount = successCount + 1)
     }
-    case object SwitchMode
+    case object BecomeSuccessful
     case object GetStats
   }
 
@@ -200,7 +200,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
       assertAppendCount("1", 5L)
 
       // switch mock to 'Success' mode
-      mockRef ! Mock.SwitchMode
+      mockRef ! Mock.BecomeSuccessful
       readSideActor.foreach(_ ! EnsureActive(tag.tag))
 
       eventually {

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -68,7 +68,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
   class Mock(inFailureMode: Boolean = false) extends Actor {
 
     private var stats = Mock.MockStats(0, 0)
-    
+
     def receive = if (inFailureMode) failureMode else successMode
 
     def successMode: Receive = getStats.orElse {


### PR DESCRIPTION
This PR is a spin-off from https://github.com/lagom/lagom/pull/1409 and it should be cherry-pickable on 1.4.x.

I'm marking it as WIP, because I still need to add test to prove that the `ReadSideActor` is re-running the `globalPrepare` after restarting. 