### PR TITLE
Fixes typos in Migration15.md

### DIFF
--- a/docs/manual/scala/releases/Migration15.md
+++ b/docs/manual/scala/releases/Migration15.md
@@ -19,7 +19,7 @@ We also recommend upgrading to sbt 1.2.1 or later, by updating the `sbt.version`
 
 ### Service Ports
 
-Lagom 1.5.0 now has support for SSL calls for gRPC integration and new a build setting was introduced to configure https port for a given service manually.
+Lagom 1.5.0 now has support for SSL calls for gRPC integration and a new build setting was introduced to configure the https port for a given service manually.
 
 In sbt, the new setting is called `lagomServiceHttpsPort`. To keep the names aligned, we are deprecating  `lagomServicePort` in favour of `lagomServiceHttpPort`.
 


### PR DESCRIPTION
(same as #1696, but for Scala documentation)