### PR TITLE
removed metaspace limit

### DIFF
--- a/.travis-jvmopts
+++ b/.travis-jvmopts
@@ -3,4 +3,3 @@
 -Xms2G
 -Xmx2G
 -Xss2M
--XX:MaxMetaspaceSize=1G


### PR DESCRIPTION
We have observed Travis failures because: `java.lang.OutOfMemoryError: Metaspace`. 

Instead of increasing the metaspace, I would like to first remove it to see how the build will behave. 

On the first commit of this file, we were using `MaxPermSize`, but `MaxMetaspaceSize` is not equivalent. As far as I know, if we set `MaxMetaspaceSize` we put an upper bound and we avoid swap. However, we never experimented to build without that limit as we simply switched from `MaxPermSize` to `MaxMetaspaceSize`.

Refs: #1671 
(cc @2m) 