### PR TITLE
Reorder travis jobs in stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,29 @@ env:
   global:
     # the following `secure` is WHITESOURCE_PASSWORD which is the same for all branches.
     - secure: "A4xDS51pB8ERJPR/a5Lui//E//1L9pJ9Eg1kcRm/OR2izg7rx7p8Wemfp9gRhz8trn1mIrXDSMSK9iwENsfIP1bc/6AgtTWKBPm9DKjG0HW3swFFMBzzd6gxmOi4JD8rOtVc62Cf4qnURz+hsPRcI5C8aAW1fNi/5x1Q3HcAMtxE8EdPR7tU6Ve8utieOFPpqNQMktcL1aFusu+QddO14ZpQ944uAg0YdRRYFMG9SCbTkNDLt66AHTF4rKyZfkbM1tadqvvDez7Uo2eGK+KoQxTyrjct8W4Gqh+obOTyj1ngaPZEKvgbIJowFCrBzY5W+oNl6S+qa6PyAwq1MWKFqyUZt4P9fk3N9MDOYvuaS+YJCQd3VS4qCL9MEWahXNc3ZT+m8u5HT5axuPy+2qiKL/wrGzAXd74K9gNKuZJD7s+79Pwn34ZEbNMZ13AxyF6QkavU+Xcr5tQNwwZ+8P+k5OGoVsJOqZ3J7M+igGDRZh0fD693Wdp+mfORQqIvJFKED4daJYgTLufwt4tBLUxPUvlUZOWZFPn8DSQqTE7vsE9VPdpKSXTv1MyHxeMTiAX+XPabEWoazB8/4rljkC/EPxAButPD+AtUatfa6fIXpyGxHIvX8CFa2UnOQe9YbTRnxqa8TYvyMsWNQn1Q1eQMkvXCetqoefW5hA0UHTU5Zy4="
-  matrix:
-    - SCRIPT=test-2.11
-    - SCRIPT=test-2.12
-    - SCRIPT=test-sbt-0.13
-    - SCRIPT=test-sbt-1.0
-    - SCRIPT=test-maven
-    - SCRIPT=test-documentation
-    - SCRIPT=test-code-style
-# important to use eval, otherwise "&&" is passed as an argument to sbt rather than being processed by bash
-script: bin/$SCRIPT
+stages:
+  - validations
+  - test
+  - test-build-tools
+jobs:
+  include:
+    - stage: validations
+      script: bin/test-code-style
+      name: "Code validations (format, binary compatibilty, whitesource, etc.)"
+    - stage: test
+      script: bin/test-2.11
+      name: "Run tests for Scala 2.11"
+    - script: bin/test-2.12
+      name: "Run tests for Scala 2.12"
+    - script: bin/test-documentation
+      name: "Documentation validations and tests"
+    - stage: test-build-tools
+      script: bin/test-sbt-0.13
+      name: "Scripted tests for sbt 0.13"
+    - script: bin/test-sbt-1.0
+      name: "Scripted tests for sbt 0.13"
+    - script: bin/test-maven
+      name: "PublishM2 and test Maven"
 before_install:
     # See https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-239493916
     - rm ~/.m2/settings.xml


### PR DESCRIPTION
Uses Play's approach: group travis jobs into stages with fast stages first. This grouping is by kind of script (same approach than in Play)

I'd like to reconsider into a different approach: run first the jobs for preferred versions (e.g. `test-2.12` + `test-sbt-1.0` + `test-code-style`).