### PR TITLE
Remove warnings from docs

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -48,6 +48,7 @@ lazy val docs = project
       "org.hibernate" % "hibernate-core" % HibernateVersion,
       "javax.validation" % "validation-api" % ValidationApiVersion
     ),
+    scalacOptions ++= Seq("-deprecation"),
     javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation"),
     testOptions in Test += Tests.Argument("-oDF"),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -19,11 +19,19 @@ val branch = {
   } else rev
 }
 
+def evictionSettings: Seq[Setting[_]] = Seq(
+  // This avoids a lot of dependency resolution warnings to be showed.
+  // No need to show them here since it is the docs project.
+  evictionWarningOptions in update := EvictionWarningOptions.default
+    .withWarnTransitiveEvictions(false)
+    .withWarnDirectEvictions(false)
+)
 
 lazy val docs = project
   .in(file("."))
   .enablePlugins(LightbendMarkdown)
   .settings(forkedTests: _*)
+  .settings(evictionSettings: _*)
   .settings(
     resolvers += Resolver.typesafeIvyRepo("releases"),
     scalaVersion := ScalaVersion,

--- a/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerService2Impl.java
+++ b/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerService2Impl.java
@@ -8,6 +8,8 @@ import com.lightbend.lagom.javadsl.pubsub.PubSubRegistry;
 import com.lightbend.lagom.javadsl.pubsub.TopicId;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -44,9 +46,11 @@ public class WorkerService2Impl implements WorkerService2 {
           return null;
         }
       });
+      Set<String> useRoles = new TreeSet<String>();
+      useRoles.add("worker-node");
       Props routerProps = new ClusterRouterGroup(groupConf,
         new ClusterRouterGroupSettings(1000, paths,
-          true, "worker-node")).props();
+          true, useRoles)).props();
     this.workerRouter = system.actorOf(routerProps, "workerRouter");
 
     this.topic = pubSub.refFor(TopicId.of(JobStatus.class, "jobs-status"));

--- a/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerServiceImpl.java
+++ b/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerServiceImpl.java
@@ -6,6 +6,8 @@ import static akka.pattern.PatternsCS.ask;
 import com.lightbend.lagom.javadsl.api.ServiceCall;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
@@ -44,9 +46,12 @@ public class WorkerServiceImpl implements WorkerService {
           return null;
         }
       });
+      Set<String> useRoles = new TreeSet<>();
+      useRoles.add("worker-node");
+
       Props routerProps = new ClusterRouterGroup(groupConf,
         new ClusterRouterGroupSettings(1000, paths,
-          true, "worker-node")).props();
+          true, useRoles)).props();
     this.workerRouter = system.actorOf(routerProps, "workerRouter");
   }
 

--- a/docs/manual/java/guide/services/code/docs/services/MessageSerializers.java
+++ b/docs/manual/java/guide/services/code/docs/services/MessageSerializers.java
@@ -303,6 +303,7 @@ public class MessageSerializers {
       }
 
       @Override
+      @SuppressWarnings("unchecked")
       public <MessageEntity> MessageSerializer<MessageEntity, ?> messageSerializerFor(Type type) {
         if (type instanceof Class) {
           Class<MessageEntity> clazz = (Class<MessageEntity>) type;

--- a/docs/manual/java/guide/services/code/docs/services/ServiceImplementation.java
+++ b/docs/manual/java/guide/services/code/docs/services/ServiceImplementation.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.time.Duration;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -59,7 +60,7 @@ public class ServiceImplementation {
     //#tick-service-call
     public ServerServiceCall<String, Source<String, ?>> tick(int intervalMs) {
       return tickMessage -> {
-        FiniteDuration interval = FiniteDuration.create(intervalMs, TimeUnit.MILLISECONDS);
+        Duration interval = Duration.ofMillis(intervalMs);
         return completedFuture(Source.tick(interval, interval, tickMessage));
       };
     }

--- a/docs/manual/java/guide/services/code/docs/services/test/ServiceTestModule.java
+++ b/docs/manual/java/guide/services/code/docs/services/test/ServiceTestModule.java
@@ -37,6 +37,7 @@ public class ServiceTestModule extends AbstractModule implements ServiceGuiceSup
    * This method is used in docs/ so that many tests can share a single Guice module.
    */
    @Override
+   @SuppressWarnings({"deprecation", "unchecked"})
    public void bindServices(ServiceBinding<?>... serviceBindings) {
     Binder binder = BinderAccessor.binder(this);
 

--- a/docs/manual/java/guide/services/code/docs/services/test/StubDependencies.java
+++ b/docs/manual/java/guide/services/code/docs/services/test/StubDependencies.java
@@ -19,7 +19,7 @@ public class StubDependencies {
   }
 
   private final Setup setup = defaultSetup()
-      .withConfigureBuilder(b -> b.overrides(
+      .configureBuilder(b -> b.overrides(
           bind(GreetingService.class).to(GreetingStub.class)));
 
 

--- a/docs/manual/scala/guide/advanced/code/Akka.scala
+++ b/docs/manual/scala/guide/advanced/code/Akka.scala
@@ -67,7 +67,7 @@ package workerserviceimpl {
           totalInstances = 1000,
           routeesPaths = paths,
           allowLocalRoutees = true,
-          useRole = Some("worker-node")
+          useRoles = Set("worker-node")
         )
       ).props
       system.actorOf(routerProps, "workerRouter")

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/CassandraBlogEventProcessor.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/CassandraBlogEventProcessor.scala
@@ -77,7 +77,7 @@ trait CassandraBlogEventProcessor {
       //#create-builder
 
       //#register-global-prepare
-      builder.setGlobalPrepare(createTable)
+      builder.setGlobalPrepare(() => createTable())
       //#register-global-prepare
 
       //#register-prepare

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/PostSpec.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/PostSpec.scala
@@ -9,13 +9,13 @@ import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.InvalidCommandE
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.lightbend.lagom.scaladsl.testkit.PersistentEntityTestDriver
 import com.typesafe.config.ConfigFactory
-import org.scalactic.ConversionCheckedTripleEquals
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 
 class PostSpec extends WordSpecLike with Matchers with BeforeAndAfterAll
-  with ConversionCheckedTripleEquals {
+  with TypeCheckedTripleEquals {
 
   val system = ActorSystem("PostSpec", JsonSerializerRegistry.actorSystemSetupFor(BlogPostSerializerRegistry))
 

--- a/docs/src/test/scala/docs/home/actor/ActorServiceSpec.scala
+++ b/docs/src/test/scala/docs/home/actor/ActorServiceSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import akka.testkit.ImplicitSender
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
-import org.scalactic.ConversionCheckedTripleEquals
+import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
@@ -23,7 +23,8 @@ object ActorServiceSpec {
 
 class ActorServiceSpec extends TestKit(ActorSystem("ActorServiceSpec", ActorServiceSpec.config))
   with ServiceSupport
-  with BeforeAndAfterAll with ConversionCheckedTripleEquals
+  with BeforeAndAfterAll
+  with TypeCheckedTripleEquals
   with ImplicitSender {
 
   val workerRoleConfig = ConfigFactory.parseString("akka.cluster.roles = [worker-node]")


### PR DESCRIPTION
## Fixes

It does not fix all the deprecated warnings in documentation samples, but most of them. So there is still some work to do related to #401.

## Purpose

Update documentation sample code to avoid deprecated APIs.