### PR TITLE
Remove sbt-site plugin in preparation of sbt 1.x

### DIFF
--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -7,13 +7,14 @@ package lagom
 import sbt._
 import Process._
 import Keys._
-import com.typesafe.sbt.preprocess.Preprocess._
 
 import java.io.File
+import java.io.PrintWriter
 
 object Protobuf {
   val paths = SettingKey[Seq[File]]("protobuf-paths", "The paths that contain *.proto files.")
   val outputPaths = SettingKey[Seq[File]]("protobuf-output-paths", "The paths where to save the generated *.java files.")
+  val importPath = SettingKey[Option[File]]("protobuf-import-path", "The path that contain additional *.proto files that can be imported.")
   val protoc = SettingKey[String]("protobuf-protoc", "The path and name of the protoc executable.")
   val protocVersion = SettingKey[String]("protobuf-protoc-version", "The version of the protoc executable.")
   val generate = TaskKey[Unit]("protobuf-generate", "Compile the protobuf sources and do all processing.")
@@ -21,18 +22,20 @@ object Protobuf {
   lazy val settings: Seq[Setting[_]] = Seq(
     paths := Seq((sourceDirectory in Compile).value, (sourceDirectory in Test).value).map(_ / "protobuf"),
     outputPaths := Seq((sourceDirectory in Compile).value, (sourceDirectory in Test).value).map(_ / "java"),
+    importPath := None,
     protoc := "protoc",
     protocVersion := "2.6.1",
     generate := {
       val sourceDirs = paths.value
       val targetDirs = outputPaths.value
+      val log = streams.value.log
 
       if (sourceDirs.size != targetDirs.size)
         sys.error(s"Unbalanced number of paths and destination paths!\nPaths: $sourceDirs\nDestination Paths: $targetDirs")
 
       if (sourceDirs exists (_.exists)) {
         val cmd = protoc.value
-        val log = streams.value.log
+
         checkProtocVersion(cmd, protocVersion.value, log)
 
         val base = baseDirectory.value
@@ -40,34 +43,35 @@ object Protobuf {
         val targets = target.value
         val cache = targets / "protoc" / "cache"
 
-        (sourceDirs zip targetDirs) map { case (src, dst) =>
-          val relative = src.relativeTo(sources).getOrElse(throw new Exception(s"path $src is not a in source tree $sources")).toString
-          val tmp = targets / "protoc" / relative
-          IO.delete(tmp)
-          generate(cmd, src, tmp, log)
-          transformDirectory(tmp, dst, _ => true, transformFile(_.replace("com.google.protobuf", "akka.protobuf")), cache, log)
+        (sourceDirs zip targetDirs) map {
+          case (src, dst) ⇒
+            val relative = src.relativeTo(sources).getOrElse(throw new Exception(s"path $src is not a in source tree $sources")).toString
+            val tmp = targets / "protoc" / relative
+            IO.delete(tmp)
+            generate(cmd, src, tmp, log, importPath.value)
+            transformDirectory(tmp, dst, _ ⇒ true, transformFile(_.replace("com.google.protobuf", "akka.protobuf")), cache, log)
         }
       }
-    }
-  )
+    })
 
-  private def callProtoc[T](protoc: String, args: Seq[String], log: Logger, thunk: (ProcessBuilder, Logger) => T): T =
+  private def callProtoc[T](protoc: String, args: Seq[String], log: Logger, thunk: (ProcessBuilder, Logger) ⇒ T): T =
     try {
       val proc = Process(protoc, args)
       thunk(proc, log)
-    } catch { case e: Exception =>
-      throw new RuntimeException("error while executing '%s' with args: %s" format(protoc, args.mkString(" ")), e)
+    } catch {
+      case e: Exception ⇒
+        throw new RuntimeException("error while executing '%s' with args: %s" format (protoc, args.mkString(" ")), e)
     }
 
   private def checkProtocVersion(protoc: String, protocVersion: String, log: Logger): Unit = {
-    val res = callProtoc(protoc, Seq("--version"), log, { (p, l) => p !! l })
+    val res = callProtoc(protoc, Seq("--version"), log, { (p, l) ⇒ p !! l })
     val version = res.split(" ").last.trim
     if (version != protocVersion) {
       sys.error("Wrong protoc version! Expected %s but got %s" format (protocVersion, version))
     }
   }
 
-  private def generate(protoc: String, srcDir: File, targetDir: File, log: Logger): Unit = {
+  private def generate(protoc: String, srcDir: File, targetDir: File, log: Logger, importPath: Option[File]): Unit = {
     val protoFiles = (srcDir ** "*.proto").get
     if (srcDir.exists)
       if (protoFiles.isEmpty)
@@ -76,12 +80,57 @@ object Protobuf {
         targetDir.mkdirs()
 
         log.info("Generating %d protobuf files from %s to %s".format(protoFiles.size, srcDir, targetDir))
-        protoFiles.foreach { proto => log.info("Compiling %s" format proto) }
+        protoFiles.foreach { proto ⇒ log.info("Compiling %s" format proto) }
+
+        val protoPathArg = importPath match {
+          case None => Nil
+          case Some(p) => Seq("--proto_path", p.absolutePath)
+        }
 
         val exitCode = callProtoc(protoc, Seq("-I" + srcDir.absolutePath, "--java_out=%s" format targetDir.absolutePath) ++
-          protoFiles.map(_.absolutePath), log, { (p, l) => p ! l })
+          protoPathArg ++ protoFiles.map(_.absolutePath), log, { (p, l) => p ! l })
         if (exitCode != 0)
           sys.error("protoc returned exit code: %d" format exitCode)
       }
   }
+
+  /**
+    * Create a transformed version of all files in a directory, given a predicate and a transform function for each file.
+    */
+  def transformDirectory(sourceDir: File, targetDir: File, transformable: File => Boolean, transform: (File, File) => Unit, cache: File, log: Logger): File = {
+    val runTransform = FileFunction.cached(cache)(FilesInfo.hash, FilesInfo.exists) { (in, out) =>
+      val map = Path.rebase(sourceDir, targetDir)
+      if (in.removed.nonEmpty || in.modified.nonEmpty) {
+        log.info("Preprocessing directory %s..." format sourceDir)
+        for (source <- in.removed; target <- map(source)) {
+          IO delete target
+        }
+        val updated = for (source <- in.modified; target <- map(source)) yield {
+          if (source.isFile) {
+            if (transformable(source)) transform(source, target)
+            else IO.copyFile(source, target)
+          }
+          target
+        }
+        log.info("Directory preprocessed: " + targetDir)
+        updated
+      } else Set.empty
+    }
+    val sources = (sourceDir ***).get.toSet
+    runTransform(sources)
+    targetDir
+  }
+
+  /**
+    * Transform a file, line by line.
+    */
+  def transformFile(transform: String ⇒ String)(source: File, target: File): Unit = {
+    IO.reader(source) { reader ⇒
+      IO.writer(target, "", IO.defaultCharset) { writer ⇒
+        val pw = new PrintWriter(writer)
+        IO.foreachLine(reader) { line ⇒ pw.println(transform(line)) }
+      }
+    }
+  }
+
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,8 +13,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
-// need this for com.typesafe.sbt.preprocess.Preprocess
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.7.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.1")


### PR DESCRIPTION
In part, done in preparation of #1455. 

~~Specifically, lagom.Protobuf is redundant an will be using removed API's when moving to sbt 1.x. To mitigate both of these, this PR replaces all functionality with an official SBT plugin.~~

sbt-site has made private some APIs required by `lagom.Protobuf`. This PR eliminates the dependency on sbt-site, which was used exclusively for those APIs and adds the functions.