### PR TITLE
Adds sbt task to validate `publishTo` settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,8 @@ def common: Seq[Setting[_]] = releaseSettings ++ bintraySettings ++ evictionSett
 
   ScalariformKeys.preferences in Compile  := formattingPreferences,
   ScalariformKeys.preferences in Test     := formattingPreferences,
-  ScalariformKeys.preferences in MultiJvm := formattingPreferences
+  ScalariformKeys.preferences in MultiJvm := formattingPreferences,
+  LagomPublish.validatePublishSettingsSetting
 )
 
 def bintraySettings: Seq[Setting[_]] = Seq(

--- a/project/LagomPublish.scala
+++ b/project/LagomPublish.scala
@@ -1,0 +1,27 @@
+import Dependencies.{ validateDependencies, validateDependenciesTask }
+import sbt.{ Def, FeedbackProvidedException, Resolver, Task, taskKey }
+import sbt.Keys.{ name, publishTo, streams }
+
+object LagomPublish {
+
+  val validatePublishSettings = taskKey[Unit]("Validate Lagom settings to publish released artifacts.")
+
+  val validatePublishSettingsTask: Def.Initialize[Task[Unit]] = Def.task {
+    val ptValue: Option[Resolver] = publishTo.value
+
+    val log = streams.value.log
+
+    if (ptValue.isEmpty) {
+      throw PublishValidationFailed
+    }else{
+       log.info(s"[${name.value}] PublishTo settings validation passed.")
+    }
+  }
+
+  val validatePublishSettingsSetting = validatePublishSettings := validatePublishSettingsTask.value
+
+  private object PublishValidationFailed extends RuntimeException with FeedbackProvidedException {
+    override def toString = "PublishTo settings validation failed!"
+  }
+
+}

--- a/project/LagomPublish.scala
+++ b/project/LagomPublish.scala
@@ -13,6 +13,8 @@ object LagomPublish {
     (name.value, resolverValue) match {
       case (_, None) => throw new PublishValidationFailed("`publishTo` not set.")
       case ("lagom-sbt-plugin", x) =>
+        // see https://github.com/sbt/sbt-bintray/blob/7c93bacaae3ffc128564ceacb6e73ec4486525dd/src/main/scala/Bintray.scala#L16-L29 for
+        // details on the syntax of Bintray Resolver names.
         if (x.get.name != "Bintray-Sbt-Publish-lagom-sbt-plugin-releases-lagom-sbt-plugin") {
           throw new PublishValidationFailed("""Invalid resolver. Expected: "Raw(Bintray-Sbt-Publish-lagom-sbt-plugin-releases-lagom-sbt-plugin)".""")
         }

--- a/project/LagomPublish.scala
+++ b/project/LagomPublish.scala
@@ -17,14 +17,14 @@ object LagomPublish {
         // see https://github.com/sbt/sbt-bintray/blob/7c93bacaae3ffc128564ceacb6e73ec4486525dd/src/main/scala/Bintray.scala#L16-L29 for
         // details on the syntax of Bintray Resolver names.
         if (inReleaseVersion && x.get.name != "Bintray-Sbt-Publish-lagom-sbt-plugin-releases-lagom-sbt-plugin") {
-          throw new PublishValidationFailed(s"""Invalid resolver. Expected: "Raw(Bintray-Sbt-Publish-lagom-sbt-plugin-releases-lagom-sbt-plugin)" but was "${x.get.name}".""")
+          throw new PublishValidationFailed("Raw(Bintray-Sbt-Publish-lagom-sbt-plugin-releases-lagom-sbt-plugin)", x.get)
         }
         // TODO: Add a validation for "lagom-sbt-plugin" when the version is a snapshot.
       case (_, x) =>
         // TODO: this could be improved to assert the specific Resolver depending on release-vs-snapshot nature of the version.
         // e.g. sonatype-staging vs sonatype-snapshots
         if (!x.get.name.toLowerCase.contains("sonatype")) {
-          throw new PublishValidationFailed(s"""Invalid resolver. Expected: Sonatype. Actual ${x.get}.""")
+          throw new PublishValidationFailed("Sonatype", x.get)
         }
     }
   }
@@ -32,7 +32,8 @@ object LagomPublish {
   val validatePublishSettingsSetting = validatePublishSettings := validatePublishSettingsTask.value
 
 
-  private class PublishValidationFailed(message: String) extends RuntimeException with FeedbackProvidedException {
+  private class PublishValidationFailed(message:String) extends RuntimeException with FeedbackProvidedException {
+    def this(expectedResolver: String, actual:Resolver) = this(s"""Invalid resolver. Expected: "$expectedResolver" but was "$actual".""")
     override def toString = message
   }
 

--- a/project/LagomPublish.scala
+++ b/project/LagomPublish.scala
@@ -1,27 +1,32 @@
-import Dependencies.{ validateDependencies, validateDependenciesTask }
+import sbt.Keys.{ name, publishTo }
 import sbt.{ Def, FeedbackProvidedException, Resolver, Task, taskKey }
-import sbt.Keys.{ name, publishTo, streams }
 
 object LagomPublish {
 
   val validatePublishSettings = taskKey[Unit]("Validate Lagom settings to publish released artifacts.")
 
   val validatePublishSettingsTask: Def.Initialize[Task[Unit]] = Def.task {
-    val ptValue: Option[Resolver] = publishTo.value
+    val resolverValue: Option[Resolver] = publishTo.value
 
-    val log = streams.value.log
-
-    if (ptValue.isEmpty) {
-      throw PublishValidationFailed
-    }else{
-       log.info(s"[${name.value}] PublishTo settings validation passed.")
+    // the following implements the rules described in https://github.com/lagom/lagom/issues/1496#issuecomment-408398508
+    // TODO: improve rules and validations depending on the version (SNAPSHOT vs release)
+    (name.value, resolverValue) match {
+      case (_, None) => throw new PublishValidationFailed("`publishTo` not set.")
+      case ("lagom-sbt-plugin", x) =>
+        if (x.get.name != "Bintray-Sbt-Publish-lagom-sbt-plugin-releases-lagom-sbt-plugin") {
+          throw new PublishValidationFailed("""Invalid resolver. Expected: "Raw(Bintray-Sbt-Publish-lagom-sbt-plugin-releases-lagom-sbt-plugin)".""")
+        }
+      case (_, x) =>
+        if (!x.get.name.toLowerCase.contains("sonatype")) {
+          throw new PublishValidationFailed(s"""Invalid resolver. Expected: Sonatype. Actual $x.""")
+        }
     }
   }
 
   val validatePublishSettingsSetting = validatePublishSettings := validatePublishSettingsTask.value
 
-  private object PublishValidationFailed extends RuntimeException with FeedbackProvidedException {
-    override def toString = "PublishTo settings validation failed!"
+  private class PublishValidationFailed(message: String) extends RuntimeException with FeedbackProvidedException {
+    override def toString = message
   }
 
 }


### PR DESCRIPTION
Related to #1496 (#1497, #1494, #1493).

Some settings like `publishTo` are only exercised during a release. On top of that, these settings often rely on default values set on `AutoPlugin`s. The third cause of confusion is having multiple plugins that may set these default values (`Sonatype` vs `Bintray`).

This PR introduces a task that asserts the correct value for each of the Lagom projects is set and the value is coherent with the rules presented in https://github.com/lagom/lagom/issues/1496#issuecomment-408398508.

On a separate PR we can add a Travis task to invoke this validation on every Travis execution.

The task runs on the current sbt state. This state differs when the current build is a `SNAPSHOT` version or a release version. A future improvement would be to make the validation alter the state so we can assert the settings are correct in both `SNAPSHOT` and release states.

Credit to @dwijnand for the suggestion on how to solve this problem (custom `sbt` tasks).