### PR TITLE
Configurable serviceHttpsPort for maven plugin

### DIFF
--- a/dev/maven-plugin/src/main/maven/plugin.xml
+++ b/dev/maven-plugin/src/main/maven/plugin.xml
@@ -54,6 +54,26 @@
             </configuration>
         </parameter>
         <parameter>
+            <name>serviceHttpPort</name>
+            <type>int</type>
+            <required>false</required>
+            <editable>true</editable>
+            <description>The http port this service should run on</description>
+            <configuration>
+                <serviceHttpPort implementation="int" default-value="-1"/>
+            </configuration>
+        </parameter>
+        <parameter>
+            <name>serviceHttpsPort</name>
+            <type>int</type>
+            <required>false</required>
+            <editable>true</editable>
+            <description>The https port this service should run on</description>
+            <configuration>
+                <serviceHttpsPort implementation="int" default-value="-1"/>
+            </configuration>
+        </parameter>
+        <parameter>
             <name>watchDirs</name>
             <type>java.util.List</type>
             <required>false</required>
@@ -504,6 +524,13 @@
                 </parameter>
                 <parameter>
                     <name>servicePort</name>
+                    <deprecated>As of release 1.5.0. Use serviceHttpPort instead.</deprecated>
+                </parameter>
+                <parameter>
+                    <name>serviceHttpPort</name>
+                </parameter>
+                <parameter>
+                    <name>serviceHttpsPort</name>
                 </parameter>
                 <parameter>
                     <name>servicePortRange</name>

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/custom-port-range-for-services/build.sbt
@@ -18,7 +18,7 @@ lazy val b = (project in file("b")).enablePlugins(LagomJava)
 
 InputKey[Unit]("verifyPortProjA") := {
   val expected = Def.spaceDelimited().parsed.head.toInt
-  val actual = (lagomServicePort in a).value
+  val actual = (lagomServiceHttpPort in a).value
   if (expected == actual) {
     println(s"Expected and got $expected port")
   } else {
@@ -28,7 +28,7 @@ InputKey[Unit]("verifyPortProjA") := {
 
 InputKey[Unit]("verifyPortProjB") := {
   val expected = Def.spaceDelimited().parsed.head.toInt
-  val actual = (lagomServicePort in b).value
+  val actual = (lagomServiceHttpPort in b).value
   if (expected == actual) {
     println(s"Expected and got $expected port")
   } else {

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
@@ -11,7 +11,7 @@ lazy val `a-api` = (project in file("a") / "api")
 
 lazy val `a-impl` = (project in file("a") / "impl").enablePlugins(LagomJava)
   .settings(
-    lagomServicePort := 10000
+    lagomServiceHttpPort := 10000
   )
   .dependsOn(`a-api`)
 
@@ -22,7 +22,7 @@ lazy val `b-api` = (project in file("b") / "api")
 
 lazy val `b-impl` = (project in file("b") / "impl").enablePlugins(LagomJava)
   .settings(
-    lagomServicePort := 10001
+    lagomServiceHttpPort := 10001
   )
   .dependsOn(`b-api`, `a-api`)
 
@@ -34,7 +34,7 @@ lazy val c = (project in file("c"))
 
 lazy val p = (project in file("p")).enablePlugins(PlayJava && LagomPlay)
   .settings(
-    lagomServicePort := 9001,
+    lagomServiceHttpPort := 9001,
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(lagomJavadslClient, lagomJavadslApi)
   )

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
@@ -13,7 +13,7 @@ lazy val `a-api` = (project in file("a") / "api")
 
 lazy val `a-impl` = (project in file("a") / "impl").enablePlugins(LagomScala)
   .settings(
-    lagomServicePort := 10000,
+    lagomServiceHttpPort := 10000,
     libraryDependencies += macwire
   )
   .dependsOn(`a-api`)
@@ -25,7 +25,7 @@ lazy val `b-api` = (project in file("b") / "api")
 
 lazy val `b-impl` = (project in file("b") / "impl").enablePlugins(LagomScala)
   .settings(
-    lagomServicePort := 10001,
+    lagomServiceHttpPort := 10001,
     libraryDependencies += macwire
   )
   .dependsOn(`b-api`, `a-api`)
@@ -39,7 +39,7 @@ lazy val c = (project in file("c"))
 
 lazy val p = (project in file("p")).enablePlugins(PlayScala && LagomPlay)
   .settings(
-    lagomServicePort := 9001,
+    lagomServiceHttpPort := 9001,
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(
       macwire

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
@@ -6,7 +6,7 @@ scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.6")
 
 lazy val p = (project in file("p")).enablePlugins(PlayJava && LagomPlay)
   .settings(
-    lagomServicePort := 9001,
+    lagomServiceHttpPort := 9001,
     routesGenerator := InjectedRoutesGenerator,
     libraryDependencies ++= Seq(lagomJavadslClient, lagomJavadslApi)
   )

--- a/docs/manual/java/guide/build/MultipleBuilds.md
+++ b/docs/manual/java/guide/build/MultipleBuilds.md
@@ -66,7 +66,8 @@ The `lagom-maven-plugin` offers a configuration item called `externalProjects` t
 Now when you run `lagom:runAll`, the `hello-impl` service will also be started.  There are a few additional configuration items that `externalProject` supports:
 
 * `playService` - Indicates that this is a Play, rather than a Lagom service. Defaults to `false`.
-* `servicePort` - Allows the port that the service is run on to be overridden. Defaults to automatic selection of a port by Lagom.
+* `serviceHttpPort` - Allows the http port that the service is run on to be overridden. Defaults to automatic selection of a port by Lagom.
+* `serviceHttpsPort` - Allows the https port that the service is run on to be overridden. Defaults to automatic selection of a port by Lagom.
 * `cassandraEnabled` - Configures whether this service needs Cassandra or not. Defaults to `true`.
 
 ### Using sbt

--- a/docs/manual/java/guide/devmode/ConfiguringServicesInDevelopment.md
+++ b/docs/manual/java/guide/devmode/ConfiguringServicesInDevelopment.md
@@ -1,6 +1,6 @@
 # How are addresses bound by services?
 
-By default, Lagom services bind to `localhost`. 
+By default, Lagom services bind to `localhost`.
 
 In Maven, this can be done by modifying the service implementation's pom configuration:
 
@@ -37,7 +37,7 @@ In Maven, you can do this by modifying the service implementation's pom configur
     <groupId>com.lightbend.lagom</groupId>
     <artifactId>lagom-maven-plugin</artifactId>
     <configuration>
-        <servicePort>11000</servicePort>
+        <serviceHttpPort>11000</serviceHttpPort>
     </configuration>
 </plugin>
 ```

--- a/docs/manual/java/guide/devmode/code/configuring-devmode-services.sbt
+++ b/docs/manual/java/guide/devmode/code/configuring-devmode-services.sbt
@@ -9,7 +9,7 @@ lagomServicesPortRange in ThisBuild := PortRange(40000, 45000)
 //#service-port
 lazy val usersImpl = (project in file("usersImpl"))
   .enablePlugins(LagomJava)
-  .settings(lagomServicePort := 11000)
+  .settings(lagomServiceHttpPort := 11000)
 //#service-port
 
 //#service-address

--- a/docs/manual/scala/guide/devmode/code/configuring-devmode-services.sbt
+++ b/docs/manual/scala/guide/devmode/code/configuring-devmode-services.sbt
@@ -5,7 +5,7 @@ lagomServicesPortRange in ThisBuild := PortRange(40000, 45000)
 //#service-port
 lazy val usersImpl = (project in file("usersImpl"))
   .enablePlugins(LagomScala)
-  .settings(lagomServicePort := 11000)
+  .settings(lagomServiceHttpPort := 11000)
 //#service-port
 
 //#service-address


### PR DESCRIPTION
This PR adds serviceHttpsPort to mvn plugin and deprecates servicePort in mvn and sbt.

Fixes #1539 
Fixes #1508 