### PR TITLE
Adds SSL support for lagom's testkit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -596,6 +596,7 @@ lazy val `testkit-javadsl` = (project in file("testkit/javadsl"))
     `server-javadsl`,
     `pubsub-javadsl`,
     `broker-javadsl`,
+    `dev-mode-ssl-support`, // TODO: remove this when SSLContext provider is promoted to play or ssl-config
     `persistence-core` % "compile;test->test",
     `persistence-cassandra-javadsl` % "test->test",
     `jackson` % "test->test",

--- a/build.sbt
+++ b/build.sbt
@@ -614,6 +614,7 @@ lazy val `testkit-scaladsl` = (project in file("testkit/scaladsl"))
     `testkit-core`,
     `server-scaladsl`,
     `broker-scaladsl`,
+    `dev-mode-ssl-support`, // TODO: remove this when SSLContext provider is promoted to play or ssl-config
     `persistence-core` % "compile;test->test",
     `persistence-scaladsl` % "compile;test->test",
     `persistence-cassandra-scaladsl` % "compile;test->test",

--- a/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
+++ b/dev/reloadable-server/src/main/scala/play/core/server/LagomReloadableDevServerStart.scala
@@ -9,6 +9,7 @@ import java.net.InetAddress
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import com.lightbend.lagom.devmode.ssl.LagomDevModeSSLEngineProvider
 import play.api.ApplicationLoader.DevContext
 import play.api._
 import play.core.server.ssl.FakeKeyStore
@@ -62,6 +63,7 @@ object LagomReloadableDevServerStart {
               // but both settings are set in case some code specifically read one config setting or the other.
               "play.server.https.address" -> httpAddress, // there's no httpsAddress
               "play.server.https.port" -> httpsPort.toString,
+              // See also com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
               // These configure the server
               "play.server.https.keyStore.path" -> keystoreFilePath.getAbsolutePath,
               "play.server.https.keyStore.type" -> "JKS",

--- a/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/TestkitSslSetup.scala
+++ b/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/TestkitSslSetup.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.testkit
+
+import java.io.File
+
+import javax.net.ssl.SSLContext
+
+private[lagom] object TestkitSslSetup {
+
+  sealed trait TestkitSslSetup {
+    def sslPort: Option[Int]
+    def sslSettings: Map[String, AnyRef]
+    def sslContext: Option[SSLContext]
+  }
+  case object Disabled extends TestkitSslSetup {
+    val sslPort: Option[Int] = None
+    val sslSettings: Map[String, AnyRef] = Map.empty[String, AnyRef]
+    val sslContext: Option[SSLContext] = None
+  }
+  case class Enabled(
+    sslPort:     Option[Int]         = Some(0),
+    sslSettings: Map[String, AnyRef],
+    sslContext:  Option[SSLContext]
+  ) extends TestkitSslSetup
+
+  val disabled: TestkitSslSetup = Disabled
+
+  def enabled(keystoreFilePath: File, sslContext: SSLContext): TestkitSslSetup = {
+    val sslSettings: Map[String, AnyRef] = Map(
+      // See also play/core/server/LagomReloadableDevServerStart.scala
+      // These configure the server
+      "play.server.https.keyStore.path" -> keystoreFilePath.getAbsolutePath,
+      "play.server.https.keyStore.type" -> "JKS",
+      // These configure the clients (play-ws and akka-grpc)
+      "ssl-config.loose.disableHostnameVerification" -> "true",
+      "ssl-config.trustManager.stores.0.type" -> "JKS",
+      "ssl-config.trustManager.stores.0.path" -> keystoreFilePath.getAbsolutePath
+    )
+    Enabled(Some(0), sslSettings, Some(sslContext))
+  }
+}

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -147,22 +147,21 @@ object ServiceTest {
     def withCluster(): Setup = withCluster(true)
 
     /**
-      * Enable or disable the SSL port.
-      *
-      * @param enabled True if the server should bind an HTTP+TLS port, or false if only HTTP should be bound.
-      * @return A copy of this setup.
-      */
+     * Enable or disable the SSL port.
+     *
+     * @param enabled True if the server should bind an HTTP+TLS port, or false if only HTTP should be bound.
+     * @return A copy of this setup.
+     */
     @ApiMayChange
     def withSsl(enabled: Boolean): Setup
 
     /**
-      * Enable the SSL port.
-      *
-      * @return A copy of this setup.
-      */
+     * Enable the SSL port.
+     *
+     * @return A copy of this setup.
+     */
     @ApiMayChange
     def withSsl(): Setup = withSsl(true)
-
 
     /**
      * Whether Cassandra is enabled.
@@ -252,11 +251,11 @@ object ServiceTest {
    * Guice bindings here.
    */
   class TestServer(
-                    val port: Int,
-                    val app: Application,
-                    server: Server,
-                    @ApiMayChange val sslContext: Optional[SSLContext] = Optional.empty(),
-                  ) {
+    val port:                     Int,
+    val app:                      Application,
+    server:                       Server,
+    @ApiMayChange val sslContext: Optional[SSLContext] = Optional.empty()
+  ) {
 
     @ApiMayChange val portSsl: Optional[Integer] = Optional.ofNullable(server.httpsPort.map(Integer.valueOf).orNull)
 
@@ -381,7 +380,7 @@ object ServiceTest {
 
     Play.start(application.asScala())
 
-    val sslSetup : TestkitSslSetup.TestkitSslSetup= if (setup.ssl) {
+    val sslSetup: TestkitSslSetup.TestkitSslSetup = if (setup.ssl) {
       val keystoreBaseFolder = application.environment().rootPath
       val keystoreFilePath: File = FakeKeyStore.getKeyStoreFilePath(keystoreBaseFolder)
       // ensure it exists
@@ -390,7 +389,7 @@ object ServiceTest {
       // TODO: review this when SSLContext provider is promoted to play or ssl-config
       val sslContext: SSLContext = new LagomDevModeSSLEngineProvider(application.environment().rootPath).sslContext
       TestkitSslSetup.enabled(keystoreFilePath, sslContext)
-    } else{
+    } else {
       Disabled
     }
 

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -7,6 +7,7 @@ package com.lightbend.lagom.javadsl.testkit
 import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Optional
 import java.util.function.{ Function => JFunction }
 
 import akka.actor.ActorSystem
@@ -27,7 +28,7 @@ import com.lightbend.lagom.spi.persistence.{ InMemoryOffsetStore, OffsetStore }
 import javax.net.ssl.SSLContext
 import play.Application
 import play.api.inject.{ ApplicationLifecycle, BindingKey, DefaultApplicationLifecycle, bind => sBind }
-import play.api.{ Configuration, Mode, Play }
+import play.api.{ Configuration, Play }
 import play.core.server.ssl.FakeKeyStore
 import play.core.server.{ Server, ServerConfig, ServerProvider }
 import play.inject.Injector
@@ -36,7 +37,7 @@ import play.inject.guice.GuiceApplicationBuilder
 import scala.annotation.tailrec
 import scala.concurrent.Promise
 import scala.concurrent.duration._
-import scala.util.{ Random, Try }
+import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -254,9 +255,10 @@ object ServiceTest {
                     val port: Int,
                     val app: Application,
                     server: Server,
-                    @ApiMayChange val portSsl: Option[Int] = None,
-                    @ApiMayChange val sslContext: Option[SSLContext] = None,
+                    @ApiMayChange val sslContext: Optional[SSLContext] = Optional.empty(),
                   ) {
+
+    @ApiMayChange val portSsl: Optional[Integer] = Optional.ofNullable(server.httpsPort.map(Integer.valueOf).orNull)
 
     /**
      * Get the service client for a service.
@@ -412,7 +414,8 @@ object ServiceTest {
       awaitPersistenceInit(system)
     }
 
-    new TestServer(assignedPort, application, srv, sslSetup.sslPort, sslSetup.sslContext)
+    val javaSslContext = Optional.ofNullable(sslSetup.sslContext.orNull)
+    new TestServer(assignedPort, application, srv, javaSslContext)
   }
 
   /**

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
@@ -103,6 +103,7 @@ object ServiceTest {
      * @param enabled True if the server should bind an HTTP+TLS port, or false if only HTTP should be bound.
      * @return A copy of this setup.
      */
+    @ApiMayChange
     def withSsl(enabled: Boolean): Setup
 
     /**
@@ -110,6 +111,7 @@ object ServiceTest {
      *
      * @return A copy of this setup.
      */
+    @ApiMayChange
     def withSsl(): Setup = withSsl(true)
 
     /**

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
@@ -100,13 +100,13 @@ object ServiceTest {
     /**
      * Enable or disable the SSL port.
      *
-     * @param enabled True if thhe server should bind an HTTP+TLS port, or false if only HTTP should be bound.
+     * @param enabled True if the server should bind an HTTP+TLS port, or false if only HTTP should be bound.
      * @return A copy of this setup.
      */
     def withSsl(enabled: Boolean): Setup
 
     /**
-     * Enable or disable the SSL port.
+     * Enable the SSL port.
      *
      * @return A copy of this setup.
      */
@@ -163,12 +163,9 @@ object ServiceTest {
         copy(cluster = false, cassandra = false)
       }
     }
+
     override def withSsl(enabled: Boolean): Setup = {
-      if (enabled) {
-        copy(ssl = true)
-      } else {
-        copy(ssl = false)
-      }
+      copy(ssl = enabled)
     }
   }
 

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
@@ -180,7 +180,11 @@ object ServiceTest {
    * When the server is started you can get the service client and other
    * Guice bindings here.
    */
-  final class TestServer[A <: LagomApplication] private[testkit] (val application: A, val playServer: Server, @ApiMayChange val sslContext: Option[SSLContext] = None) {
+  final class TestServer[A <: LagomApplication] private[testkit] (
+    val application:              A,
+    val playServer:               Server,
+    @ApiMayChange val sslContext: Option[SSLContext] = None
+  ) {
 
     /**
      * Convenient access to the materializer


### PR DESCRIPTION
This is related to #1595 but not a fix.

This is a minimal change to make ssl available in lagom's `TestService` that unblocks testing gRPC. The UX for gRPC users is not great but at least this works. Needs massaging and improving.

At the moment I keps the scope scala-only as we discuss and improve the approach.