### PR TITLE
Explicitly disables Bintray and sets up Sonatype on dev mode projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,9 +129,11 @@ def releaseStepCommandAndRemaining(command: String): State => State = { original
   runCommand(command, originalState.copy(remainingCommands = Nil)).copy(remainingCommands = originalRemaining)
 }
 
-def runtimeScalaSettings: Seq[Setting[_]] = Seq(
-  publishTo := sonatypePublishTo.value,
+def sonatypeSettings: Seq[Setting[_]] = Seq(
+  publishTo := sonatypePublishTo.value
+)
 
+def runtimeScalaSettings: Seq[Setting[_]] = Seq(
   crossScalaVersions := Dependencies.ScalaVersions,
   scalaVersion := Dependencies.ScalaVersions.head,
 
@@ -147,7 +149,7 @@ def runtimeScalaSettings: Seq[Setting[_]] = Seq(
   )
 )
 
-def runtimeLibCommon: Seq[Setting[_]] = common ++ runtimeScalaSettings ++ Seq(
+def runtimeLibCommon: Seq[Setting[_]] = common ++ sonatypeSettings ++ runtimeScalaSettings ++ Seq(
   Dependencies.validateDependenciesSetting,
   Dependencies.pruneWhitelistSetting,
   Dependencies.dependencyWhitelistSetting,
@@ -1069,6 +1071,9 @@ lazy val `reloadable-server` = (project in file("dev") / "reloadable-server")
   )
 
 lazy val `build-tool-support` = (project in file("dev") / "build-tool-support")
+  .disablePlugins(BintrayPlugin)
+  .enablePlugins(AutomateHeaderPlugin && Sonatype)
+  .settings(sonatypeSettings: _*)
   .settings(common: _*)
   .settings(
     name := "lagom-build-tool-support",
@@ -1088,6 +1093,9 @@ lazy val `build-tool-support` = (project in file("dev") / "build-tool-support")
 //
 // https://github.com/playframework/playframework/blob/2.6.7/framework/build.sbt#L27-L40
 lazy val `sbt-build-tool-support` = (project in file("dev") / "build-tool-support")
+  .disablePlugins(BintrayPlugin)
+  .enablePlugins(AutomateHeaderPlugin && Sonatype)
+  .settings(sonatypeSettings: _*)
   .settings(common: _*)
   .settings(
     name := "lagom-sbt-build-tool-support",
@@ -1137,7 +1145,9 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
   ).dependsOn(`sbt-build-tool-support`)
 
 lazy val `maven-plugin` = (project in file("dev") / "maven-plugin")
-  .enablePlugins(lagom.SbtMavenPlugin)
+  .disablePlugins(BintrayPlugin)
+  .enablePlugins(lagom.SbtMavenPlugin && AutomateHeaderPlugin && Sonatype && Unidoc)
+  .settings(sonatypeSettings: _*)
   .settings(common: _*)
   .settings(
     name := "Lagom Maven Plugin",
@@ -1185,6 +1195,9 @@ val ArchetypeVariablePattern = "%([A-Z-]+)%".r
 
 def archetypeProject(archetypeName: String) =
   Project(s"maven-$archetypeName-archetype", file("dev") / "archetypes" / s"maven-$archetypeName")
+    .disablePlugins(BintrayPlugin)
+    .enablePlugins(AutomateHeaderPlugin && Sonatype)
+    .settings(sonatypeSettings: _*)
     .settings(common: _*)
     .settings(
       name := s"maven-archetype-lagom-$archetypeName",
@@ -1218,6 +1231,9 @@ def archetypeProject(archetypeName: String) =
 
 lazy val `maven-java-archetype` = archetypeProject("java")
 lazy val `maven-dependencies` = (project in file("dev") / "maven-dependencies")
+  .disablePlugins(BintrayPlugin)
+  .enablePlugins(AutomateHeaderPlugin && Sonatype)
+  .settings(sonatypeSettings: _*)
     .settings(common: _*)
     .settings(
       name := "lagom-maven-dependencies",
@@ -1298,8 +1314,11 @@ lazy val `maven-dependencies` = (project in file("dev") / "maven-dependencies")
 
 // This project doesn't get aggregated, it is only executed by the sbt-plugin scripted dependencies
 lazy val `sbt-scripted-tools` = (project in file("dev") / "sbt-scripted-tools")
-  .settings(name := "lagom-sbt-scripted-tools")
+  .disablePlugins(BintrayPlugin)
+  .enablePlugins(AutomateHeaderPlugin && Sonatype)
+  .settings(sonatypeSettings: _*)
   .settings(common: _*)
+  .settings(name := "lagom-sbt-scripted-tools")
   .settings(
     sbtPlugin := true,
     crossScalaVersions := Dependencies.SbtScalaVersions,
@@ -1389,6 +1408,7 @@ lazy val `play-integration-javadsl` = (project in file("dev") / "service-registr
 lazy val `cassandra-server` = (project in file("dev") / "cassandra-server")
   .settings(common: _*)
   .settings(runtimeScalaSettings: _*)
+  .settings(sonatypeSettings)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-cassandra-server",
@@ -1398,6 +1418,7 @@ lazy val `cassandra-server` = (project in file("dev") / "cassandra-server")
 lazy val `kafka-server` = (project in file("dev") / "kafka-server")
   .settings(common: _*)
   .settings(runtimeScalaSettings: _*)
+  .settings(sonatypeSettings)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
     name := "lagom-kafka-server",

--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -9,14 +9,14 @@ Lagom 1.5 also updates to the latest major versions of Play (2.7) and Akka HTTP 
 
 ### Maven
 
-If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.5.0-M1`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
+If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.5.0-M2`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
 
 ### sbt
 
 The version of Lagom can be updated by editing the `project/plugins.sbt` file, and updating the version of the Lagom sbt plugin. For example:
 
 ```scala
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M2")
 ```
 
 

--- a/docs/manual/scala/releases/Migration15.md
+++ b/docs/manual/scala/releases/Migration15.md
@@ -10,7 +10,7 @@ Lagom 1.5 also updates to the latest major versions of Play (2.7) and Akka HTTP 
 The version of Lagom can be updated by editing the `project/plugins.sbt` file, and updating the version of the Lagom sbt plugin. For example:
 
 ```scala
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M1")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.0-M2")
 ```
 
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,11 +5,17 @@ libraryDependencies ++= Seq(
 )
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+
+// the plugins used during release can have an impact on default values
+// of the build. To validate your changes on the release plugins don't
+// affect the release process, review https://github.com/lagom/lagom/issues/1496#issuecomment-408398508
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.9")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.4")
+
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm" % "0.4.0")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.1")


### PR DESCRIPTION
In #1494 we ensured all projects had `publishTo` information but we didn't ensure the value was correct.

The fix here explicitly disables `Bintray` plugin, enables `Sonatype` and sets the correct `publishTo` value for a few projects.