### PR TITLE
Adds sbt-sonatype settings after upgrading to version 2.0+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,6 +146,8 @@ def runtimeScalaSettings: Seq[Setting[_]] = Seq(
 )
 
 def runtimeLibCommon: Seq[Setting[_]] = common ++ runtimeScalaSettings ++ Seq(
+  publishTo := sonatypePublishTo.value,
+
   Dependencies.validateDependenciesSetting,
   Dependencies.pruneWhitelistSetting,
   Dependencies.dependencyWhitelistSetting,


### PR DESCRIPTION
In https://github.com/lagom/lagom/pull/1463 we bumped `sbt-sonatype` from `0.5.0` to `2.3`. This introduced a bug
because since [2.0.0-M1](https://github.com/xerial/sbt-sonatype/blob/master/ReleaseNotes.md) the `sbt-sonatype` plugin
no longer overrides `publishTo` and it requires users to set an explicit value.