### PR TITLE
Upgrade cachecontrol dependency to 1.1.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
     // Also be sure to update PlayVersion in docs/build.sbt.
     val Play = "2.7.0-M4"
     val PlayJson = "2.6.10"
-    val PlayStandaloneWs = "2.0.0-M6"
+    val PlayStandaloneWs = "2.0.0-RC1"
     val Twirl = "1.4.0-M2"
     val PlayFileWatch = "1.1.7"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -182,7 +182,7 @@ object Dependencies {
       akkaPersistenceCassandraLauncher,
       "com.typesafe.netty" % "netty-reactive-streams" % Versions.NettyReactiveStreams,
       "com.typesafe.netty" % "netty-reactive-streams-http" % Versions.NettyReactiveStreams,
-      "com.typesafe.play" %% "cachecontrol" % "1.1.3",
+      "com.typesafe.play" %% "cachecontrol" % "1.1.4",
       playJson,
       playFunctional,
       // play client libs


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Related
https://github.com/playframework/play-ws/issues/265

## Purpose

Upgrading the cachecontrol dependency, pulling in playframework/cachecontrol#30 to not cache POST responses by default
