### PR TITLE
Bind Netty service gateway to the configured host (not 0.0.0.0)

### DIFF
--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/NettyServiceGateway.scala
@@ -365,7 +365,7 @@ class NettyServiceGateway(lifecycle: ApplicationLifecycle, config: ServiceGatewa
     }
   }
 
-  private val bindFuture = server.bind(config.port).channelFutureToScala
+  private val bindFuture = server.bind(config.host, config.port).channelFutureToScala
   lifecycle.addStopHook(() => {
     for {
       channel <- bindFuture


### PR DESCRIPTION
Related to #1378

I stumbled upon this code and noticed this `bind` was ignoring `config.host`.

cc @erip