### PR TITLE
travis webhook for contributors channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ before_cache:
 notifications:
   webhooks:
     urls:
-        - https://webhooks.gitter.im/e/773aba95141768c32dae
-    on_success: always
+      - https://webhooks.gitter.im/e/2aa0aeda88d31fe293d4
+    on_success: change
     on_failure: always
+    on_start: never
+


### PR DESCRIPTION
This changes the travis webhook to send the notifications to the [gitter:lagom/contributors](https://gitter.im/lagom/contributors?utm_source=share-link&utm_medium=link&utm_campaign=share-link)