### PR TITLE
Support trustStore password

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -577,6 +577,7 @@ lazy val `testkit-core` = (project in file("testkit/core"))
   )
   .settings(forkedTests: _*)
   .dependsOn(
+    `dev-mode-ssl-support`, // TODO: remove this when SSLContext provider is promoted to play or ssl-config
     // Ideally, this would be the other way around,
     // but it will require some more refactoring
     `persistence-testkit`

--- a/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/TestkitSslSetup.scala
+++ b/testkit/core/src/main/scala/com/lightbend/lagom/internal/testkit/TestkitSslSetup.scala
@@ -4,9 +4,8 @@
 
 package com.lightbend.lagom.internal.testkit
 
-import java.io.File
-
 import javax.net.ssl.SSLContext
+import com.lightbend.lagom.devmode.ssl.KeyStoreMetadata
 
 private[lagom] object TestkitSslSetup {
 
@@ -39,16 +38,22 @@ private[lagom] object TestkitSslSetup {
    * @param clientSslContext   SSLContext to create SSL clients
    * @return
    */
-  def enabled(serverKeyStoreFile: File, trustStoreFile: File, clientSslContext: SSLContext): TestkitSslSetup = {
+  def enabled(
+    keyStoreMetadata:   KeyStoreMetadata,
+    trustStoreMetadata: KeyStoreMetadata,
+    clientSslContext:   SSLContext
+  ): TestkitSslSetup = {
     val sslSettings: Map[String, AnyRef] = Map(
       // See also play/core/server/LagomReloadableDevServerStart.scala
       // These configure the server
-      "play.server.https.keyStore.path" -> serverKeyStoreFile.getAbsolutePath,
-      "play.server.https.keyStore.type" -> "JKS",
+      "play.server.https.keyStore.path" -> keyStoreMetadata.storeFile.getAbsolutePath,
+      "play.server.https.keyStore.type" -> keyStoreMetadata.storeType,
+      "play.server.https.keyStore.password" -> String.valueOf(keyStoreMetadata.storePassword),
       // These configure the clients (play-ws and akka-grpc)
       "ssl-config.loose.disableHostnameVerification" -> "true",
-      "ssl-config.trustManager.stores.0.type" -> "JKS",
-      "ssl-config.trustManager.stores.0.path" -> trustStoreFile.getAbsolutePath
+      "ssl-config.trustManager.stores.0.path" -> trustStoreMetadata.storeFile.getAbsolutePath,
+      "ssl-config.trustManager.stores.0.type" -> trustStoreMetadata.storeType,
+      "ssl-config.trustManager.stores.0.password" -> String.valueOf(trustStoreMetadata.storePassword)
     )
     Enabled(Some(0), sslSettings, Some(clientSslContext))
   }

--- a/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
+++ b/testkit/javadsl/src/main/scala/com/lightbend/lagom/javadsl/testkit/ServiceTest.scala
@@ -381,11 +381,10 @@ object ServiceTest {
 
     val sslSetup: TestkitSslSetup.TestkitSslSetup = if (setup.ssl) {
       val sslHolder = new LagomDevModeSSLHolder(application.environment().asScala())
-      val keystoreFile: File = sslHolder.keyStoreFile
       val clientSslContext: SSLContext = sslHolder.sslContext
       // In tests we're using a self-signed certificate so we use the same keyStore for both
       // the server and the client trustStore.
-      TestkitSslSetup.enabled(keystoreFile, keystoreFile, clientSslContext)
+      TestkitSslSetup.enabled(sslHolder.keyStoreMetadata, sslHolder.trustStoreMetadata, clientSslContext)
     } else {
       Disabled
     }

--- a/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
+++ b/testkit/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/testkit/ServiceTest.scala
@@ -304,11 +304,10 @@ object ServiceTest {
 
     val sslSetup: TestkitSslSetup.TestkitSslSetup = if (setup.ssl) {
       val sslHolder = new LagomDevModeSSLHolder(environment)
-      val keystoreFile: File = sslHolder.keyStoreFile
       val clientSslContext: SSLContext = sslHolder.sslContext
       // In tests we're using a self-signed certificate so we use the same keyStore for both
       // the server and the client trustStore.
-      TestkitSslSetup.enabled(keystoreFile, keystoreFile, clientSslContext)
+      TestkitSslSetup.enabled(sslHolder.keyStoreMetadata, sslHolder.trustStoreMetadata, clientSslContext)
     } else {
       Disabled
     }


### PR DESCRIPTION
Also clean up code so SSLHolder encapsulates thhe reuse of an underlying FakeKeyStore. With this code cleanup 
it is getting easier to read the keyStore and the trustStore from separate locations. There's still work to be done though.

Related to https://github.com/lightbend/ssl-config/pull/129 and https://github.com/lightbend/ssl-config/pull/92