### PR TITLE
fail if any deprecated APIs are used in docs.

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -48,7 +48,7 @@ lazy val docs = project
       "org.hibernate" % "hibernate-core" % HibernateVersion,
       "javax.validation" % "validation-api" % ValidationApiVersion
     ),
-    scalacOptions ++= Seq("-deprecation"),
+    scalacOptions ++= Seq("-deprecation", "-Xfatal-warnings"),
     javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation"),
     testOptions in Test += Tests.Argument("-oDF"),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -49,7 +49,7 @@ lazy val docs = project
       "javax.validation" % "validation-api" % ValidationApiVersion
     ),
     scalacOptions ++= Seq("-deprecation", "-Xfatal-warnings"),
-    javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation"),
+    javacOptions ++= Seq("-encoding", "UTF-8", "-source", "1.8", "-target", "1.8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation", "-Werror"),
     testOptions in Test += Tests.Argument("-oDF"),
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // This is needed so that Java APIs that use immutables will typecheck by the Scala compiler


### PR DESCRIPTION
Fixes #401.