### PR TITLE
Adds unit tests for SSL testkit API

### DIFF
--- a/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/TestOverTlsTest.java
+++ b/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/TestOverTlsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.javadsl.testkit;
+
+import akka.actor.ActorSystem;
+import akka.stream.ActorMaterializer;
+import akka.stream.ActorMaterializerSettings;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import com.google.inject.AbstractModule;
+import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport;
+import com.typesafe.sslconfig.ssl.SSLContextBuilder;
+import org.junit.Test;
+import play.libs.ws.WSClient;
+import play.libs.ws.WSResponse;
+import play.libs.ws.ahc.AhcWSClient;
+import play.shaded.ahc.io.netty.handler.ssl.ClientAuth;
+import play.shaded.ahc.io.netty.handler.ssl.JdkSslContext;
+import play.shaded.ahc.org.asynchttpclient.AsyncHttpClient;
+import play.shaded.ahc.org.asynchttpclient.AsyncHttpClientConfig;
+import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClient;
+import play.shaded.ahc.org.asynchttpclient.DefaultAsyncHttpClientConfig;
+
+import javax.net.ssl.SSLContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+// This is a complement to TestOverTlsSpec so we can embed some java code in theh docs. The actual unit test of
+// the feature to use SSL in tests is on TestOverTlsSpec.
+public class TestOverTlsTest {
+
+    @Test
+    public void testOverTlsWithCustomClient() {
+        ServiceTest.withServer(
+            ServiceTest.defaultSetup()
+                .withCluster(false)
+                .withSsl()
+                        .configureBuilder(builder ->
+                                builder.bindings(new TestTlsServiceModule())), server -> {
+
+                WSClient wsClient = buildCustomWS(server.clientSslContext().get());
+                String response = wsClient
+                    .url("https://localhost:"+server.portSsl().get()+ "/api/sample")
+                    .get()
+                    .thenApply(WSResponse::getBody)
+                    .toCompletableFuture()
+                    .get(5, TimeUnit.SECONDS);
+
+            assertEquals("sample response", response);
+        });
+    }
+
+
+    private WSClient buildCustomWS(SSLContext sslContext){
+        // Set up Akka
+        String name = "test-client";
+        ActorSystem system = ActorSystem.create(name);
+        ActorMaterializerSettings settings = ActorMaterializerSettings.create(system);
+        ActorMaterializer materializer = ActorMaterializer.create(settings, system, name);
+
+        // Setup the client to use the custom SSLContext
+        JdkSslContext jdkSslContext = new JdkSslContext(sslContext, true, ClientAuth.NONE);
+        AsyncHttpClientConfig asyncHttpClientConfig =
+            new DefaultAsyncHttpClientConfig.Builder()
+                .setSslContext(jdkSslContext)
+                .build();
+        AsyncHttpClient asyncHttpClient =
+            new DefaultAsyncHttpClient(asyncHttpClientConfig);
+
+
+        // Set up WSClient instance directly from asynchttpclient.
+        return new AhcWSClient(
+            asyncHttpClient,
+            materializer
+        );
+    }
+}

--- a/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/TestTlsService.java
+++ b/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/TestTlsService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.javadsl.testkit;
+
+import akka.NotUsed;
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.transport.Method;
+
+import static com.lightbend.lagom.javadsl.api.Service.*;
+
+/**
+ *
+ */
+public interface TestTlsService extends Service {
+
+    ServiceCall<NotUsed, String> sampleCall();
+
+    @Override
+    default Descriptor descriptor(){
+        return named("java-test-tls")
+            .withCalls(
+                restCall(Method.GET, "/api/sample", this::sampleCall)
+            ) ;
+    }
+}

--- a/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/tls/TestTlsService.java
+++ b/testkit/javadsl/src/test/java/com/lightbend/lagom/javadsl/testkit/services/tls/TestTlsService.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package com.lightbend.lagom.javadsl.testkit;
+package com.lightbend.lagom.javadsl.testkit.services.tls;
 
 import akka.NotUsed;
 import com.lightbend.lagom.javadsl.api.Descriptor;

--- a/testkit/javadsl/src/test/scala/com/lightbend/lagom/javadsl/testkit/TestOverTlsSpec.scala
+++ b/testkit/javadsl/src/test/scala/com/lightbend/lagom/javadsl/testkit/TestOverTlsSpec.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.javadsl.testkit
+
+import java.util.concurrent.{ CompletableFuture, CompletionStage, TimeUnit }
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.japi.function.Procedure
+import akka.stream.ActorMaterializer
+import com.google.inject.AbstractModule
+import com.lightbend.lagom.javadsl.api.ServiceCall
+import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport
+import com.lightbend.lagom.javadsl.testkit.ServiceTest.{ Setup, TestServer }
+import com.typesafe.config.ConfigFactory
+import javax.inject.Inject
+import javax.net.ssl.SSLContext
+import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
+import org.scalatest.time.{ Seconds, Span }
+import org.scalatest.{ Matchers, WordSpec }
+import play.api.libs.ws.ahc.{ AhcWSClientConfigFactory, StandaloneAhcWSClient }
+import play.inject.guice.GuiceApplicationBuilder
+
+import scala.compat.java8.FunctionConverters._
+
+/**
+ *
+ */
+class TestOverTlsSpec extends WordSpec with Matchers with ScalaFutures {
+
+  val timeout = PatienceConfiguration.Timeout(Span(5, Seconds))
+  val defaultSetup = ServiceTest.defaultSetup.withCluster(false)
+
+  "TestOverTls" when {
+    "started with ssl" should {
+
+      "not provide an ssl port by default" in {
+        withServer(defaultSetup) { server =>
+          server.portSsl.isPresent shouldBe false
+        }
+      }
+
+      "provide an ssl port" in {
+        withServer(defaultSetup.withSsl()) { server =>
+          server.portSsl.isPresent shouldBe true
+        }
+      }
+
+      "provide an ssl context for the client" in {
+        withServer(defaultSetup.withSsl()) { server =>
+          server.clientSslContext.isPresent shouldBe true
+        }
+      }
+
+      "complete an RPC call" in {
+        withServer(defaultSetup.withSsl()) { server =>
+          // The client's provided by Lagom's ServiceTest default to use HTTP
+          val client: TestTlsService = server.client(classOf[TestTlsService])
+          val response = client.sampleCall()
+            .invoke().toCompletableFuture.get(5, TimeUnit.SECONDS)
+          response should be("sample response")
+        }
+      }
+
+      "complete a WS call over HTTPS" in {
+        withServer(defaultSetup.withSsl()) { server =>
+          implicit val ctx = server.app.asScala().actorSystem.dispatcher
+          // To explicitly use HTTPS on a test you must create a client of your own and make sure it uses
+          // the provided SSLContext
+          val wsClient = buildCustomWS(server.clientSslContext.get)
+          val response =
+            wsClient
+              .url(s"https://localhost:${server.portSsl.get}/api/sample")
+              .get()
+              .map {
+                _.body[String]
+              }
+          whenReady(response, timeout) { r =>
+            r should be("sample response")
+          }
+        }
+      }
+    }
+  }
+
+  def withServer(setup: Setup)(block: TestServer => Unit): Unit = {
+    ServiceTest.withServer(
+      setup.configureBuilder((registerService _).asJava),
+      // We can't use a Single Abstract Method lambda until we drop Scala 2.11 support
+      new Procedure[TestServer] {
+        override def apply(server: TestServer): Unit = block(server)
+      }
+    )
+  }
+
+  def registerService(builder: GuiceApplicationBuilder): GuiceApplicationBuilder =
+    builder.bindings(new TestTlsServiceModule)
+
+  private def buildCustomWS(sslContext: SSLContext) = {
+    implicit val system = ActorSystem("test-client")
+    implicit val mat = ActorMaterializer()
+    // This setting enables the use of `SSLContext.setDefault` on the following line.
+    val sslConfig = ConfigFactory.parseString("play.ws.ssl.default = true").withFallback(ConfigFactory.load())
+    SSLContext.setDefault(sslContext)
+    val config = AhcWSClientConfigFactory.forConfig(sslConfig)
+    // This wsClient will use the `SSLContext` from `SSLContext.getDefault` (instead of the internal config-based)
+    val wsClient = StandaloneAhcWSClient(config)
+    wsClient
+  }
+}
+
+// Thhe actual TestTlsService for javadsl tests is written in java. See TestTlsService.java
+//trait TestTlsService extends Service
+
+class TestTlsServiceImpl @Inject() () extends TestTlsService {
+  override def sampleCall(): ServiceCall[NotUsed, String] = {
+    new ServiceCall[NotUsed, String]() {
+      override def invoke(request: NotUsed): CompletionStage[String] =
+        CompletableFuture.completedFuture("sample response")
+    }
+  }
+}
+
+class TestTlsServiceModule extends AbstractModule with ServiceGuiceSupport {
+  override def configure(): Unit = bindService(classOf[TestTlsService], classOf[TestTlsServiceImpl])
+}

--- a/testkit/javadsl/src/test/scala/com/lightbend/lagom/javadsl/testkit/TestOverTlsSpec.scala
+++ b/testkit/javadsl/src/test/scala/com/lightbend/lagom/javadsl/testkit/TestOverTlsSpec.scala
@@ -14,6 +14,7 @@ import com.google.inject.AbstractModule
 import com.lightbend.lagom.javadsl.api.ServiceCall
 import com.lightbend.lagom.javadsl.server.ServiceGuiceSupport
 import com.lightbend.lagom.javadsl.testkit.ServiceTest.{ Setup, TestServer }
+import com.lightbend.lagom.javadsl.testkit.services.tls.TestTlsService
 import com.typesafe.config.ConfigFactory
 import javax.inject.Inject
 import javax.net.ssl.SSLContext

--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/TestOverTlsSpec.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/TestOverTlsSpec.scala
@@ -13,7 +13,7 @@ import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationC
 import com.typesafe.config.ConfigFactory
 import javax.net.ssl.SSLContext
 import org.scalatest.concurrent.{ PatienceConfiguration, ScalaFutures }
-import org.scalatest.time.{ Milliseconds, Seconds, Span }
+import org.scalatest.time.{ Seconds, Span }
 import org.scalatest.{ Matchers, WordSpec }
 import play.api.libs.ws.ahc.{ AhcWSClientConfigFactory, AhcWSComponents, StandaloneAhcWSClient }
 

--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/TestOverTlsSpec.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/TestOverTlsSpec.scala
@@ -1,0 +1,52 @@
+package com.lightbend.lagom.scaladsl.testkit
+
+import java.nio.file.{ Files, Path, Paths }
+
+import com.lightbend.lagom.scaladsl.api.{ Descriptor, Service }
+import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraPersistenceComponents
+import com.lightbend.lagom.scaladsl.persistence.jdbc.JdbcPersistenceComponents
+import com.lightbend.lagom.scaladsl.persistence.{ PersistenceComponents, PersistentEntityRegistry }
+import com.lightbend.lagom.scaladsl.playjson.{ EmptyJsonSerializerRegistry, JsonSerializerRegistry }
+import com.lightbend.lagom.scaladsl.server.{ LagomApplication, LagomApplicationContext, LagomServer, LocalServiceLocator }
+import org.scalatest.{ Matchers, WordSpec }
+import play.api.db.HikariCPComponents
+import play.api.libs.ws.ahc.AhcWSComponents
+
+import scala.util.Properties
+
+/**
+  *
+  */
+class TestOverTlsSpec extends WordSpec with Matchers {
+  "TestOverTls" when {
+    "started with ssl" should {
+      "provide an ssl port" in {
+        ServiceTest.withServer(ServiceTest.defaultSetup.withSsl())(new TestTlsApplication(_)) { server =>
+          server.playServer.httpsPort
+        }
+      }
+
+      "provide an ssl context for the client" in {
+      }
+    }
+  }
+}
+
+trait TestTlsService extends Service {
+
+  import Service._
+
+  override final def descriptor: Descriptor = named("test-tls")
+
+}
+
+class TestTlsServiceImpl() extends TestTlsService
+
+class TestTlsApplication(context: LagomApplicationContext) extends LagomApplication(context)
+  with LocalServiceLocator
+  with AhcWSComponents {
+
+  override lazy val lagomServer: LagomServer = serverFor[TestTlsService](new TestTlsServiceImpl())
+
+}
+


### PR DESCRIPTION
Fixes #1608

This adds unit tests for the SSL support introduced in testkit.

The implementation for both the scaldsl and the javadsl is currently in scala but I?ll eventually migrate the 
javadsl to java to deuse the code on the docs.