### PR TITLE
Setup truststore via ssl-config for all clients to pick up

### DIFF
--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -62,8 +62,13 @@ object LagomReloadableDevServerStart {
               // but both settings are set in case some code specifically read one config setting or the other.
               "play.server.https.address" -> httpAddress, // there's no httpsAddress
               "play.server.https.port" -> httpsPort.toString,
+              // These configure the server
               "play.server.https.keyStore.path" -> keystoreFilePath.getAbsolutePath,
-              "play.server.https.keyStore.type" -> "JKS"
+              "play.server.https.keyStore.type" -> "JKS",
+              // These configure the clients (play-ws and akka-grpc)
+              "ssl-config.loose.disableHostnameVerification" -> "true",
+              "ssl-config.trustManager.stores.0.type" -> "JKS",
+              "ssl-config.trustManager.stores.0.path" -> keystoreFilePath.getAbsolutePath
             )
           } else Map.empty
 
@@ -74,10 +79,6 @@ object LagomReloadableDevServerStart {
             "play.server.http.address" -> httpAddress,
             "play.server.http.port" -> httpPort.toString
           )
-
-        val httpsClientSettings: Map[String, String] = Map(
-          "ssl-config.loose.disableHostnameVerification" -> "true"
-        )
 
         // each user service needs to tune its "play.filters.hosts.allowed" so that Play's
         // AllowedHostFilter (https://www.playframework.com/documentation/2.6.x/AllowedHostsFilter)
@@ -96,8 +97,7 @@ object LagomReloadableDevServerStart {
           ServerConfig.rootDirConfig(path) ++
             buildLink.settings.asScala.toMap ++
             httpSettings ++
-            httpsSettings ++
-            httpsClientSettings +
+            httpsSettings +
             allowHostsSetting +
             clusterSettings
         //            ("play.server.akka.http2.enabled" -> "true") +


### PR DESCRIPTION
When ssl is enabled this will configure the default truststore for play WS and akka grpc clients.