### PR TITLE
Created x-refs to the lagom-recipes repo.

### DIFF
--- a/docs/manual/common/gettingstarted/LagomExamples.md
+++ b/docs/manual/common/gettingstarted/LagomExamples.md
@@ -1,11 +1,11 @@
 # Learning more from Lagom examples
 
-After getting started with Hello World, you can learn more about Lagom by downloading and running one of the examples from GitHub:
+After getting started with Hello World, you can learn more about Lagom by downloading and running one of the following examples from GitHub:
 
 * [Chirper](https://github.com/search?utf8=%E2%9C%93&q=Lagom+chirper) demonstrates a Twitter-like application and is available for Java and Scala, with Java variations that demonstrate use of JPA and JDBC.
 * [Online Auction](https://github.com/search?utf8=%E2%9C%93&q=lagom%2Fonline+auction&type=Repositories&ref=searchresults) demonstrates an eBay-like application and is also available for both Java and Scala.
 
-The following table outlines some of the Lagom features you can observe in each of the examples.
+Some of the Lagom features you can observe in these examples include:
 
 Feature |Chirper| Online Auction |
 --------|:--------:|:-------------:|
@@ -15,6 +15,20 @@ How to communicate between services| Y | Y
 How streaming service calls work | Y | N
 How to develop a Play app with Lagom | Y | Y
 How to consume Lagom services from a front-end Play app | N | Y
+
+For focused examples, check the [lagom-recipes](https://github.com/lagom/lagom-recipes) repository on GitHub. Each recipe describes how to achieve a particular goal, such as:
+
+* How do I enable CORS? (using Lagom's javadsl or scaladsl)
+* How do I create a Subscriber only service? (also referred to as consumer service)
+* How do I use RDBMS read-sides with Cassandra write-sides? (mixed persistence in java or mixed persistence in scala)
+* How to create a stateless service in Lagom for Java that uses Play's Internationalization Support.
+* How do I manipulate Headers and Status Codes and test those cases?(HTTP header handling)
+* How do I handle multipart/form-data file uploads? (Scala example, Java example)
+* How do I use a custom message serializer and response header to implement file downloads? (Scala example)
+* How do I integrate Lightbend Telemetry (Cinnamon)? (Java/Maven example)
+* How do I configure the Circuit Breaker Panel for a Lagom Java application? (Java/Maven example)
+* How do I deploy a Lagom Maven application in Kubernetes? (Java/Maven example)
+* How do I use Lagom with Couchbase both write-side and read-side? Java Maven and Scala Sbt) (Couchbase Persistence is NOT production ready yet)
 
 
 

--- a/docs/manual/common/guide/production/EnterpriseSuite.md
+++ b/docs/manual/common/guide/production/EnterpriseSuite.md
@@ -31,6 +31,8 @@ To use these with Lagom, the Cinnamon Telemetry agent must be included as a depe
 * [Java example project](https://developer.lightbend.com/docs/cinnamon/current/getting-started/lagom_java.html)
 * [Scala example project](https://developer.lightbend.com/docs/cinnamon/current/getting-started/lagom_scala.html)
 
+See [Integrating Lagom with Lightbend Telemetry](https://github.com/lagom/lagom-recipes/blob/master/lightbend-telemetry/lightbend-telemetry-java-mvn/README.md) for a Java example of integrating Telemetry into a Lagom service.
+
 ## Configuring a Lagom build for Enterprise Suite
 
 Bintray credentials are required to build applications using the Enterprise Suite portion of the Reactive Platform. Lightbend customers should log into the [support portal](https://portal.lightbend.com/ReactivePlatform/EnterpriseSuiteCredentials) to obtain their credentials. Follow the links below to see how to supply the credentials when using sbt or Maven.

--- a/docs/manual/java/guide/broker/KafkaClient.md
+++ b/docs/manual/java/guide/broker/KafkaClient.md
@@ -1,6 +1,6 @@
 # Lagom Kafka Client
 
-Lagom provides an implementation of the Message Broker API that uses Kafka. In the remainder you will learn how to add the dependency in your build, and how to configure and tune topic's publishers and subscribers.
+Lagom provides an implementation of the Message Broker API that uses Kafka. The following sections show how to add the dependency in your build, and how to configure and tune topic publishers and subscribers. For information on running Kafka in development, see the [Kafka Server](../KafkaServer.md) page. 
 
 ## Dependency
 
@@ -74,3 +74,5 @@ If/when your subscriber-only service evolves to include features that publish da
 ### Consuming Topics from 3rd parties
 
 You may want your Lagom service to consume data produced on services not implemented in Lagom. In that case, as described in the [[Service Clients|ServiceClients]] section, you can create a `third-party-service-api` module in your Lagom project. That module will contain a Service Descriptor [[declaring the topic|MessageBrokerApi#Declaring-a-topic]] you will consume from. Once you have your `ThirdPartyService` interface and related classes implemented, you should add `third-party-service-api` as a dependency on your `fancy-service-impl`. Finally, you can consume from the topic described in `ThirdPartyService` as documented in the [[Subscribe to a topic|MessageBrokerApi#Subscribe-to-a-topic]] section.
+
+For an example, see the [consumer service recipe](https://github.com/lagom/lagom-recipes/blob/master/consumer-service/consumer-service-java-sbt/README.md).

--- a/docs/manual/java/guide/cluster/PersistentEntity.md
+++ b/docs/manual/java/guide/cluster/PersistentEntity.md
@@ -1,6 +1,6 @@
 # Persistent Entity
 
-[[Event Sourcing and CQRS|ES_CQRS]] is a recommended introduction to this section.
+We recommend reading [[Event Sourcing and CQRS|ES_CQRS]] as a prerequisite to this section.
 
 A `PersistentEntity` has a stable entity identifier, with which it can be accessed from the service implementation or other places. The state of an entity is persistent (durable) using [Event Sourcing](https://msdn.microsoft.com/en-us/library/jj591559.aspx). We represent all state changes as events and those immutable facts are appended to an event log. To recreate the current state of an entity when it is started we replay these events.
 
@@ -32,11 +32,11 @@ We recommend using Cassandra. Cassandra is a very scalable distributed database,
 
 Lagom also provides out of the box support for running Cassandra in a development environment - developers do not need to install, configure or manage Cassandra at all themselves when using Lagom, which makes for great developer velocity, and it means gone are the days where developers spend days setting up their development environment before they can start to be productive on a project.
 
-For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project.
+For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project. To see how to use Cassandra for write-side persistence and JPA for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-recipes/blob/master/mixed-persistence/mixed-persistence-java-sbt/README.md) recipe.
 
 ## PersistentEntity Stub
 
-This is how a [PersistentEntity](api/index.html?com/lightbend/lagom/javadsl/persistence/PersistentEntity.html) class looks like before filling in the implementation details:
+This is what a [PersistentEntity](api/index.html?com/lightbend/lagom/javadsl/persistence/PersistentEntity.html) class looks like before filling in the implementation details:
 
 @[post1](code/docs/home/persistence/Post1.java)
 

--- a/docs/manual/java/guide/services/ServiceClients.md
+++ b/docs/manual/java/guide/services/ServiceClients.md
@@ -69,6 +69,8 @@ All service calls with Lagom service clients are by default using circuit breake
 
 In the above example the default identifier is used for the `sayHi` method, since no specific identifier is given. The default identifier is the same as the service name, i.e. `"hello"` in this example. The `hiAgain` method will use another circuit breaker instance, since `"hello2"` is specified as circuit breaker identifier.
 
+See [CircuitBreakerPanel recipe](https://github.com/lagom/lagom-recipes/tree/master/circuitbreakerpanel/circuitbreakerpanel-java-mvn) for an example you can use with any arbitrary API to apply the circuit breaker pattern.
+
 ### Circuit Breaker Configuration
 
 On the client side you can configure the circuit breakers. The default configuration is:

--- a/docs/manual/java/guide/services/ServiceImplementation.md
+++ b/docs/manual/java/guide/services/ServiceImplementation.md
@@ -66,6 +66,8 @@ If you're required to pass or return a `ServerServiceCall`, you can use the `Hea
 
 @[header-service-call-of-lambda](code/docs/services/ServiceImplementation.java)
 
+See [Header Manipulation and HTTP testing](https://github.com/lagom/lagom-recipes/blob/master/http-header-handling/http-header-handling-java-sbt/README.md) for an example of status code manipulation and how to test it.
+
 ## Service call composition
 
 You may have situations where you want to compose service calls with cross cutting concerns such as security or logging.  In Lagom, this is done by composing service calls explicitly.  The following shows a simple logging service call:

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -1,6 +1,6 @@
 # Persistent Entity
 
-[[Event Sourcing and CQRS|ES_CQRS]] is a recommended introduction to this section.
+We recommend reading [[Event Sourcing and CQRS|ES_CQRS]] as a prerequisite to this section.
 
 A `PersistentEntity` has a stable entity identifier, with which it can be accessed from the service implementation or other places. The state of an entity is persistent (durable) using [Event Sourcing](https://msdn.microsoft.com/en-us/library/jj591559.aspx). We represent all state changes as events and those immutable facts are appended to an event log. To recreate the current state of an entity when it is started we replay these events.
 
@@ -32,11 +32,11 @@ We recommend using Cassandra. Cassandra is a very scalable distributed database,
 
 Lagom also provides out of the box support for running Cassandra in a development environment - developers do not need to install, configure or manage Cassandra at all themselves when using Lagom, which makes for great developer velocity, and it means gone are the days where developers spend days setting up their development environment before they can start to be productive on a project.
 
-For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project.
+For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project. To see how to use Cassandra for write-side persistence and JPA for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-recipes/blob/master/mixed-persistence/mixed-persistence-scala-sbt/README.md) recipe.
 
 ## PersistentEntity Stub
 
-This is how a [PersistentEntity](api/index.html#com/lightbend/lagom/scaladsl/persistence/PersistentEntity) class looks like before filling in the implementation details:
+This is what a [PersistentEntity](api/index.html#com/lightbend/lagom/scaladsl/persistence/PersistentEntity) class looks like before filling in the implementation details:
 
 @[post1](code/docs/home/scaladsl/persistence/Post1.scala)
 

--- a/docs/manual/scala/guide/services/ServiceImplementation.md
+++ b/docs/manual/scala/guide/services/ServiceImplementation.md
@@ -46,6 +46,8 @@ Here's an example of working with the headers:
 
 @[server-service-call](code/ServiceImplementation.scala)
 
+
+
 ## Service call composition
 
 You may have situations where you want to compose service calls with cross cutting concerns such as security or logging.  In Lagom, this is done by composing service calls explicitly.  The following shows a simple logging service call:


### PR DESCRIPTION
By creating these x-refs, readers of the Lagom doc can have access to the recipes. I did not x-ref individual recipes that I could not find an appropriate place for, nor the last two: deployment to K8s, because it is likely that James new guide will be more appropriate to reference; couchbase, because it is not considered production ready yet.  

The important thing to check that the locations where I did create x-refs make sense. 