### PR TITLE
Cross build style/header checks

### DIFF
--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -4,11 +4,13 @@
 
 runSbt  +scalariformFormat \
         +test:scalariformFormat \
-        multi-jvm:scalariformFormat \
-        +headerCheck \
+        multi-jvm:scalariformFormat
+
+runSbt  +headerCheck \
         +test:headerCheck \
-        multi-jvm:headerCheck \
-        validateDependencies \
+        multi-jvm:headerCheck
+
+runSbt  validateDependencies \
         mimaCheckOneAtATime
 
 git diff --exit-code || (

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -2,12 +2,12 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-runSbt  scalariformFormat \
-        test:scalariformFormat \
-        multi-jvm:scalariformFormat \
-        headerCheck \
-        test:headerCheck \
-        multi-jvm:headerCheck \
+runSbt  +scalariformFormat \
+        +test:scalariformFormat \
+        +multi-jvm:scalariformFormat \
+        +headerCheck \
+        +test:headerCheck \
+        +multi-jvm:headerCheck \
         validateDependencies \
         mimaCheckOneAtATime
 

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -4,10 +4,10 @@
 
 runSbt  +scalariformFormat \
         +test:scalariformFormat \
-        +multi-jvm:scalariformFormat \
+        multi-jvm:scalariformFormat \
         +headerCheck \
         +test:headerCheck \
-        +multi-jvm:headerCheck \
+        multi-jvm:headerCheck \
         validateDependencies \
         mimaCheckOneAtATime
 

--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/DynamicProjectAdder.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/DynamicProjectAdder.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package sbt {
 
   import sbt.internal.{ BuildStructure, Load, LoadedBuild }

--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/LagomImportCompat.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/LagomImportCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package com.lightbend.lagom.sbt
 
 import sbt.ForkOptions

--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/LagomPluginCompat.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/LagomPluginCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package com.lightbend.lagom.sbt
 
 import sbt._

--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/run/RunSupportCompat.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/run/RunSupportCompat.scala
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package com.lightbend.lagom.sbt.run
 
 import sbt._


### PR DESCRIPTION
I noticed after a local `sbt +publishLocal` that some files didn't get the extra blank line in the `sbt-header` update (#1459).

This is because these are files that are only built when cross-building the sbt 1.0 version of the plugin, but our style check in Travis CI only builds the first Scala version for each module.

I expect the build to fail on the first commit. Once I confirm that it fails as expected, I'll push another commit with the fix.