### PR TITLE
Extends the usage of CS in Lagom-core (mostly dev mode)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -548,6 +548,8 @@ lazy val `server-scaladsl` = (project in file("service/scaladsl/server"))
 
       // changed signature of a method in a private class in https://github.com/lagom/lagom/pull/1109
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.scaladsl.server.ActorSystemProvider.start"),
+      // and changed the result type in https://github.com/lagom/lagom/pull/1483
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("com.lightbend.lagom.scaladsl.server.ActorSystemProvider.start"),
 
       // injected body parsers to avoid access to global state in https://github.com/lagom/lagom/pull/1401
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.server.LagomServerBuilder.this")

--- a/build.sbt
+++ b/build.sbt
@@ -264,6 +264,7 @@ def mimaSettings(versions: Seq[String]): Seq[Setting[_]] = {
     },
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[Problem]("com.lightbend.lagom.internal.*"),
+      ProblemFilters.exclude[Problem]("com.lightbend.lagom.*Components*"),
       ProblemFilters.exclude[Problem]("com.lightbend.lagom.*Module*")
     )
   )
@@ -495,7 +496,6 @@ lazy val `client-scaladsl` = (project in file("service/scaladsl/client"))
     name := "lagom-scaladsl-client",
     Dependencies.`client-scaladsl`,
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.client.CircuitBreakerComponents.circuitBreakersPanel"),
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem]("com.lightbend.lagom.scaladsl.api.LagomConfigComponent.config")
     )
   )
@@ -549,8 +549,7 @@ lazy val `server-scaladsl` = (project in file("service/scaladsl/server"))
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.scaladsl.server.ActorSystemProvider.start"),
 
       // injected body parsers to avoid access to global state in https://github.com/lagom/lagom/pull/1401
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.server.LagomServerBuilder.this"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.server.LagomServerComponents.playBodyParsers")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.scaladsl.server.LagomServerBuilder.this")
     )
   )
   .enablePlugins(RuntimeLibPlugins)
@@ -690,11 +689,7 @@ lazy val `cluster-scaladsl` = (project in file("cluster/scaladsl"))
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-scaladsl-cluster",
-    Dependencies.`cluster-scaladsl`,
-    mimaBinaryIssueFilters ++= Seq(
-      // see https://github.com/lagom/lagom/pull/1393
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.cluster.ClusterComponents.environment")
-    )
+    Dependencies.`cluster-scaladsl`
   ) configs (MultiJvm)
 
 lazy val `pubsub-javadsl` = (project in file("pubsub/javadsl"))
@@ -741,8 +736,6 @@ lazy val `persistence-javadsl` = (project in file("persistence/javadsl"))
   .settings(
     name := "lagom-javadsl-persistence",
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[MissingClassProblem]("com.lightbend.lagom.javadsl.persistence.PersistenceModule$InitServiceLocatorHolder"),
-      ProblemFilters.exclude[MissingClassProblem]("com.lightbend.lagom.javadsl.persistence.PersistenceModule$"),
       // See https://github.com/lagom/lagom/pull/405 for justification for this breaking change,
       // and verification that it causes no binary compatibility problems in practice.
       ProblemFilters.exclude[IncompatibleTemplateDefProblem]("com.lightbend.lagom.javadsl.persistence.PersistentEntity$Persist"),
@@ -837,7 +830,6 @@ lazy val `persistence-cassandra-scaladsl` = (project in file("persistence-cassan
     name := "lagom-scaladsl-persistence-cassandra",
     Dependencies.`persistence-cassandra-scaladsl`,
     mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("com.lightbend.lagom.scaladsl.persistence.cassandra.ReadSideCassandraPersistenceComponents.testCasReadSideSettings"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.scaladsl.persistence.cassandra.testkit.TestUtil#AwaitPersistenceInit.persist"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.scaladsl.persistence.cassandra.testkit.TestUtil#AwaitPersistenceInit.persistAsync")
     )
@@ -889,11 +881,7 @@ lazy val `persistence-jdbc-javadsl` = (project in file("persistence-jdbc/javadsl
 lazy val `persistence-jdbc-scaladsl` = (project in file("persistence-jdbc/scaladsl"))
   .settings(
     name := "lagom-scaladsl-persistence-jdbc",
-    Dependencies.`persistence-jdbc-scaladsl`,
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[UpdateForwarderBodyProblem]("com.lightbend.lagom.scaladsl.persistence.jdbc.WriteSideJdbcPersistenceComponents.slickProvider"),
-      ProblemFilters.exclude[MissingTypesProblem]("com.lightbend.lagom.scaladsl.persistence.jdbc.ReadSideJdbcPersistenceComponents")
-    )
+    Dependencies.`persistence-jdbc-scaladsl`
   )
   .dependsOn(
     `persistence-jdbc-core` % "compile;test->test",

--- a/build.sbt
+++ b/build.sbt
@@ -165,6 +165,7 @@ def formattingPreferences = {
     .setPreference(RewriteArrowSymbols, false)
     .setPreference(AlignParameters, true)
     .setPreference(AlignSingleLineCaseStatements, true)
+    .setPreference(AllowParamGroupsOnNewlines, true)
     .setPreference(SpacesAroundMultiImports, true)
     .setPreference(DanglingCloseParenthesis, Force)
     .setPreference(AlignArguments, false)

--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -240,7 +240,7 @@ object LagomReloadableDevServerStart {
         val actorSystemName = serverConfig.configuration.underlying.getString("lagom.akka.dev-mode.actor-system.name")
         val actorSystem = ActorSystem(actorSystemName, devModeAkkaConfig)
         val serverContext = ServerProvider.Context(serverConfig, appProvider, actorSystem, ActorMaterializer()(actorSystem),
-          () => actorSystem.terminate())
+          () => Future.successful(()))
         val serverProvider = ServerProvider.fromConfiguration(classLoader, serverConfig.configuration)
         serverProvider.createServer(serverContext)
       } catch {

--- a/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/devmode/LagomDevModeComponents.scala
+++ b/dev/service-registry/devmode-scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/devmode/LagomDevModeComponents.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.scaladsl.devmode
 
 import java.net.URI
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import akka.discovery.SimpleServiceDiscovery
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.registry.{ DevModeSimpleServiceDiscovery, ServiceRegistryClient }
@@ -17,7 +17,6 @@ import com.lightbend.lagom.scaladsl.api.deser.DefaultExceptionSerializer
 import com.lightbend.lagom.scaladsl.api.{ ServiceInfo, ServiceLocator }
 import com.lightbend.lagom.scaladsl.client.CircuitBreakerComponents
 import play.api.Environment
-import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.WSClient
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -38,10 +37,10 @@ import scala.concurrent.{ ExecutionContext, Future }
  * will be automatically provided to the service by Lagom's dev mode build plugins.
  */
 trait LagomDevModeComponents extends LagomDevModeServiceLocatorComponents {
-  def applicationLifecycle: ApplicationLifecycle
+  def coordinatedShutdown: CoordinatedShutdown
 
   // Eagerly register services
-  new ServiceRegistration(serviceInfo, applicationLifecycle, config, serviceRegistry)(executionContext)
+  new ServiceRegistration(serviceInfo, coordinatedShutdown, config, serviceRegistry)(executionContext)
 }
 
 /**

--- a/dev/service-registry/registration-javadsl/src/main/scala/com/lightbend/lagom/internal/server/ServiceRegistrationModule.scala
+++ b/dev/service-registry/registration-javadsl/src/main/scala/com/lightbend/lagom/internal/server/ServiceRegistrationModule.scala
@@ -9,13 +9,12 @@ import java.util.function.{ Function => JFunction }
 
 import akka.actor.CoordinatedShutdown
 import akka.{ Done, NotUsed }
-import com.google.inject.Provider
 import com.lightbend.lagom.internal.javadsl.registry.{ ServiceRegistry, ServiceRegistryService }
 import com.lightbend.lagom.internal.javadsl.server.ResolvedServices
 import com.typesafe.config.Config
 import javax.inject.{ Inject, Provider, Singleton }
-import play.api.{ Configuration, Environment, Logger }
 import play.api.inject.{ Binding, Module }
+import play.api.{ Configuration, Environment, Logger }
 
 import scala.compat.java8.FutureConverters.CompletionStageOps
 import scala.concurrent.{ ExecutionContext, Future }

--- a/dev/service-registry/registration-javadsl/src/main/scala/com/lightbend/lagom/internal/server/ServiceRegistrationModule.scala
+++ b/dev/service-registry/registration-javadsl/src/main/scala/com/lightbend/lagom/internal/server/ServiceRegistrationModule.scala
@@ -7,20 +7,18 @@ package com.lightbend.lagom.internal.server
 import java.net.URI
 import java.util.function.{ Function => JFunction }
 
-import scala.compat.java8.FutureConverters.CompletionStageOps
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import akka.NotUsed
-import javax.inject.{ Inject, Provider, Singleton }
-import com.lightbend.lagom.internal.javadsl.registry.{ ServiceAcl, ServiceRegistry, ServiceRegistryService }
+import akka.actor.CoordinatedShutdown
+import akka.{ Done, NotUsed }
+import com.google.inject.Provider
+import com.lightbend.lagom.internal.javadsl.registry.{ ServiceRegistry, ServiceRegistryService }
 import com.lightbend.lagom.internal.javadsl.server.ResolvedServices
 import com.typesafe.config.Config
-import play.api.Configuration
-import play.api.Environment
-import play.api.Logger
-import play.api.inject.ApplicationLifecycle
-import play.api.inject.Binding
-import play.api.inject.Module
+import javax.inject.{ Inject, Provider, Singleton }
+import play.api.{ Configuration, Environment, Logger }
+import play.api.inject.{ Binding, Module }
+
+import scala.compat.java8.FutureConverters.CompletionStageOps
+import scala.concurrent.{ ExecutionContext, Future }
 
 class ServiceRegistrationModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
@@ -49,20 +47,20 @@ object ServiceRegistrationModule {
    */
   @Singleton
   private class RegisterWithServiceRegistry @Inject() (
-    lifecycle:        ApplicationLifecycle,
-    resolvedServices: ResolvedServices,
-    config:           ServiceConfig,
-    registry:         ServiceRegistry
+    coordinatedShutdown: CoordinatedShutdown,
+    resolvedServices:    ResolvedServices,
+    config:              ServiceConfig,
+    registry:            ServiceRegistry
   )(implicit ec: ExecutionContext) {
 
     private lazy val logger: Logger = Logger(this.getClass())
 
     private val locatableServices = resolvedServices.services.filter(_.descriptor.locatableService)
 
-    lifecycle.addStopHook { () =>
+    coordinatedShutdown.addTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "unregister-services-from-service-locator-javadsl") { () =>
       Future.sequence(locatableServices.map { service =>
         registry.unregister(service.descriptor.name).invoke().toScala
-      }).map(_ => ())
+      }).map(_ => Done)
     }
 
     locatableServices.foreach { service =>

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
@@ -30,14 +30,9 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
-class AkkaHttpServiceGatewayFactory @Inject() (
-  coordinatedShutdown:                     CoordinatedShutdown,
-  config:                                  ServiceGatewayConfig,
-  @Named("serviceRegistryActor") registry: ActorRef
-)(implicit
-  actorSystem: ActorSystem,
-  mat: Materializer
-) {
+class AkkaHttpServiceGatewayFactory @Inject() (coordinatedShutdown: CoordinatedShutdown, config: ServiceGatewayConfig)
+  (@Named("serviceRegistryActor") registry: ActorRef)
+  (implicit actorSystem: ActorSystem, mat: Materializer) {
 
   def start(): InetSocketAddress = {
     new AkkaHttpServiceGateway(coordinatedShutdown, config, registry).address

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
@@ -165,18 +165,12 @@ class AkkaHttpServiceGateway(coordinatedShutdown: CoordinatedShutdown, config: S
 
   private val bindingFuture = Http().bindAndHandle(handler, config.host, config.port)
 
-  coordinatedShutdown.addTask(
-    CoordinatedShutdown.PhaseServiceUnbind,
-    "unbind-akka-http-service-gateway"
-  ) {
-      () =>
-        {
-          (for {
-            binding <- bindingFuture
-            unbind <- binding.unbind()
-          } yield unbind).map(_ => Done)
-        }
-    }
+  coordinatedShutdown.addTask(CoordinatedShutdown.PhaseServiceUnbind, "unbind-akka-http-service-gateway") { () =>
+    for {
+      binding <- bindingFuture
+      _ <- binding.unbind()
+    } yield Done
+  }
 
   val address: InetSocketAddress = Await.result(bindingFuture, 10.seconds).localAddress
 }

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
@@ -6,9 +6,9 @@ package com.lightbend.lagom.gateway
 
 import java.net.InetSocketAddress
 import java.util.Locale
-import javax.inject.{ Inject, Named }
 
-import akka.actor.{ ActorRef, ActorSystem }
+import akka.Done
+import akka.actor.{ ActorRef, ActorSystem, CoordinatedShutdown }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ws._
@@ -18,8 +18,8 @@ import akka.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import akka.util.Timeout
 import com.lightbend.lagom.internal.javadsl.registry.ServiceRegistryService
 import com.lightbend.lagom.registry.impl.ServiceRegistryActor.{ Found, NotFound, Route, RouteResult }
+import javax.inject.{ Inject, Named }
 import org.slf4j.LoggerFactory
-import play.api.inject.ApplicationLifecycle
 import play.api.libs.typedmap.TypedMap
 import play.api.mvc.request.{ RemoteConnection, RequestAttrKey, RequestTarget }
 import play.api.mvc.{ Headers, RequestHeader }
@@ -30,15 +30,21 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{ Await, Future }
 
-class AkkaHttpServiceGatewayFactory @Inject() (lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig,
-                                               @Named("serviceRegistryActor") registry: ActorRef)(implicit actorSystem: ActorSystem, mat: Materializer) {
+class AkkaHttpServiceGatewayFactory @Inject() (
+  coordinatedShutdown:                     CoordinatedShutdown,
+  config:                                  ServiceGatewayConfig,
+  @Named("serviceRegistryActor") registry: ActorRef
+)(implicit
+  actorSystem: ActorSystem,
+  mat: Materializer
+) {
 
   def start(): InetSocketAddress = {
-    new AkkaHttpServiceGateway(lifecycle, config, registry).address
+    new AkkaHttpServiceGateway(coordinatedShutdown, config, registry).address
   }
 }
 
-class AkkaHttpServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGatewayConfig, registry: ActorRef)(implicit actorSystem: ActorSystem, mat: Materializer) {
+class AkkaHttpServiceGateway(coordinatedShutdown: CoordinatedShutdown, config: ServiceGatewayConfig, registry: ActorRef)(implicit actorSystem: ActorSystem, mat: Materializer) {
 
   private val log = LoggerFactory.getLogger(classOf[AkkaHttpServiceGateway])
 
@@ -158,12 +164,19 @@ class AkkaHttpServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGat
   }
 
   private val bindingFuture = Http().bindAndHandle(handler, config.host, config.port)
-  lifecycle.addStopHook(() => {
-    for {
-      binding <- bindingFuture
-      unbind <- binding.unbind()
-    } yield unbind
-  })
+
+  coordinatedShutdown.addTask(
+    CoordinatedShutdown.PhaseServiceUnbind,
+    "unbind-akka-http-service-gateway"
+  ) {
+      () =>
+        {
+          (for {
+            binding <- bindingFuture
+            unbind <- binding.unbind()
+          } yield unbind).map(_ => Done)
+        }
+    }
 
   val address: InetSocketAddress = Await.result(bindingFuture, 10.seconds).localAddress
 }

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
@@ -368,7 +368,7 @@ class NettyServiceGateway(coordinatedShutdown: CoordinatedShutdown, config: Serv
 
   private val bindFuture = server.bind(config.host, config.port).channelFutureToScala
 
-  val unbindTimeout = cs.timeout(CoordinatedShutdown.PhaseServiceUnbind)
+  val unbindTimeout = coordinatedShutdown.timeout(CoordinatedShutdown.PhaseServiceUnbind)
   coordinatedShutdown.addTask(
     CoordinatedShutdown.PhaseServiceUnbind,
     "unbind-netty-service-gateway"

--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
@@ -373,8 +373,8 @@ class NettyServiceGateway(coordinatedShutdown: CoordinatedShutdown, config: Serv
     for {
       channel <- bindFuture
       _ <- channel.close().channelFutureToScala
+      _ <- eventLoop.shutdownGracefully(100, unbindTimeout.toMillis - 100, TimeUnit.MILLISECONDS).toScala
     } yield {
-      eventLoop.shutdownGracefully(100, unbindTimeout.toMillis - 100, TimeUnit.MILLISECONDS)
       poolMap.asScala.foreach(_.getValue.close())
       Done
     }

--- a/dev/service-registry/service-locator/src/test/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGatewaySpec.scala
+++ b/dev/service-registry/service-locator/src/test/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGatewaySpec.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.gateway
 
 import java.net.URI
 
-import akka.actor.{ ActorSystem, Props }
+import akka.actor.{ ActorSystem, CoordinatedShutdown, Props }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.ws.{ Message, TextMessage, UpgradeToWebSocket, WebSocketRequest }
 import akka.http.scaladsl.model.{ HttpEntity, HttpRequest, HttpResponse }
@@ -18,7 +18,7 @@ import com.lightbend.lagom.javadsl.api.ServiceAcl
 import com.lightbend.lagom.javadsl.api.transport.Method
 import com.lightbend.lagom.registry.impl.{ ServiceRegistryActor, UnmanagedServices }
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec }
-import play.api.inject.DefaultApplicationLifecycle
+import play.core.server.Server.ServerStoppedReason
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Await
@@ -29,13 +29,13 @@ class AkkaHttpServiceGatewaySpec extends WordSpec with Matchers with BeforeAndAf
   implicit val actorSystem = ActorSystem()
   import actorSystem.dispatcher
   implicit val mat = ActorMaterializer()
+  val coordinatedShutdown = CoordinatedShutdown(actorSystem)
   val http = Http()
 
-  var serviceBinding: Http.ServerBinding = _
   var gateway: AkkaHttpServiceGateway = _
 
   override protected def beforeAll(): Unit = {
-    serviceBinding = Await.result(http.bindAndHandle(Flow[HttpRequest].map {
+    var serviceBinding = Await.result(http.bindAndHandle(Flow[HttpRequest].map {
       case hello if hello.uri.path.toString() == "/hello" => HttpResponse(entity = HttpEntity("Hello!"))
       case stream if stream.uri.path.toString() == "/stream" =>
         stream.header[UpgradeToWebSocket].get.handleMessages(Flow[Message])
@@ -51,7 +51,7 @@ class AkkaHttpServiceGatewaySpec extends WordSpec with Matchers with BeforeAndAf
       ))
     ))))
 
-    gateway = new AkkaHttpServiceGateway(new DefaultApplicationLifecycle, ServiceGatewayConfig("127.0.0.1", 0), serviceRegistry)
+    gateway = new AkkaHttpServiceGateway(coordinatedShutdown, ServiceGatewayConfig("127.0.0.1", 0), serviceRegistry)
   }
 
   def gatewayUri = "http://localhost:" + gateway.address.getPort
@@ -85,6 +85,6 @@ class AkkaHttpServiceGatewaySpec extends WordSpec with Matchers with BeforeAndAf
   }
 
   override protected def afterAll(): Unit = {
-    actorSystem.terminate()
+    coordinatedShutdown.run(ServerStoppedReason)
   }
 }

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -245,7 +245,6 @@ abstract class LagomApplication(context: LagomApplicationContext)
     applicationLifecycle.addStopHook(stopHook)
     system
   }
-  override lazy val coordinatedShutdown: CoordinatedShutdown = CoordinatedShutdown(actorSystem)
 
   LagomServerTopicFactoryVerifier.verify(lagomServer, topicPublisherName)
 }

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -240,11 +240,8 @@ abstract class LagomApplication(context: LagomApplicationContext)
     Configuration.load(environment) ++ context.playContext.initialConfiguration ++ additionalConfig
   }
 
-  override lazy val actorSystem: ActorSystem = {
-    val (system, stopHook) = ActorSystemProvider.start(config, environment, optionalJsonSerializerRegistry)
-    applicationLifecycle.addStopHook(stopHook)
-    system
-  }
+  override lazy val actorSystem: ActorSystem =
+    ActorSystemProvider.start(config, environment, optionalJsonSerializerRegistry)
 
   LagomServerTopicFactoryVerifier.verify(lagomServer, topicPublisherName)
 }
@@ -260,7 +257,7 @@ private object ActorSystemProvider {
     config:             Config,
     environment:        Environment,
     serializerRegistry: Option[JsonSerializerRegistry]
-  ): (ActorSystem, StopHook) = {
+  ): ActorSystem = {
     val serializationSetup =
       JsonSerializerRegistry.serializationSetupFor(serializerRegistry.getOrElse(EmptyJsonSerializerRegistry))
 
@@ -268,7 +265,7 @@ private object ActorSystemProvider {
       environment.classLoader,
       Configuration(config),
       serializationSetup
-    )
+    )._1
   }
 
 }

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -245,6 +245,7 @@ abstract class LagomApplication(context: LagomApplicationContext)
     applicationLifecycle.addStopHook(stopHook)
     system
   }
+  override lazy val coordinatedShutdown: CoordinatedShutdown = CoordinatedShutdown(actorSystem)
 
   LagomServerTopicFactoryVerifier.verify(lagomServer, topicPublisherName)
 }

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.scaladsl.server
 
 import java.net.URI
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, CoordinatedShutdown }
 import akka.event.Logging
 import com.lightbend.lagom.internal.scaladsl.client.ScaladslServiceResolver
 import com.lightbend.lagom.internal.scaladsl.server.ScaladslServerMacroImpl


### PR DESCRIPTION
I had worked on this few weeks ago but needed CS merged and 2.7.0-Mx. 

Its' mostly dogfooding so devmode components use Coordinated Shutdown instead of `ApplicationLifecycle`.

Related to #1379