### PR TITLE
Use Alpakka Kafka Committer with Lagom's settings

### DIFF
--- a/service/core/kafka/client/src/main/resources/reference.conf
+++ b/service/core/kafka/client/src/main/resources/reference.conf
@@ -60,6 +60,10 @@ lagom.broker.kafka {
       # within a fixed amount of time.
       # The value provided must be strictly greater than zero.
       batching-interval = 5 seconds
+
+      # Parallelsim for async committing to Kafka
+      # The value provided must be strictly greater than zero.
+      batching-parallelism = 3
     }
   }
 }

--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
@@ -41,7 +41,7 @@ private[lagom] class JavadslKafkaSubscriber[Payload, SubscriberPayload](kafkaCon
 
   private lazy val consumerId = KafkaClientIdSequenceNumber.getAndIncrement
 
-  private def consumerConfig = ConsumerConfig(system.settings.config)
+  private def consumerConfig = ConsumerConfig(system)
 
   @throws(classOf[IllegalArgumentException])
   override def withGroupId(groupIdName: String): Subscriber[SubscriberPayload] = {

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaSubscriber.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaSubscriber.scala
@@ -37,7 +37,7 @@ private[lagom] class ScaladslKafkaSubscriber[Payload, SubscriberPayload](kafkaCo
 
   private lazy val consumerId = KafkaClientIdSequenceNumber.getAndIncrement
 
-  private def consumerConfig = ConsumerConfig(system.settings.config)
+  private def consumerConfig = ConsumerConfig(system)
 
   @throws(classOf[IllegalArgumentException])
   override def withGroupId(groupIdName: String): Subscriber[SubscriberPayload] = {


### PR DESCRIPTION
Alpakka Kafka's Committer flow is the recommended way to issue commits to Kafka. 
All current settings are overwritten by the values from Lagom's configuration in `lagom.broker.kafka.client.consumer`. To keep it forward compatible `CommitterSettings` is read from the Actor System's config.

Just as before this supports only one configuration of the Kafka client within Lagom.

Fixes #1650