### PR TITLE
reverts Load.reapply change introduced in #1500

### DIFF
--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/DynamicProjectAdder.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/DynamicProjectAdder.scala
@@ -10,9 +10,8 @@ package sbt {
 
     def reapply(
       newSettings: Seq[Setting[_]],
-      structure:   BuildStructure,
-      log:         Logger
-    )(implicit display: Show[ScopedKey[_]]): BuildStructure = Load.reapply(newSettings, structure, log)
+      structure:   BuildStructure
+    )(implicit display: Show[ScopedKey[_]]): BuildStructure = Load.reapply(newSettings, structure)
 
     def finalTransforms(ss: Seq[Setting[_]]): Seq[Setting[_]] = Load.finalTransforms(ss)
 
@@ -121,8 +120,7 @@ package com.lightbend.lagom.sbt {
 
         // Now we recreate the structure, this is where the structure data is calculated, which evaluates all the settings
         // and works out all the dependencies.
-        val logger = extracted.get(Keys.sLog in ThisBuild)
-        val reindexedStructure = sbt.LagomLoad.reapply(newSession.mergeSettings, structureWithNewProject, logger)
+        val reindexedStructure = sbt.LagomLoad.reapply(newSession.mergeSettings, structureWithNewProject)
 
         // And finally, put all the new stuff in a new state.
         state.copy(attributes = state.attributes.put(stateBuildStructure, reindexedStructure).put(sessionSettings, newSession))


### PR DESCRIPTION
This PR reverts a change we introduced in PR #1500 to make it compatible with sbt 1.2.0. 

This change makes Lagom compatible with sbt < 1.2.0 and >= 1.2.1, but not compatible with 1.2.0.