### PR TITLE
Sets version to 1.5.0-SNAPSHOT on branch 1.5.x

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.0-RC1"
+version in ThisBuild := "1.5.0-SNAPSHOT"


### PR DESCRIPTION
When the `1.5.x` branch was created we picked the wrong commit. Instead of 454ecfcea53fdf63e203b412c1354b4d9a2144f6 we should have picked ad4439965cd3d7a432043eae9bf1acc144ae59dc