### PR TITLE
Remove unused metrics-service snippet

### DIFF
--- a/docs/manual/scala/guide/services/code/ServiceClients.scala
+++ b/docs/manual/scala/guide/services/code/ServiceClients.scala
@@ -79,24 +79,3 @@ package circuitbreakers {
   }
 
 }
-
-
-package metricsservice {
-
-  import helloservice._
-  import com.lightbend.lagom.scaladsl.server.{LagomApplication, LagomApplicationContext, LagomServerComponents}
-  import play.api.libs.ws.ahc.AhcWSComponents
-  import com.softwaremill.macwire._
-
-  //#metrics-service
-
-  abstract class MyApplication(context: LagomApplicationContext)
-    extends LagomApplication(context)
-      with AhcWSComponents 
-      with LagomServerComponents {
-
-    override lazy val lagomServer = serverFor[HelloService](wire[HelloServiceImpl])
-  }
-  //#metrics-service
-
-}


### PR DESCRIPTION
In https://github.com/lagom/lagom/pull/1419#issuecomment-401623005, @erip pointed out that this snippet is no longer referenced.

## References

The snippet inclusion was removed in #1246.
