### PR TITLE
Fix version on branch and reset akka

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,6 +1,6 @@
 val ScalaVersion = "2.12.7"
 
-val AkkaVersion: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.19")
+val AkkaVersion: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.18")
 val JUnitVersion = "4.12"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion = "3.0.5"

--- a/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerService2Impl.java
+++ b/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerService2Impl.java
@@ -1,6 +1,6 @@
 package docs.home.actor;
 
-import static akka.pattern.Patterns.ask;
+import static akka.pattern.PatternsCS.ask;
 
 import com.lightbend.lagom.javadsl.api.ServiceCall;
 import com.lightbend.lagom.javadsl.pubsub.PubSubRef;

--- a/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerServiceImpl.java
+++ b/docs/manual/java/guide/advanced/code/docs/home/actor/WorkerServiceImpl.java
@@ -1,7 +1,7 @@
 package docs.home.actor;
 
 //#service-impl
-import static akka.pattern.Patterns.ask;
+import static akka.pattern.PatternsCS.ask;
 
 import com.lightbend.lagom.javadsl.api.ServiceCall;
 

--- a/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
+++ b/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
@@ -18,7 +18,6 @@ import com.lightbend.lagom.javadsl.persistence.TestEntity.Cmd;
 import com.lightbend.lagom.javadsl.persistence.TestEntity.Evt;
 import com.lightbend.lagom.javadsl.persistence.TestEntity.State;
 import java.io.File;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -111,7 +110,8 @@ public class PersistentEntityRefTest {
 
   @Test(expected = AskTimeoutException.class)
   public void testAskTimeout() throws Throwable {
-    PersistentEntityRef<Cmd> ref = registry().refFor(TestEntity.class, "10").withAskTimeout(Duration.ofMillis(1));
+    PersistentEntityRef<Cmd> ref = registry().refFor(TestEntity.class, "10").withAskTimeout(
+        FiniteDuration.create(1, MILLISECONDS));
 
     List<CompletionStage<Evt>> replies = new ArrayList<>();
     for (int i = 0; i < 100; i++) {

--- a/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRef.java
+++ b/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRef.java
@@ -7,12 +7,12 @@ package com.lightbend.lagom.javadsl.persistence;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.NoSerializationVerificationNeeded;
-import akka.pattern.Patterns;
+import akka.pattern.PatternsCS;
+import akka.util.Timeout;
 import scala.concurrent.duration.FiniteDuration;
 
 import java.io.NotSerializableException;
 import java.io.ObjectStreamException;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -24,22 +24,12 @@ import java.util.concurrent.CompletionStage;
 public final class PersistentEntityRef<Command> implements NoSerializationVerificationNeeded {
   private final String entityId;
   private final ActorRef region;
-  private final Duration timeout;
+  private final Timeout timeout;
 
-    /**
-     * @deprecated As of Lagom 1.5. Use {@link #PersistentEntityRef(String, ActorRef, Duration)} instead.
-     */
-  @Deprecated
   public PersistentEntityRef(String entityId, ActorRef region, FiniteDuration askTimeout) {
     this.entityId = entityId;
     this.region = region;
-    this.timeout = Duration.ofMillis(askTimeout.toMillis());
-  }
-
-  public PersistentEntityRef(String entityId, ActorRef region, Duration askTimeout) {
-    this.entityId = entityId;
-    this.region = region;
-    this.timeout = askTimeout;
+    this.timeout = Timeout.apply(askTimeout);
   }
 
   /**
@@ -61,11 +51,11 @@ public final class PersistentEntityRef<Command> implements NoSerializationVerifi
    * <p>
    * The <code>CompletionStage</code> may also be completed with failure, sent by the <code>PersistentEntity</code>
    * or a <code>akka.pattern.AskTimeoutException</code> if there is no reply within a timeout.
-   * The timeout can defined in configuration or overridden using {@link #withAskTimeout(Duration)}.
+   * The timeout can defined in configuration or overridden using {@link #withAskTimeout(FiniteDuration)}.
    */
   @SuppressWarnings("unchecked")
   public <Reply, Cmd extends Object & PersistentEntity.ReplyType<Reply>> CompletionStage<Reply> ask(Cmd command) {
-    CompletionStage<Object> future = Patterns.ask(region, new CommandEnvelope(entityId, command), timeout);
+    CompletionStage<Object> future = PatternsCS.ask(region, new CommandEnvelope(entityId, command), timeout);
 
     return future.thenCompose(result -> {
       if (result instanceof Throwable) {
@@ -84,21 +74,8 @@ public final class PersistentEntityRef<Command> implements NoSerializationVerifi
    * but it can be adjusted for a specific <code>PersistentEntityRef</code> using this method.
    * Note that this returns a new <code>PersistentEntityRef</code> instance with the given timeout
    * (<code>PersistentEntityRef</code> is immutable).
-   *
-   * @deprecated As of Lagom 1.5. Use {@link #withAskTimeout(Duration)} instead.
    */
-  @Deprecated
   public PersistentEntityRef<Command> withAskTimeout(FiniteDuration timeout) {
-    return new PersistentEntityRef<>(entityId, region, timeout);
-  }
-
-  /**
-   * The timeout for {@link #ask(Object)}. The timeout is by default defined in configuration
-   * but it can be adjusted for a specific <code>PersistentEntityRef</code> using this method.
-   * Note that this returns a new <code>PersistentEntityRef</code> instance with the given timeout
-   * (<code>PersistentEntityRef</code> is immutable).
-   */
-  public PersistentEntityRef<Command> withAskTimeout(Duration timeout) {
     return new PersistentEntityRef<>(entityId, region, timeout);
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,11 +18,9 @@ object Dependencies {
     val PlayFileWatch = "1.1.8"
 
     // Also be sure to update AkkaVersion in docs/build.sbt.
-    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.19")
+    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.18")
     val AkkaHttp = "10.1.5"
     val AkkaManagement = "0.19.0"
-    val Aeron = "1.12.0"
-
     // Also be sure to update ScalaVersion in docs/build.sbt.
     val Scala = Seq("2.12.7", "2.11.12")
     val SbtScala = Seq("2.10.7", "2.12.7")
@@ -257,8 +255,8 @@ object Dependencies {
       "com.typesafe.slick" %% "slick-hikaricp" % Versions.Slick,
       "com.zaxxer" % "HikariCP" % "3.2.0",
       "commons-codec" % "commons-codec" % "1.10",
-      "io.aeron" % "aeron-client" % Versions.Aeron,
-      "io.aeron" % "aeron-driver" % Versions.Aeron,
+      "io.aeron" % "aeron-client" % "1.11.2",
+      "io.aeron" % "aeron-driver" % "1.11.2",
       dropwizardMetricsCore,
       "io.jsonwebtoken" % "jjwt" % "0.9.1",
       // Netty 3 uses a different package to Netty 4, and a different artifact ID, so can safely coexist
@@ -270,7 +268,7 @@ object Dependencies {
       "junit" % "junit" % Versions.JUnit,
       "net.jodah" % "typetools" % "0.5.0",
       "org.lz4" % "lz4-java" % "1.4.1",
-      "org.agrona" % "agrona" % "0.9.27",
+      "org.agrona" % "agrona" % "0.9.25",
       commonsLang,
       kafkaClients,
       "org.codehaus.mojo" % "animal-sniffer-annotations" % "1.17",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.0-RC1"
+version in ThisBuild := "1.5.0-SNAPSHOT"


### PR DESCRIPTION
related to https://github.com/lagom/lagom/issues/1693

This PR reverts the "bump Akka version to 2.5.19" commit and include the fix from https://github.com/lagom/lagom/pull/1695 introducing yet another scenario where the build breaks (at least I had it break locally).