### PR TITLE
Simplify ServiceCall#invoke, without using asInstanceOf

### DIFF
--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/ServiceCall.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/ServiceCall.scala
@@ -34,8 +34,7 @@ trait ServiceCall[Request, Response] {
    *
    * @return A future of the response entity.
    */
-  def invoke()(implicit evidence: Request =:= NotUsed): Future[Response] =
-    this.asInstanceOf[ServiceCall[NotUsed, Response]].invoke(NotUsed)
+  def invoke()(implicit evidence: NotUsed =:= Request): Future[Response] = invoke(NotUsed)
 
   /**
    * Make any modifications necessary to the request header.


### PR DESCRIPTION
By flipping the definition of the implicit evidence, invoke can simply be called with NotUsed.

 # Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?