### PR TITLE
[1.4.x] Update Akka to 2.5.20

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,6 +1,6 @@
 val ScalaVersion = "2.12.8"
 
-val AkkaVersion = "2.5.19"
+val AkkaVersion = "2.5.20"
 val JUnitVersion = "4.11"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion = "3.0.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val PlayFileWatchVersion = "1.1.7"
 
   // Also be sure to update AkkaVersion in docs/build.sbt.
-  val AkkaVersion = "2.5.19"
+  val AkkaVersion = "2.5.20"
   val AkkaHttpVersion = "10.0.15"
   // Also be sure to update ScalaVersion in docs/build.sbt.
   val ScalaVersions = Seq("2.12.8", "2.11.12")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,7 +69,7 @@ object Dependencies {
   private val javassist = "org.javassist" % "javassist" % "3.21.0-GA"
   private val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
   private val typesafeConfig = "com.typesafe" % "config" % "1.3.3"
-  private val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.6"
+  private val sslConfig = "com.typesafe" %% "ssl-config-core" % "0.3.7"
   private val h2 = "com.h2database" % "h2" % "1.4.192"
   private val cassandraDriverCore = "com.datastax.cassandra" % "cassandra-driver-core" % "3.2.0" excludeAll (excludeSlf4j: _*)
 


### PR DESCRIPTION
Lightbend Orchestration (`reactive-lib`) 1.7.0 evicts `akka-actor` 2.5.19, causing a version conflict between different Akka modules.

## References

https://discuss.lightbend.com/t/cluster-fail-with-error-akka-version-must-be-the-same-across-all-modules-of-akka-that-you-are-using/3396