### PR TITLE
Bumps ssl-config to 0.3.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,7 +75,7 @@ object Dependencies {
   private val javassist = "org.javassist" % "javassist" % "3.21.0-GA"
   private val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
   private val typesafeConfig = "com.typesafe" % "config" % "1.3.3"
-  private val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.5"
+  private val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.6"
   private val h2 = "com.h2database" % "h2" % "1.4.192"
   private val cassandraDriverCore = "com.datastax.cassandra" % "cassandra-driver-core" % "3.6.0" excludeAll (excludeSlf4j: _*)
 


### PR DESCRIPTION
0.3.5 defaulted to PKCS12 format for the auto-generated key stores. The ssl-config library doesn't support setting the trustStore password which is required in PKCS12 format to read the trusted certificates. As a consequence generated stores could not be used as truststores.

Related to https://github.com/playframework/playframework/pull/8691