### PR TITLE
Add a TransportException constructor with message and cause

### DIFF
--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/TransportException.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/TransportException.java
@@ -41,6 +41,12 @@ public class TransportException extends RuntimeException {
         this.exceptionMessage = exceptionMessage;
     }
 
+    public TransportException(TransportErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+        this.exceptionMessage = new ExceptionMessage(this.getClass().getSimpleName(), message);
+    }
+
     public static TransportException fromCodeAndMessage(TransportErrorCode errorCode, ExceptionMessage exceptionMessage) {
         BiFunction<TransportErrorCode, ExceptionMessage, TransportException> creator = BY_NAME_TRANSPORT_EXCEPTIONS.get(exceptionMessage.name());
         if (creator != null) {


### PR DESCRIPTION
Added another constructor with message in TransportMessage.java to suffice RuntimeException constructor

# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?



## Purpose

This PR adds another constructor to ```TransportException.java``` which takes ```message```, ```Throwable``` exception and ```TransportErrorCode```.


## References

After discussing it with @TimMoore on contributor channel on Lagom Gitter. Here is the conversation:

> Piyush Goyal @piyushGoyal2 Jun 20 09:03
Lagom version 1.4.x /Java Version. There is no support for custom error message to be passed to RunTimeException(message, Throwable) constructor. TransportException has only one constructor which takes TransportErrorCode and Throwable and it passes cause.getMessage() as the message to RuntimeException constructor. The message field in the constructor of RuntimeException was created to pass a custom message which we are clearing skipping here. Any opinion on why it was done. My recommendation would be create another constructor which takes an extra parameter as String message apart from Throwable and TransportErrorCode and call the super with the message and throwable. ExceptionMessage can be formed using the throwable.getMessage

> Tim Moore @TimMoore Jun 20 09:22
@piyushGoyal2 sounds OK to me

> Piyush Goyal @piyushGoyal2 Jun 20 09:22
should I raise a pull request then. 

> Tim Moore @TimMoore Jun 20 09:24
@piyushGoyal2 that would be great. I would just say that the ExceptionMessage should probably be built from the extra message parameter rather than throwable.getMessage.

Are there any relevant issues / PRs / mailing lists discussions?
