### PR TITLE
Adds some comments on Travis scripts

### DIFF
--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -5,7 +5,8 @@
 
 ## The following are three separate `sbt` invocations because in some versions of sbt (0.13)
 ## trying to run all tasks in a single session caused "GC overhead limit exceeded" (both in
-## Travis and locally)
+## Travis and locally).
+## See https://github.com/lagom/lagom/pull/1482
 
 runSbt  +scalariformFormat \
         +test:scalariformFormat \

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -2,6 +2,11 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
+
+## The following are three separate `sbt` invocations because in some versions of sbt (0.13)
+## trying to run all tasks in a single session caused "GC overhead limit exceeded" (both in
+## Travis and locally)
+
 runSbt  +scalariformFormat \
         +test:scalariformFormat \
         multi-jvm:scalariformFormat


### PR DESCRIPTION
Related to https://github.com/lagom/lagom/pull/1482.

The comments explain why it's three `sbt` invocations instead fo one.