### PR TITLE
Provide Akka Discovery support in dev mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1049,6 +1049,7 @@ lazy val devEnvironmentProjects = Seq[Project](
   `service-registration-javadsl`,
   `cassandra-server`,
   `play-integration-javadsl`,
+  `service-registry-client-core`,
   `devmode-scaladsl`,
   `service-registry-client-javadsl`,
   `maven-java-archetype`,
@@ -1346,6 +1347,15 @@ lazy val `service-locator` = (project in file("dev") / "service-registry" / "ser
   )
   .dependsOn(`server-javadsl`, logback, `service-registry-client-javadsl`)
 
+lazy val `service-registry-client-core` = (project in file("dev") / "service-registry" / "client-core")
+  .settings(
+    name := "lagom-service-registry-client-core",
+    Dependencies.`service-registry-client-core`
+  )
+  .settings(runtimeLibCommon: _*)
+  .enablePlugins(RuntimeLibPlugins)
+  .dependsOn(logback % Test)
+
 lazy val `service-registry-client-javadsl` = (project in file("dev") / "service-registry" / "client-javadsl")
   .settings(
     name := "lagom-service-registry-client",
@@ -1353,7 +1363,7 @@ lazy val `service-registry-client-javadsl` = (project in file("dev") / "service-
   )
   .settings(runtimeLibCommon: _*)
   .enablePlugins(RuntimeLibPlugins)
-  .dependsOn(`client-javadsl`, immutables % "provided")
+  .dependsOn(`client-javadsl`, `service-registry-client-core`, immutables % "provided")
 
 lazy val `service-registration-javadsl` = (project in file("dev") / "service-registry" / "registration-javadsl")
   .settings(
@@ -1372,7 +1382,7 @@ lazy val `devmode-scaladsl` = (project in file("dev") / "service-registry" / "de
   .settings(runtimeLibCommon: _*)
   .settings(mimaSettings(since13): _*)
   .enablePlugins(RuntimeLibPlugins)
-  .dependsOn(`client-scaladsl`)
+  .dependsOn(`client-scaladsl`, `service-registry-client-core`)
 
 lazy val `play-integration-javadsl` = (project in file("dev") / "service-registry" / "play-integration-javadsl")
   .settings(

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/LagomConfig.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/LagomConfig.scala
@@ -21,7 +21,8 @@ object LagomConfig {
   def actorSystemConfig(name: String) = Map(
     "lagom.akka.dev-mode.actor-system.name" -> s"$name-internal-dev-mode",
     "play.akka.actor-system" -> s"$name-application",
-    "lagom.defaults.cluster.join-self" -> "on"
+    "lagom.defaults.cluster.join-self" -> "on",
+    "akka.discovery.method" -> "com.lightbend.lagom.internal.registry.DevModeSimpleServiceDiscovery"
   )
 
 }

--- a/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/AbstractLoggingServiceRegistryClient.scala
+++ b/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/AbstractLoggingServiceRegistryClient.scala
@@ -8,6 +8,7 @@ import java.net.URI
 
 import org.slf4j.{ Logger, LoggerFactory }
 
+import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.{ Failure, Success }
 
@@ -16,14 +17,14 @@ private[lagom] abstract class AbstractLoggingServiceRegistryClient(implicit ec: 
 
   protected val log: Logger = LoggerFactory.getLogger(getClass)
 
-  override def locateAll(serviceName: String): Future[List[URI]] = {
+  override def locateAll(serviceName: String): Future[immutable.Seq[URI]] = {
     require(
       serviceName != ServiceRegistryClient.ServiceName,
       "The service registry client cannot locate the service registry service itself"
     )
     log.debug("Locating service name=[{}] ...", serviceName)
 
-    val location: Future[List[URI]] = internalLocateAll(serviceName)
+    val location: Future[immutable.Seq[URI]] = internalLocateAll(serviceName)
 
     location.onComplete {
       case Success(Nil) =>
@@ -37,6 +38,6 @@ private[lagom] abstract class AbstractLoggingServiceRegistryClient(implicit ec: 
     location
   }
 
-  protected def internalLocateAll(serviceName: String): Future[List[URI]]
+  protected def internalLocateAll(serviceName: String): Future[immutable.Seq[URI]]
 
 }

--- a/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/AbstractLoggingServiceRegistryClient.scala
+++ b/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/AbstractLoggingServiceRegistryClient.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.registry
+
+import java.net.URI
+
+import org.slf4j.{ Logger, LoggerFactory }
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
+
+private[lagom] abstract class AbstractLoggingServiceRegistryClient(implicit ec: ExecutionContext)
+  extends ServiceRegistryClient {
+
+  protected val log: Logger = LoggerFactory.getLogger(getClass)
+
+  override def locateAll(serviceName: String): Future[List[URI]] = {
+    require(
+      serviceName != ServiceRegistryClient.ServiceName,
+      "The service registry client cannot locate the service registry service itself"
+    )
+    log.debug("Locating service name=[{}] ...", serviceName)
+
+    val location: Future[List[URI]] = internalLocateAll(serviceName)
+
+    location.onComplete {
+      case Success(Nil) =>
+        log.warn("serviceName=[{}] was not found. Hint: Maybe it was not started?", serviceName)
+      case Success(uris) =>
+        log.debug("serviceName=[{}] can be reached at uris=[{}]", serviceName: Any, uris: Any)
+      case Failure(e) =>
+        log.warn("Service registry replied with an error when looking up serviceName=[{}]", serviceName: Any, e: Any)
+    }
+
+    location
+  }
+
+  protected def internalLocateAll(serviceName: String): Future[List[URI]]
+
+}

--- a/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/DevModeSimpleServiceDiscovery.scala
+++ b/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/DevModeSimpleServiceDiscovery.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.registry
+
+import java.net.URI
+
+import akka.actor.ActorSystem
+import akka.discovery.SimpleServiceDiscovery._
+import akka.discovery.{ Lookup, ServiceDiscovery, SimpleServiceDiscovery }
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+
+private[lagom] class DevModeSimpleServiceDiscovery(system: ActorSystem) extends SimpleServiceDiscovery {
+  private val clientPromise = Promise[ServiceRegistryClient]
+
+  implicit private val ec: ExecutionContext = system.dispatcher
+
+  def setServiceRegistryClient(client: ServiceRegistryClient): Unit = clientPromise.success(client)
+
+  override def lookup(lookup: Lookup, resolveTimeout: FiniteDuration): Future[Resolved] =
+    for {
+      client <- clientPromise.future
+      uris <- client.locateAll(lookup.serviceName)
+    } yield Resolved(lookup.serviceName, uris.map(toResolvedTarget))
+
+  private def toResolvedTarget(uri: URI) = ResolvedTarget(uri.getHost, optionalPort(uri.getPort))
+
+  private def optionalPort(port: Int): Option[Int] = if (port < 0) None else Some(port)
+}
+
+private[lagom] object DevModeSimpleServiceDiscovery {
+  def apply(system: ActorSystem): DevModeSimpleServiceDiscovery =
+    ServiceDiscovery(system)
+      .loadServiceDiscovery(classOf[DevModeSimpleServiceDiscovery].getName)
+      .asInstanceOf[DevModeSimpleServiceDiscovery]
+}

--- a/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/ServiceRegistryClient.scala
+++ b/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/ServiceRegistryClient.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.registry
+
+import java.net.URI
+
+import scala.concurrent.Future
+
+private[lagom] trait ServiceRegistryClient {
+  def locateAll(serviceName: String): Future[List[URI]]
+}
+
+private[lagom] object ServiceRegistryClient {
+  final val ServiceName = "lagom-service-registry"
+}

--- a/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/ServiceRegistryClient.scala
+++ b/dev/service-registry/client-core/src/main/scala/com/lightbend/lagom/internal/registry/ServiceRegistryClient.scala
@@ -6,10 +6,11 @@ package com.lightbend.lagom.internal.registry
 
 import java.net.URI
 
+import scala.collection.immutable
 import scala.concurrent.Future
 
 private[lagom] trait ServiceRegistryClient {
-  def locateAll(serviceName: String): Future[List[URI]]
+  def locateAll(serviceName: String): Future[immutable.Seq[URI]]
 }
 
 private[lagom] object ServiceRegistryClient {

--- a/dev/service-registry/client-core/src/test/scala/com/lightbend/lagom/internal/registry/AbstractLoggingServiceRegistryClientSpec.scala
+++ b/dev/service-registry/client-core/src/test/scala/com/lightbend/lagom/internal/registry/AbstractLoggingServiceRegistryClientSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.registry
+
+import java.net.URI
+
+import org.scalatest.{ AsyncWordSpec, Matchers }
+
+import scala.concurrent.Future
+
+class AbstractLoggingServiceRegistryClientSpec extends AsyncWordSpec with Matchers {
+
+  private val client = new AbstractLoggingServiceRegistryClient {
+    override def internalLocateAll(serviceName: String): Future[List[URI]] = serviceName match {
+      case "failing-service"    => Future.failed(new IllegalArgumentException("Ignore: expected error"))
+      case "empty-service"      => Future.successful(List())
+      case "successful-service" => Future.successful(List(URI.create("http://localhost:8080")))
+    }
+  }
+
+  "AbstractLoggingServiceRegistryClient" when {
+    /*
+     * This class is very simple, and the tests are straightforward, but it's
+     * still useful to run the tests to manually inspect log messages.
+     */
+
+    "internal lookup fails" in {
+      client.locateAll("failing-service")
+        .failed
+        .map(_ shouldBe an[IllegalArgumentException])
+    }
+
+    "internal lookup has no result" in {
+      client.locateAll("empty-service")
+        .map(_ shouldEqual Nil)
+    }
+
+    "internal lookup has a successful result" in {
+      client.locateAll("successful-service")
+        .map(_ shouldEqual List(URI.create("http://localhost:8080")))
+    }
+
+  }
+}

--- a/dev/service-registry/client-core/src/test/scala/com/lightbend/lagom/internal/registry/DevModeSimpleServiceDiscoverySpec.scala
+++ b/dev/service-registry/client-core/src/test/scala/com/lightbend/lagom/internal/registry/DevModeSimpleServiceDiscoverySpec.scala
@@ -12,6 +12,7 @@ import akka.testkit.TestKit
 import org.scalatest.concurrent.ScalaFutures._
 import org.scalatest.{ Matchers, WordSpecLike }
 
+import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -44,6 +45,6 @@ class DevModeSimpleServiceDiscoverySpec
 }
 
 private class StaticServiceRegistryClient(registrations: Map[String, List[URI]]) extends ServiceRegistryClient {
-  override def locateAll(serviceName: String): Future[List[URI]] =
+  override def locateAll(serviceName: String): Future[immutable.Seq[URI]] =
     Future.successful(registrations.getOrElse(serviceName, Nil))
 }

--- a/dev/service-registry/client-core/src/test/scala/com/lightbend/lagom/internal/registry/DevModeSimpleServiceDiscoverySpec.scala
+++ b/dev/service-registry/client-core/src/test/scala/com/lightbend/lagom/internal/registry/DevModeSimpleServiceDiscoverySpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.registry
+
+import java.net.URI
+
+import akka.actor.ActorSystem
+import akka.discovery.SimpleServiceDiscovery.{ Resolved, ResolvedTarget }
+import akka.testkit.TestKit
+import org.scalatest.concurrent.ScalaFutures._
+import org.scalatest.{ Matchers, WordSpecLike }
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class DevModeSimpleServiceDiscoverySpec
+  extends TestKit(ActorSystem("DevModeSimpleServiceDiscoverySpec"))
+  with WordSpecLike
+  with Matchers {
+
+  private val client = new StaticServiceRegistryClient(
+    Map(
+      "test-service" -> List(URI.create("http://localhost:8080")),
+      "test-service-without-port" -> List(URI.create("http://localhost"))
+    )
+  )
+  private val discovery = DevModeSimpleServiceDiscovery(system)
+  discovery.setServiceRegistryClient(client)
+
+  "DevModeSimpleServiceDiscoverySpec" should {
+    "resolve services in the registry" in {
+      val expected = Resolved("test-service", List(ResolvedTarget("localhost", Some(8080))))
+      discovery.lookup("test-service", 100.milliseconds).futureValue shouldBe expected
+    }
+
+    "allow missing ports" in {
+      val expected = Resolved("test-service-without-port", List(ResolvedTarget("localhost", None)))
+      discovery.lookup("test-service-without-port", 100.milliseconds).futureValue shouldBe expected
+    }
+  }
+
+}
+
+private class StaticServiceRegistryClient(registrations: Map[String, List[URI]]) extends ServiceRegistryClient {
+  override def locateAll(serviceName: String): Future[List[URI]] =
+    Future.successful(registrations.getOrElse(serviceName, Nil))
+}

--- a/dev/service-registry/client-javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/registry/JavaServiceRegistryClient.scala
+++ b/dev/service-registry/client-javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/registry/JavaServiceRegistryClient.scala
@@ -5,11 +5,12 @@
 package com.lightbend.lagom.internal.javadsl.registry
 
 import java.net.URI
-import javax.inject.{ Inject, Singleton }
 
+import javax.inject.{ Inject, Singleton }
 import com.lightbend.lagom.internal.registry.AbstractLoggingServiceRegistryClient
 import com.lightbend.lagom.javadsl.api.transport.NotFound
 
+import scala.collection.immutable
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -19,10 +20,10 @@ private[lagom] class JavaServiceRegistryClient @Inject() (
   implicit val ec: ExecutionContext
 ) extends AbstractLoggingServiceRegistryClient {
 
-  override protected def internalLocateAll(serviceName: String): Future[List[URI]] =
+  override protected def internalLocateAll(serviceName: String): Future[immutable.Seq[URI]] =
     registry.lookup(serviceName).invoke()
       .toScala
-      .map(List[URI](_))
+      .map(immutable.Seq[URI](_))
       .recover {
         case _: NotFound => Nil
       }

--- a/dev/service-registry/client-javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/registry/JavaServiceRegistryClient.scala
+++ b/dev/service-registry/client-javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/registry/JavaServiceRegistryClient.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.javadsl.registry
+
+import java.net.URI
+import javax.inject.{ Inject, Singleton }
+
+import com.lightbend.lagom.internal.registry.AbstractLoggingServiceRegistryClient
+import com.lightbend.lagom.javadsl.api.transport.NotFound
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.{ ExecutionContext, Future }
+
+@Singleton
+private[lagom] class JavaServiceRegistryClient @Inject() (
+  registry:        ServiceRegistry,
+  implicit val ec: ExecutionContext
+) extends AbstractLoggingServiceRegistryClient {
+
+  override protected def internalLocateAll(serviceName: String): Future[List[URI]] =
+    registry.lookup(serviceName).invoke()
+      .toScala
+      .map(List[URI](_))
+      .recover {
+        case _: NotFound => Nil
+      }
+
+}

--- a/dev/service-registry/client-javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/registry/ServiceRegistry.java
+++ b/dev/service-registry/client-javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/registry/ServiceRegistry.java
@@ -13,6 +13,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Optional;
 
+import com.lightbend.lagom.internal.registry.ServiceRegistryClient$;
 import org.pcollections.PSequence;
 
 import akka.NotUsed;
@@ -30,13 +31,13 @@ import com.lightbend.lagom.javadsl.api.transport.UnsupportedMediaType;
 
 public interface ServiceRegistry extends Service {
 
-	String SERVICE_NAME = "lagom-service-registry";
+	String SERVICE_NAME = ServiceRegistryClient$.MODULE$.ServiceName();
 
 	ServiceCall<ServiceRegistryService, NotUsed> register(String name);
 	ServiceCall<NotUsed, NotUsed> unregister(String name);
 	ServiceCall<NotUsed, URI> lookup(String name);
 	ServiceCall<NotUsed, PSequence<RegisteredService>> registeredServices();
-	
+
 	@Override
 	default Descriptor descriptor() {
 		// @formatter:off
@@ -90,7 +91,7 @@ class CustomSerializers {
               }
               catch(URISyntaxException e) {
                 throw new DeserializationException(e);
-              } 
+              }
           }
       }
 

--- a/dev/service-registry/client-javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/registry/ServiceRegistryModule.scala
+++ b/dev/service-registry/client-javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/registry/ServiceRegistryModule.scala
@@ -10,21 +10,20 @@ import java.util.concurrent.CompletionStage
 import java.util.function.{ Function => JFunction }
 import javax.inject.{ Inject, Provider, Singleton }
 
+import akka.actor.ActorSystem
+import akka.discovery.SimpleServiceDiscovery
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.javadsl.api.broker.NoTopicFactoryProvider
 import com.lightbend.lagom.internal.javadsl.client.{ JavadslServiceClientImplementor, JavadslWebSocketClient, ServiceClientLoader }
+import com.lightbend.lagom.internal.registry.{ DevModeSimpleServiceDiscovery, ServiceRegistryClient }
 import com.lightbend.lagom.javadsl.api.Descriptor.Call
-import com.lightbend.lagom.javadsl.api.transport.NotFound
 import com.lightbend.lagom.javadsl.api.{ ServiceInfo, ServiceLocator }
-import com.lightbend.lagom.javadsl.client.{ CircuitBreakersPanel, CircuitBreakingServiceLocator }
 import com.lightbend.lagom.javadsl.jackson.{ JacksonExceptionSerializer, JacksonSerializerFactory }
 import play.api.inject.{ Binding, Module }
 import play.api.libs.ws.WSClient
 import play.api.{ Configuration, Environment, Logger, Mode }
 
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
 
 class ServiceRegistryModule(environment: Environment, configuration: Configuration) extends Module {
   private val logger = Logger(this.getClass)
@@ -37,9 +36,14 @@ class ServiceRegistryModule(environment: Environment, configuration: Configurati
           "only during development."
       }
       Seq(
-        bind[ServiceRegistryServiceLocator.ServiceLocatorConfig].toInstance(createDevServiceLocatorConfig),
-        bind[ServiceRegistry].to(new ServiceRegistryClientProvider),
-        bind[ServiceLocator].to[ServiceRegistryServiceLocator]
+        bind[ServiceLocatorConfig].toInstance(createDevServiceLocatorConfig),
+        bind[ServiceRegistry].to(new ServiceRegistryProvider),
+        bind[ServiceRegistryClient].to[JavaServiceRegistryClient],
+        bind[ServiceLocator].to[ServiceRegistryServiceLocator],
+
+        // This needs to be instantiated eagerly to ensure it initializes for
+        // Akka libraries that use service discovery without dependency injection.
+        bind[SimpleServiceDiscovery].toProvider[DevModeSimpleServiceDiscoveryProvider].eagerly()
       )
     } else {
       logger.debug {
@@ -51,11 +55,11 @@ class ServiceRegistryModule(environment: Environment, configuration: Configurati
     }
   }
 
-  protected def createDevServiceLocatorConfig: ServiceRegistryServiceLocator.ServiceLocatorConfig = {
+  protected def createDevServiceLocatorConfig: ServiceLocatorConfig = {
     val serviceLocatorURLKey = "lagom.service-locator.url"
     val config = configuration.underlying
     val url = config.getString(serviceLocatorURLKey)
-    ServiceRegistryServiceLocator.ServiceLocatorConfig(new URI(url))
+    ServiceLocatorConfig(new URI(url))
   }
 }
 
@@ -63,8 +67,8 @@ class ServiceRegistryModule(environment: Environment, configuration: Configurati
  * This is needed to break the circular dependency between the ServiceRegistry and the ServiceLocator.
  */
 @Singleton
-class ServiceRegistryClientProvider extends Provider[ServiceRegistry] {
-  @Inject private var config: ServiceRegistryServiceLocator.ServiceLocatorConfig = _
+class ServiceRegistryProvider extends Provider[ServiceRegistry] {
+  @Inject private var config: ServiceLocatorConfig = _
   @Inject private var ws: WSClient = _
   @Inject private var webSocketClient: JavadslWebSocketClient = _
   @Inject private var serviceInfo: ServiceInfo = _
@@ -86,7 +90,7 @@ class ServiceRegistryClientProvider extends Provider[ServiceRegistry] {
   /**
    * The service locator implementation used by the ServiceRegistry's client implementation.
    */
-  private class ClientServiceLocator(config: ServiceRegistryServiceLocator.ServiceLocatorConfig) extends BaseServiceLocator {
+  private class ClientServiceLocator(config: ServiceLocatorConfig) extends BaseServiceLocator {
     override protected def lookup(name: String): Future[Optional[URI]] = {
       require(name == ServiceRegistry.SERVICE_NAME)
       Future.successful(Optional.of(config.url))
@@ -94,46 +98,7 @@ class ServiceRegistryClientProvider extends Provider[ServiceRegistry] {
   }
 }
 
-@Singleton
-class ServiceRegistryServiceLocator @Inject() (
-  circuitBreakers: CircuitBreakersPanel,
-  registry:        ServiceRegistry,
-  config:          ServiceRegistryServiceLocator.ServiceLocatorConfig,
-  implicit val ec: ExecutionContext
-) extends CircuitBreakingServiceLocator(circuitBreakers) {
-
-  private val logger: Logger = Logger(this.getClass())
-
-  override def locate(name: String, serviceCall: Call[_, _]): CompletionStage[Optional[URI]] = {
-    require(name != ServiceRegistry.SERVICE_NAME)
-    logger.debug(s"Locating service name=[$name] ...")
-
-    val location: Future[Optional[URI]] = {
-      val asOptionalURI: URI => Optional[URI] = uri => {
-        try Optional.of(uri)
-        catch {
-          case e: java.net.URISyntaxException =>
-            logger.error(s"Invalid address=[$uri] returned for service name=[$name]", e)
-            Optional.empty()
-          case _: NullPointerException =>
-            logger.error(s"Null address returned for service name=[$name]")
-            Optional.empty()
-        }
-      }
-      import scala.compat.java8.FutureConverters._
-      registry.lookup(name).invoke().toScala.map(asOptionalURI).recover {
-        case notFound: NotFound => Optional.empty()
-      }
-    }
-    location.onComplete {
-      case Success(address) =>
-        if (address.isPresent()) logger.debug(s"Service name=[$name] can be reached at address=[${address.get.getPath}]")
-        else logger.warn(s"Service name=[$name] was not found. Hint: Maybe it was not registered?")
-      case Failure(e) => logger.warn(s"The service locator replied with an error when looking up the service name=[$name] address", e)
-    }
-    location.toJava
-  }
-}
+case class ServiceLocatorConfig(url: URI)
 
 abstract class BaseServiceLocator extends ServiceLocator {
   import scala.compat.java8.FutureConverters._
@@ -152,6 +117,16 @@ abstract class BaseServiceLocator extends ServiceLocator {
   protected def lookup(name: String): Future[Optional[URI]]
 }
 
-object ServiceRegistryServiceLocator {
-  case class ServiceLocatorConfig(url: URI)
+@Singleton
+private final class DevModeSimpleServiceDiscoveryProvider @Inject() (
+  actorSystem:           ActorSystem,
+  serviceRegistryClient: ServiceRegistryClient
+) extends Provider[DevModeSimpleServiceDiscovery] {
+
+  override def get(): DevModeSimpleServiceDiscovery = {
+    val discovery = DevModeSimpleServiceDiscovery(actorSystem)
+    discovery.setServiceRegistryClient(serviceRegistryClient)
+    discovery
+  }
+
 }

--- a/dev/service-registry/client-javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/registry/ServiceRegistryServiceLocator.scala
+++ b/dev/service-registry/client-javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/registry/ServiceRegistryServiceLocator.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.javadsl.registry
+
+import java.net.URI
+import java.util.concurrent.CompletionStage
+import java.util.{ Optional, List => JList }
+import javax.inject.{ Inject, Singleton }
+
+import com.lightbend.lagom.internal.registry.ServiceRegistryClient
+import com.lightbend.lagom.javadsl.api.Descriptor.Call
+import com.lightbend.lagom.javadsl.client.{ CircuitBreakersPanel, CircuitBreakingServiceLocator }
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.FutureConverters._
+import scala.compat.java8.OptionConverters._
+import scala.concurrent.ExecutionContext
+
+@Singleton
+private[lagom] class ServiceRegistryServiceLocator @Inject() (
+  circuitBreakers: CircuitBreakersPanel,
+  client:          ServiceRegistryClient,
+  implicit val ec: ExecutionContext
+) extends CircuitBreakingServiceLocator(circuitBreakers) {
+
+  override def locateAll(name: String, serviceCall: Call[_, _]): CompletionStage[JList[URI]] =
+    client.locateAll(name).map(_.asJava).toJava
+
+  override def locate(name: String, serviceCall: Call[_, _]): CompletionStage[Optional[URI]] =
+    client.locateAll(name).map(_.headOption.asJava).toJava
+
+}

--- a/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ScalaServiceRegistryClient.scala
+++ b/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ScalaServiceRegistryClient.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.scaladsl.registry
+
+import java.net.URI
+
+import com.lightbend.lagom.internal.registry.AbstractLoggingServiceRegistryClient
+import com.lightbend.lagom.scaladsl.api.transport.NotFound
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+private[lagom] class ScalaServiceRegistryClient(registry: ServiceRegistry)(implicit ec: ExecutionContext)
+  extends AbstractLoggingServiceRegistryClient {
+
+  override protected def internalLocateAll(serviceName: String): Future[List[URI]] =
+    registry.lookup(serviceName).invoke()
+      .map(List[URI](_))
+      .recover {
+        case _: NotFound => Nil
+      }
+
+}

--- a/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ScalaServiceRegistryClient.scala
+++ b/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ScalaServiceRegistryClient.scala
@@ -9,14 +9,15 @@ import java.net.URI
 import com.lightbend.lagom.internal.registry.AbstractLoggingServiceRegistryClient
 import com.lightbend.lagom.scaladsl.api.transport.NotFound
 
+import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 
 private[lagom] class ScalaServiceRegistryClient(registry: ServiceRegistry)(implicit ec: ExecutionContext)
   extends AbstractLoggingServiceRegistryClient {
 
-  override protected def internalLocateAll(serviceName: String): Future[List[URI]] =
+  override protected def internalLocateAll(serviceName: String): Future[immutable.Seq[URI]] =
     registry.lookup(serviceName).invoke()
-      .map(List[URI](_))
+      .map(immutable.Seq[URI](_))
       .recover {
         case _: NotFound => Nil
       }

--- a/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ServiceRegistry.scala
+++ b/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ServiceRegistry.scala
@@ -8,6 +8,7 @@ import java.net.URI
 
 import akka.NotUsed
 import akka.util.ByteString
+import com.lightbend.lagom.internal.registry.ServiceRegistryClient
 import com.lightbend.lagom.scaladsl.api.deser.MessageSerializer.{ NegotiatedDeserializer, NegotiatedSerializer }
 import com.lightbend.lagom.scaladsl.api.deser.{ MessageSerializer, StrictMessageSerializer }
 import com.lightbend.lagom.scaladsl.api.transport.{ MessageProtocol, Method }
@@ -33,7 +34,7 @@ trait ServiceRegistry extends Service {
   import ServiceRegistry._
 
   def descriptor: Descriptor = {
-    named(ServiceName).withCalls(
+    named(ServiceRegistryClient.ServiceName).withCalls(
       restCall(Method.PUT, "/services/:id", register _),
       restCall(Method.DELETE, "/services/:id", this.unregister _),
       restCall(Method.GET, "/services/:id", lookup _),
@@ -43,7 +44,6 @@ trait ServiceRegistry extends Service {
 }
 
 object ServiceRegistry {
-  val ServiceName = "lagom-service-registry"
 
   implicit val uriMessageSerializer: MessageSerializer[URI, ByteString] = new StrictMessageSerializer[URI] {
 

--- a/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ServiceRegistryServiceLocator.scala
+++ b/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ServiceRegistryServiceLocator.scala
@@ -19,7 +19,7 @@ private[lagom] class ServiceRegistryServiceLocator(
 ) extends CircuitBreakingServiceLocator(circuitBreakers) {
 
   override def locateAll(name: String, serviceCall: Call[_, _]): Future[List[URI]] =
-    client.locateAll(name)
+    client.locateAll(name).map(_.toList)
 
   override def locate(name: String, serviceCall: Call[_, _]): Future[Option[URI]] =
     locateAll(name, serviceCall).map(_.headOption)

--- a/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ServiceRegistryServiceLocator.scala
+++ b/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/registry/ServiceRegistryServiceLocator.scala
@@ -6,44 +6,22 @@ package com.lightbend.lagom.internal.scaladsl.registry
 
 import java.net.URI
 
-import com.lightbend.lagom.scaladsl.client.CircuitBreakersPanel
+import com.lightbend.lagom.internal.registry.ServiceRegistryClient
 import com.lightbend.lagom.scaladsl.api.Descriptor.Call
-import com.lightbend.lagom.scaladsl.api.transport.NotFound
-import com.lightbend.lagom.scaladsl.client.CircuitBreakingServiceLocator
-import play.api.Logger
+import com.lightbend.lagom.scaladsl.client.{ CircuitBreakersPanel, CircuitBreakingServiceLocator }
 
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
 
-class ServiceRegistryServiceLocator(
+private[lagom] class ServiceRegistryServiceLocator(
   circuitBreakers: CircuitBreakersPanel,
-  registry:        ServiceRegistry,
+  client:          ServiceRegistryClient,
   implicit val ec: ExecutionContext
 ) extends CircuitBreakingServiceLocator(circuitBreakers) {
 
-  private val logger: Logger = Logger(this.getClass())
+  override def locateAll(name: String, serviceCall: Call[_, _]): Future[List[URI]] =
+    client.locateAll(name)
 
-  override def locate(name: String, serviceCall: Call[_, _]): Future[Option[URI]] = {
-
-    require(name != ServiceRegistry.ServiceName)
-    logger.debug(s"Locating service name=[$name] ...")
-
-    val location: Future[Option[URI]] = {
-      registry.lookup(name).invoke().map(Some.apply).recover {
-        case notFound: NotFound => None
-      }
-    }
-
-    location.onComplete {
-      case Success(Some(address)) =>
-        logger.debug(s"Service name=[$name] can be reached at address=[${address.getPath}]")
-      case Success(None) =>
-        logger.warn(s"Service name=[$name] was not found. Hint: Maybe it was not registered?")
-      case Failure(e) =>
-        logger.warn(s"The service locator replied with an error when looking up the service name=[$name] address", e)
-    }
-
-    location
-  }
+  override def locate(name: String, serviceCall: Call[_, _]): Future[Option[URI]] =
+    locateAll(name, serviceCall).map(_.headOption)
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,3 +1,4 @@
+import Dependencies.scalaTest
 import sbt._
 import sbt.Keys._
 
@@ -16,6 +17,7 @@ object Dependencies {
   // Also be sure to update AkkaVersion in docs/build.sbt.
   val AkkaVersion = "2.5.14"
   val AkkaHttpVersion = "10.1.3"
+  val AkkaManagementVersion = "0.17.0"
   // Also be sure to update ScalaVersion in docs/build.sbt.
   val ScalaVersions = Seq("2.12.6", "2.11.12")
   val SbtScalaVersions = Seq("2.10.6", "2.12.6")
@@ -85,6 +87,8 @@ object Dependencies {
   private val akkaStreamTestkit = "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion
   private val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
   private val reactiveStreams = "org.reactivestreams" % "reactive-streams" % "1.0.2"
+
+  private val akkaDiscovery = "com.lightbend.akka.discovery" %% "akka-discovery" % AkkaManagementVersion
 
   private val akkaPersistenceJdbc = "com.github.dnvriend" %% "akka-persistence-jdbc" % AkkaPersistenceJdbcVersion excludeAll (excludeSlf4j: _*)
 
@@ -160,6 +164,7 @@ object Dependencies {
       "com.novocode" % "junit-interface" % JUnitInterfaceVersion,
       typesafeConfig,
       sslConfig,
+      akkaDiscovery,
       akkaHttpCore,
       akkaStreamKafka,
       akkaParsing,
@@ -701,16 +706,30 @@ object Dependencies {
     scalaTest % Test
   )
 
+  val `service-registry-client-core` =
+    libraryDependencies ++= Seq(
+      akkaDiscovery,
+      slf4jApi,
+
+      akkaTestkit % Test,
+      scalaTest % Test
+    )
+
   val `service-registry-client-javadsl` =
     libraryDependencies ++= Seq(
-      "junit" % "junit" % JUnitVersion,
+      akkaDiscovery,
+
       akkaTestkit % Test,
+      "junit" % "junit" % JUnitVersion % Test,
       "com.novocode" % "junit-interface" % "0.11" % Test
     )
 
   val `service-registration-javadsl` = libraryDependencies ++= Nil
 
-  val `devmode-scaladsl` = libraryDependencies ++= Nil
+  val `devmode-scaladsl` =
+    libraryDependencies ++= Seq(
+      akkaDiscovery
+    )
 
   val `play-integration-javadsl` = libraryDependencies ++= Nil
 


### PR DESCRIPTION
## Fixes

Fixes #1426

## Background Context

The [Akka Management](https://developer.lightbend.com/docs/akka-management/current/) library recently introduced a new component for [Service Discovery](https://developer.lightbend.com/docs/akka-management/current/discovery.html). This is used as the basis of [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/current/bootstrap.html), to help service nodes locate each other when forming a cluster, but is intended to be used in many other contexts in the future, including typical service-to-service communication scenarios (such as in [Akka gRPC](https://github.com/akka/akka-grpc), see https://github.com/akka/akka-grpc/issues/137).

We hope to make Akka Service Discovery into the fundamental service discovery API for all of the Lightbend Reactive Platform (Akka, Lagom and Play) and eventually migrate away from Lagom's `ServiceLocator` API. As a first step, we are providing a compatibility in Lagom's development mode, so that Akka Service Discovery works seamlessly with the built-in service registry. This will allow Akka gRPC and any other libraries that use Akka Service Discovery to automatically discover other services that are run in the same `runAll` command.

## References

- #1291 is related, but the reverse: providing a Lagom `ServiceLocator` implementation that is backed by Akka Service Discovery, allowing use of Akka Service Discovery methods in Lagom (such as the [Consul method](https://developer.lightbend.com/docs/akka-management/current/discovery.html)).