### PR TITLE
Increase max metaspace size. Decrease max heap size (-Xmx)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1220,8 +1220,8 @@ def scriptedSettings: Seq[Setting[_]] = ScriptedPlugin.scriptedSettings ++
   Seq(
     scripted := scripted.tag(Tags.Test).evaluated,
     scriptedLaunchOpts ++= Seq(
-      "-Xmx768m",
-      "-XX:MaxMetaspaceSize=384m",
+      "-Xmx512m",
+      "-XX:MaxMetaspaceSize=512m",
       "-Dscala.version=" + sys.props.get("scripted.scala.version").getOrElse((scalaVersion in `reloadable-server`).value)
     )
   )


### PR DESCRIPTION
Fixes #1693 (supersedes #1684)


Tunes `scripted` test JVMs: Increases the maximum size for `Metaspace` and reduces the maximum heap size. This is a workaround solution to avoid the head-of-line block on the build pipeline (see #1693 for more details)


The actual issue is a classloader leak in Lagom Dev Mode. Solving that is out of scope at this moment. This solution kicks the can down the road...