### PR TITLE
Cache entire .sbt directory on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
     - rm ~/.m2/settings.xml
 cache:
   directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot/scala*
+    - $HOME/.ivy2
+    - $HOME/.sbt
     - $HOME/.m2/repository
 before_cache:
   # Ensure changes to the cache aren't persisted
@@ -33,6 +33,7 @@ before_cache:
   - rm -r $HOME/.m2/repository/com/lightbend/lagom/*
   # Delete all ivydata files since ivy touches them on each build
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
+  - find $HOME/.sbt -name "*.lock" -delete
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
## Purpose

This will help to reduce the number of errors due to Travis failing to download sbt dependencies.

## Background Context

We are having a bunch of errors on our builds that are not related to pull-request changes. Most of them are happening because Travis is failing to download sbt launcher:

```
Downloading sbt launcher for 0.13.17:
  From  http://repo.typesafe.com/typesafe/ivy-releases/org.scala-sbt/sbt-launch/0.13.17/sbt-launch.jar
    To  /home/travis/.sbt/launchers/0.13.17/sbt-launch.jar
Download failed. Obtain the jar manually and place it at /home/travis/.sbt/launchers/0.13.17/sbt-launch.jar
```

It is possible the problem is on Bintray side. By caching `~/.sbt` and `~/.ivy2` we should reduce the change of failure since sbt launcher and its dependencies are cached.

## References

https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html#Caching