### PR TITLE
Build Lagom using a snapshot version of Akka

### DIFF
--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -9,11 +9,20 @@ set -o pipefail
 # CURRENT_BRANCH is used when updating Whitesource to determine the correct project name
 export CURRENT_BRANCH=${TRAVIS_BRANCH}
 
+EXTRA_OPTS=""
+
+# Check if it is a scheduled build
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    # `sort` is not necessary, but it is good to make it predictable.
+    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '[0-9]\.[0-9]-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    EXTRA_OPTS="-Dakka.version=${AKKA_VERSION}"
+fi
+
 runSbt() {
-  sbt --warn -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
+  sbt ${EXTRA_OPTS} --warn -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
 }
 
 runSbtNoisy() {
-  sbt -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
+  sbt ${EXTRA_OPTS} -jvm-opts .travis-jvmopts 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
 }
 

--- a/bin/test-2.11
+++ b/bin/test-2.11
@@ -2,4 +2,11 @@
 
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
+# We are not running Scala 2.11 job for scheduled builds because they use
+# Akka snapshots which aren't being published for Scala 2.11 anymore.
+if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    printMessage "SKIPPING TESTS FOR SCALA 2.11"
+    exit
+fi
+
 runSbtNoisy "+++2.11.12 test"

--- a/project/AkkaSnapshotRepositories.scala
+++ b/project/AkkaSnapshotRepositories.scala
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
+import sbt.Keys._
+import sbt._
+
+/**
+ * This plugins adds Akka snapshot repositories when running a nightly build.
+ */
+object AkkaSnapshotRepositories extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def projectSettings: Seq[Def.Setting[_]] = {
+    // If this is a cron job in Travis:
+    // https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
+    resolvers ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+      case Some(_) => Seq("akka-snapshot-repository" at "https://repo.akka.io/snapshots")
+      case None => Seq.empty
+    })
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,3 +1,6 @@
+/**
+ * Copyright (C) 2016-2018 Lightbend Inc. <https://www.lightbend.com>
+ */
 import sbt.Keys._
 import sbt._
 
@@ -15,7 +18,7 @@ object Dependencies {
     val PlayFileWatch = "1.1.7"
 
     // Also be sure to update AkkaVersion in docs/build.sbt.
-    val Akka = "2.5.16"
+    val Akka: String = sys.props.getOrElse("akka.version", "2.5.16")
     val AkkaHttp = "10.1.3"
     val AkkaManagement = "0.17.0"
     // Also be sure to update ScalaVersion in docs/build.sbt.


### PR DESCRIPTION
## Purpose

This is intended to be used in a CRON job running daily. A follow up here is to do the same for Play.

## References

https://github.com/playframework/playframework/pull/8601
