### PR TITLE
Merges travis stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,10 @@ stages:
 
 jobs:
   include:
-    - stage: validations
+    - stage: validations-and-test
       script: bin/test-code-style
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
-    - stage: test
-      script: bin/test-2.11
+    - script: bin/test-2.11
       name: "Run tests for Scala 2.11"
     - script: bin/test-2.12
       name: "Run tests for Scala 2.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ env:
     - TRAVIS_JDK=adopt@1.8.192-12
 
 stages:
-  - validations
-  - test
+  - validations-and-test
   - test-build-tools
   - java-11
 


### PR DESCRIPTION
With the migration to travis-ci.com complete we now hhave 8 workers (instead of 5). I think it's more convenient to have fewer, bigger stages. 

This PR merges `validation` and `test` and I'm eager to merge `test-build-tools` too. Opinions?