### PR TITLE
Update reference.conf

### DIFF
--- a/persistence-jdbc/core/src/main/resources/reference.conf
+++ b/persistence-jdbc/core/src/main/resources/reference.conf
@@ -4,9 +4,6 @@ jdbc-defaults.slick {
 
   # The driver to use
   driver = "slick.driver.H2Driver$"
-
-  # The JNDI name
-  jndiName = "DefaultDS"
 }
 
 # Configure the default database to be bound to JNDI


### PR DESCRIPTION
  The JNDI name in `jdbc-defaults.slick` seems misleading, let it be in
 `lagom.persistence.read-side.jdbc.slick.jndiName = "DefaultDS"` itself, it is correct according to `com.lightbend.lagom.internal.persistence.jdbc.SlickProvider.scala:40 in "com.lightbend.lagom" % "lagom-sbt-plugin" % "1.4.9"`

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #1672

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References
#1672 
Are there any relevant issues / PRs / mailing lists discussions?
