### PR TITLE
[WIP] Documentation updates for 1.5.0

### DIFF
--- a/docs/manual/java/guide/build/MultipleBuilds.md
+++ b/docs/manual/java/guide/build/MultipleBuilds.md
@@ -66,7 +66,7 @@ The `lagom-maven-plugin` offers a configuration item called `externalProjects` t
 Now when you run `lagom:runAll`, the `hello-impl` service will also be started.  There are a few additional configuration items that `externalProject` supports:
 
 * `playService` - Indicates that this is a Play, rather than a Lagom service. Defaults to `false`.
-* `servicePort` - Allows the port that the service is run on to be overridden. Defaults to automatic selection of a port by Lagom.
+* `serviceHttpPort` - Allows the port that the service is run on to be overridden. Defaults to automatic selection of a port by Lagom.
 * `cassandraEnabled` - Configures whether this service needs Cassandra or not. Defaults to `true`.
 
 ### Using sbt

--- a/docs/manual/java/guide/devmode/ConfiguringServicesInDevelopment.md
+++ b/docs/manual/java/guide/devmode/ConfiguringServicesInDevelopment.md
@@ -1,6 +1,6 @@
 # How are addresses bound by services?
 
-By default, Lagom services bind to `localhost`. 
+By default, Lagom services bind to `localhost`.
 
 In Maven, this can be done by modifying the service implementation's pom configuration:
 
@@ -37,7 +37,7 @@ In Maven, you can do this by modifying the service implementation's pom configur
     <groupId>com.lightbend.lagom</groupId>
     <artifactId>lagom-maven-plugin</artifactId>
     <configuration>
-        <servicePort>11000</servicePort>
+        <serviceHttpPort>11000</serviceHttpPort>
     </configuration>
 </plugin>
 ```

--- a/docs/manual/java/guide/devmode/code/configuring-devmode-services.sbt
+++ b/docs/manual/java/guide/devmode/code/configuring-devmode-services.sbt
@@ -9,7 +9,7 @@ lagomServicesPortRange in ThisBuild := PortRange(40000, 45000)
 //#service-port
 lazy val usersImpl = (project in file("usersImpl"))
   .enablePlugins(LagomJava)
-  .settings(lagomServicePort := 11000)
+  .settings(lagomServiceHttpPort := 11000)
 //#service-port
 
 //#service-address

--- a/docs/manual/scala/guide/devmode/code/configuring-devmode-services.sbt
+++ b/docs/manual/scala/guide/devmode/code/configuring-devmode-services.sbt
@@ -5,7 +5,7 @@ lagomServicesPortRange in ThisBuild := PortRange(40000, 45000)
 //#service-port
 lazy val usersImpl = (project in file("usersImpl"))
   .enablePlugins(LagomScala)
-  .settings(lagomServicePort := 11000)
+  .settings(lagomServiceHttpPort := 11000)
 //#service-port
 
 //#service-address


### PR DESCRIPTION
This is WIP and can only be merged when we are about to release 1.5.0. 

This PR should only include documentation updates that are relevant for Lagom 1.5.0. For example, SSL support, new mvn and sbt settings (`serviceHttpPort`, serviceHttpsPort`), gRPC integration, etc.

Migration documentation for 1.5.0, on the other hand, can be updated before each milestone release.