### PR TITLE
Fix documentation and maven config to be aligned to false as default behaviour

### DIFF
--- a/dev/maven-plugin/src/main/maven/plugin.xml
+++ b/dev/maven-plugin/src/main/maven/plugin.xml
@@ -118,7 +118,7 @@
             <editable>true</editable>
             <description>Whether the Cassandra database should be cleaned when it starts.</description>
             <configuration>
-                <cassandraCleanOnStart implementation="boolean" default-value="true">${cassandra.cleanOnStart}</cassandraCleanOnStart>
+                <cassandraCleanOnStart implementation="boolean" default-value="false">${cassandra.cleanOnStart}</cassandraCleanOnStart>
             </configuration>
         </parameter>
         <parameter>

--- a/docs/manual/common/guide/devmode/CassandraServer.md
+++ b/docs/manual/common/guide/devmode/CassandraServer.md
@@ -25,7 +25,7 @@ In sbt:
 
 ## Clean up on start
 
-By default, all database files created by your running services are going to be deleted the next time the Cassandra server is started. You can turn off this feature by adding the following in your build.
+By default, all database files created by your running services are saved for the next time the Cassandra server is started. You can change the behaviour by adding the following in your build.
 
 In the Maven root project pom:
 
@@ -35,7 +35,7 @@ In the Maven root project pom:
     <artifactId>lagom-maven-plugin</artifactId>
     <version>${lagom.version}</version>
     <configuration>
-        <cassandraCleanOnStart>false</cassandraCleanOnStart>
+        <cassandraCleanOnStart>true</cassandraCleanOnStart>
     </configuration>
 </plugin>
 ```

--- a/docs/manual/common/guide/devmode/code/build-cassandra-opts.sbt
+++ b/docs/manual/common/guide/devmode/code/build-cassandra-opts.sbt
@@ -4,7 +4,7 @@ lagomCassandraPort in ThisBuild := 9042
 //#cassandra-port
 
 //#cassandra-clean-on-start
-lagomCassandraCleanOnStart in ThisBuild := false
+lagomCassandraCleanOnStart in ThisBuild := true
 //#cassandra-clean-on-start
 
 //#cassandra-jvm-options


### PR DESCRIPTION
## Fixes

Fixes #1622

## Purpose

The default behaviour of deleting cassandra data on startup on dev mode should be aligned to false