### PR TITLE
Delayed cluster feature startup

### DIFF
--- a/docs/manual/java/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/java/guide/broker/MessageBrokerApi.md
@@ -76,6 +76,14 @@ The easiest way to achieve this is to use a total function which returns `Done` 
 
 @[subscribe-to-topic-skip-messages](code/docs/javadsl/mb/AnotherServiceImpl.java)
 
+### Delaying subscription until cluster start
+
+When Lagom starts, it may take some time to form a cluster with other nodes. In development, this happens almost immediately because there is only a single node that starts a cluster with itself. But in production, it typically might take 5-10 seconds. During this time, Lagom's cluster based features, such as persistence, won't be available, and attempts to use them will result in errors and timeouts. If you start your Kafka subscriptions immediately when Lagom starts up, then they will likely fail. Generally, this is not a big a problem, because Lagom will automatically restart the stream when this happens, but it does mean that you're likely to see errors in the logs.
+
+To handle this situation a little more gracefully, you may consider delaying starting your subscriptions until after the cluster has started. This can be done using the `akka.cluster.Cluster` extension class, like so:
+
+@[delay-subscription](code/docs/javadsl/mb/AnotherServiceImpl.java)
+
 ## Polymorphic event streams
 
 Typically you will want to publish more than one type of event to a particular topic. This can be done by creating an interface that each event implements. In order to successfully serialize these events to and from JSON, a few extra annotations are needed to instruct Jackson to describe and consume the type of the event in the produced JSON.

--- a/docs/manual/java/guide/broker/code/docs/javadsl/mb/AnotherServiceImpl.java
+++ b/docs/manual/java/guide/broker/code/docs/javadsl/mb/AnotherServiceImpl.java
@@ -2,6 +2,8 @@ package docs.javadsl.mb;
 
 import akka.Done;
 import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.cluster.Cluster;
 import akka.stream.FlowShape;
 import akka.stream.Graph;
 import akka.stream.UniformFanInShape;
@@ -76,5 +78,18 @@ public class AnotherServiceImpl implements AnotherService {
                 }
             }));
         //#subscribe-to-topic-skip-messages
+    }
+
+    private void delaySubscription() {
+        ActorSystem actorSystem = ActorSystem.create();
+        //#delay-subscription
+        Cluster.get(actorSystem).registerOnMemberUp(() -> {
+            helloService.greetingsTopic()
+                .subscribe()
+                .atLeastOnce(Flow.fromFunction((GreetingMessage message) -> {
+                    return doSomethingWithTheMessage(message);
+                }));
+        });
+        //#delay-subscription
     }
 }

--- a/docs/manual/scala/guide/broker/MessageBrokerApi.md
+++ b/docs/manual/scala/guide/broker/MessageBrokerApi.md
@@ -72,6 +72,14 @@ The easiest way to achieve this is to use a total function which returns `Done` 
 
 @[subscribe-to-topic-skip-messages](code/docs/scaladsl/mb/AnotherServiceImpl.scala)
 
+### Delaying subscription until cluster start
+
+When Lagom starts, it may take some time to form a cluster with other nodes. In development, this happens almost immediately because there is only a single node that starts a cluster with itself. But in production, it typically might take 5-10 seconds. During this time, Lagom's cluster based features, such as persistence, won't be available, and attempts to use them will result in errors and timeouts. If you start your Kafka subscriptions immediately when Lagom starts up, then they will likely fail. Generally, this is not a big a problem, because Lagom will automatically restart the stream when this happens, but it does mean that you're likely to see errors in the logs.
+
+To handle this situation a little more gracefully, you may consider delaying starting your subscriptions until after the cluster has started. This can be done like so:
+
+@[delay-subscription](code/docs/scaladsl/mb/AnotherServiceImpl.scala)
+
 ## Polymorphic event streams
 
 Typically you will want to publish more than one type of event to a particular topic. This can be done by creating an interface that each event implements. In order to successfully serialize these events to and from JSON, you will have to include some extra information on your JSON representation of the data.

--- a/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/AnotherServiceImpl.scala
+++ b/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/AnotherServiceImpl.scala
@@ -9,6 +9,7 @@ import akka.stream.scaladsl.Merge
 import akka.stream.scaladsl.Partition
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.api.broker.Message
+import akka.actor.ActorSystem
 
 //#inject-service
 class AnotherServiceImpl(helloService: HelloService) extends AnotherService {
@@ -68,5 +69,21 @@ class AnotherServiceImpl(helloService: HelloService) extends AnotherService {
         }
       )
     //#subscribe-to-topic-skip-messages
+  }
+
+  def delaySubscription = {
+    val actorSystem = ActorSystem()
+    //#delay-subscription
+    import akka.cluster.Cluster
+
+    Cluster(actorSystem).registerOnMemberUp {
+      helloService
+        .greetingsTopic()
+        .subscribe
+        .atLeastOnce(
+          Flow.fromFunction(doSomethingWithTheMessage)
+        )
+    }
+    //#delay-subscription
   }
 }

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -36,7 +36,9 @@ private[lagom] abstract class CassandraOffsetStore(
     }
   }
 
-  val startupTask = if (cassandraReadSideSettings.autoCreateTables) {
+  // This must be lazy to ensure that the startup task doesn't run until something actually tries to use it.
+  // This ensures that we don't try and use any cluster features before the cluster is formed.
+  lazy val startupTask = if (cassandraReadSideSettings.autoCreateTables) {
     Some(
       ClusterStartupTask(
         system,

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -11,6 +11,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import com.lightbend.lagom.internal.javadsl.persistence.AbstractPersistentEntityRegistry
+import com.lightbend.lagom.internal.persistence.PersistenceConfig
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraKeyspaceConfig
 import play.api.inject.Injector
 
@@ -18,8 +19,8 @@ import play.api.inject.Injector
  * Internal API
  */
 @Singleton
-private[lagom] final class CassandraPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector)
-  extends AbstractPersistentEntityRegistry(system, injector) {
+private[lagom] final class CassandraPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector, config: PersistenceConfig)
+  extends AbstractPersistentEntityRegistry(system, injector, config) {
 
   private val log = Logging.getLogger(system, getClass)
 

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -27,7 +27,7 @@ class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSp
   import system.dispatcher
 
   private lazy val injector = new GuiceInjectorBuilder().build()
-  override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system, injector)
+  override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system, injector, persistenceConfig)
 
   private lazy val testSession: CassandraSession = new CassandraSession(system)
   private lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(system)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -7,16 +7,15 @@ package com.lightbend.lagom.internal.scaladsl.persistence.cassandra
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
-import akka.persistence.query.PersistenceQuery
-import akka.persistence.query.scaladsl.EventsByTagQuery
+import com.lightbend.lagom.internal.persistence.PersistenceConfig
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraKeyspaceConfig
 import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntityRegistry
 
 /**
  * Internal API
  */
-private[lagom] final class CassandraPersistentEntityRegistry(system: ActorSystem)
-  extends AbstractPersistentEntityRegistry(system) {
+private[lagom] final class CassandraPersistentEntityRegistry(system: ActorSystem, config: PersistenceConfig)
+  extends AbstractPersistentEntityRegistry(system, config) {
 
   private val log = Logging.getLogger(system, getClass)
 

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -24,7 +24,7 @@ trait CassandraPersistenceComponents extends PersistenceComponents
  */
 trait WriteSideCassandraPersistenceComponents extends WriteSidePersistenceComponents {
   override lazy val persistentEntityRegistry: PersistentEntityRegistry =
-    new CassandraPersistentEntityRegistry(actorSystem)
+    new CassandraPersistentEntityRegistry(actorSystem, persistenceConfig)
 
   def serviceLocator: ServiceLocator
 

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -24,7 +24,7 @@ object CassandraReadSideSpec {
 class CassandraReadSideSpec extends CassandraPersistenceSpec(CassandraReadSideSpec.defaultConfig, TestEntitySerializerRegistry) with AbstractReadSideSpec {
   import system.dispatcher
 
-  override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system)
+  override protected lazy val persistentEntityRegistry = new CassandraPersistentEntityRegistry(system, persistenceConfig)
 
   private lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(system)
   private lazy val testSession: CassandraSession = new CassandraSession(system)

--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStore.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStore.scala
@@ -81,7 +81,9 @@ private[lagom] class SlickOffsetStore(system: ActorSystem, val slick: SlickProvi
 
   private val offsets = TableQuery[OffsetStore]
 
-  private val startupTask = if (slick.autoCreateTables) {
+  // This must be lazy to ensure that the startup task doesn't run until something actually tries to use it.
+  // This ensures that we don't try and use any cluster features before the cluster is formed.
+  private lazy val startupTask = if (slick.autoCreateTables) {
     Some(
       ClusterStartupTask(
         system,

--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickProvider.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickProvider.scala
@@ -58,7 +58,7 @@ private[lagom] class SlickProvider(system: ActorSystem)(implicit ec: ExecutionCo
 
   // This feature is somewhat limited, it assumes that the read side database is the same database as the journals and
   // snapshots
-  private val createTablesTask: Option[ClusterStartupTask] = if (autoCreateTables) {
+  private lazy val createTablesTask: Option[ClusterStartupTask] = if (autoCreateTables) {
     val journalCfg = new JournalTableConfiguration(system.settings.config.getConfig("jdbc-read-journal"))
     val snapshotCfg = new SnapshotTableConfiguration(system.settings.config.getConfig("jdbc-snapshot-store"))
 

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -11,6 +11,7 @@ import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
 import com.lightbend.lagom.internal.javadsl.persistence.AbstractPersistentEntityRegistry
+import com.lightbend.lagom.internal.persistence.PersistenceConfig
 import com.lightbend.lagom.javadsl.persistence.PersistentEntity
 import play.api.inject.Injector
 
@@ -18,8 +19,8 @@ import play.api.inject.Injector
  * INTERNAL API
  */
 @Singleton
-private[lagom] final class JdbcPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector, slickProvider: SlickProvider)
-  extends AbstractPersistentEntityRegistry(system, injector) {
+private[lagom] final class JdbcPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector, slickProvider: SlickProvider, config: PersistenceConfig)
+  extends AbstractPersistentEntityRegistry(system, injector, config) {
 
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcReadSideSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcReadSideSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 
 class JdbcReadSideSpec extends JdbcPersistenceSpec with AbstractReadSideSpec {
   private lazy val injector = new GuiceInjectorBuilder().build()
-  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, injector, slick)
+  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, injector, slick, persistenceConfig)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
     new JdbcTestEntityReadSide.TestEntityReadSideProcessor(jdbcReadSide)

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -7,6 +7,7 @@ package com.lightbend.lagom.internal.scaladsl.persistence.jdbc
 import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
+import com.lightbend.lagom.internal.persistence.PersistenceConfig
 import com.lightbend.lagom.internal.persistence.jdbc.SlickProvider
 import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntityRegistry
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
@@ -14,8 +15,8 @@ import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
 /**
  * INTERNAL API
  */
-private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, slickProvider: SlickProvider)
-  extends AbstractPersistentEntityRegistry(system) {
+private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, slickProvider: SlickProvider, config: PersistenceConfig)
+  extends AbstractPersistentEntityRegistry(system, config) {
 
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -20,9 +20,11 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 
   override def register(entityFactory: => PersistentEntity): Unit = {
-    Cluster(system).registerOnMemberUp {
-      ensureTablesCreated
-    }
+    if (config.delayRegistration) {
+      Cluster(system).registerOnMemberUp {
+        ensureTablesCreated
+      }
+    } else ensureTablesCreated
     super.register(entityFactory)
   }
 

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -5,9 +5,8 @@
 package com.lightbend.lagom.internal.scaladsl.persistence.jdbc
 
 import akka.actor.ActorSystem
+import akka.cluster.Cluster
 import akka.persistence.jdbc.query.scaladsl.JdbcReadJournal
-import akka.persistence.query.scaladsl.EventsByTagQuery
-import akka.persistence.query.{ NoOffset, Offset, PersistenceQuery, Sequence }
 import com.lightbend.lagom.internal.persistence.jdbc.SlickProvider
 import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntityRegistry
 import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
@@ -21,7 +20,9 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 
   override def register(entityFactory: => PersistentEntity): Unit = {
-    ensureTablesCreated
+    Cluster(system).registerOnMemberUp {
+      ensureTablesCreated
+    }
     super.register(entityFactory)
   }
 

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceComponents.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceComponents.scala
@@ -42,7 +42,7 @@ trait WriteSideJdbcPersistenceComponents extends WriteSidePersistenceComponents 
   def executionContext: ExecutionContext
 
   override lazy val persistentEntityRegistry: PersistentEntityRegistry =
-    new JdbcPersistentEntityRegistry(actorSystem, slickProvider)
+    new JdbcPersistentEntityRegistry(actorSystem, slickProvider, persistenceConfig)
 
 }
 

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
@@ -4,7 +4,6 @@
 
 package com.lightbend.lagom.scaladsl.persistence.jdbc
 
-import akka.persistence.query.Sequence
 import com.lightbend.lagom.internal.scaladsl.persistence.jdbc.{ JdbcPersistentEntityRegistry, JdbcSessionImpl }
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
@@ -13,7 +12,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class JdbcReadSideSpec extends JdbcPersistenceSpec(TestEntitySerializerRegistry) with AbstractReadSideSpec {
-  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, slick)
+  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, slick, persistenceConfig)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
     new JdbcTestEntityReadSide.TestEntityReadSideProcessor(jdbcReadSide)

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickReadSideSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickReadSideSpec.scala
@@ -17,7 +17,7 @@ class SlickReadSideSpec
 
   import system.dispatcher
 
-  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, slick)
+  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, slick, persistenceConfig)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
     new SlickTestEntityReadSide.TestEntityReadSideProcessor(slickReadSide, slick.db, slick.profile)

--- a/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImplSpec.scala
+++ b/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImplSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.duration._
 
 class JpaReadSideImplSpec extends JpaPersistenceSpec with AbstractReadSideSpec {
   private lazy val injector = new GuiceInjectorBuilder().build()
-  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, injector, slick)
+  override protected lazy val persistentEntityRegistry = new JdbcPersistentEntityRegistry(system, injector, slick, persistenceConfig)
 
   private lazy val jpaReadSide: JpaReadSide = new JpaReadSideImpl(jpa, offsetStore)
 

--- a/persistence/core/src/main/resources/reference.conf
+++ b/persistence/core/src/main/resources/reference.conf
@@ -34,6 +34,17 @@ lagom.persistence {
   # Default timeout for PersistentEntityRef.ask replies.
   ask-timeout = 5s
 
+  # Whether the registration of persistent entitities should be delayed until
+  # the cluster has started up. If true, a call to
+  # PersistentEntityRegistry.register won't immediately start cluster sharding
+  # for that entity, rather, it will register a callback to start cluster
+  # sharding once the cluster is started. This ensures there are no extraneous
+  # log messages during startup as clustered features try to use the cluster
+  # before the cluster has started, however it also means any calls to
+  # PersistentEntityRegistry.refFor will fail until the cluster has started
+  # up.
+  delay-registration = false
+
   dispatcher {
     type = Dispatcher
     executor = "thread-pool-executor"

--- a/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/PersistenceConfig.scala
+++ b/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/PersistenceConfig.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.persistence
+
+import com.typesafe.config.Config
+
+import scala.concurrent.duration._
+
+case class PersistenceConfig(
+  maxNumberOfShards:         Int,
+  snapshotAfter:             Option[Int],
+  passivateAfterIdleTimeout: Duration,
+  runEntitiesOnRole:         Option[String],
+  askTimeout:                FiniteDuration,
+  delayRegistration:         Boolean
+)
+
+object PersistenceConfig {
+  def apply(config: Config): PersistenceConfig = {
+    new PersistenceConfig(
+      maxNumberOfShards = config.getInt("max-number-of-shards"),
+      snapshotAfter = config.getString("snapshot-after") match {
+        case "off" => None
+        case _     => Some(config.getInt("snapshot-after"))
+      },
+      passivateAfterIdleTimeout = {
+        val duration = config.getDuration("passivate-after-idle-timeout").toMillis.millis
+        if (duration == Duration.Zero) Duration.Undefined else duration
+      },
+      runEntitiesOnRole = Some(config.getString("run-entities-on-role")).filter(_.nonEmpty),
+      askTimeout = config.getDuration("ask-timeout").toMillis.millis,
+      delayRegistration = config.getBoolean("delay-registration")
+    )
+  }
+}

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistenceConfigProvider.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/PersistenceConfigProvider.scala
@@ -1,0 +1,14 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.javadsl.persistence
+
+import com.lightbend.lagom.internal.persistence.PersistenceConfig
+import javax.inject.{ Inject, Provider, Singleton }
+import play.api.Configuration
+
+@Singleton
+class PersistenceConfigProvider @Inject() (configuration: Configuration) extends Provider[PersistenceConfig] {
+  override lazy val get = PersistenceConfig(configuration.underlying.getConfig("lagom.persistence"))
+}

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
@@ -54,8 +54,10 @@ private[lagom] class ReadSideImpl @Inject() (
     clazz:            Class[_]
   ) = {
 
+    val cluster = Cluster(system)
+
     // Only run if we're configured to run on this role
-    if (config.role.forall(Cluster(system).selfRoles.contains)) {
+    if (config.role.forall(cluster.selfRoles.contains)) {
       // try to create one instance to fail fast (e.g. wrong constructor)
       val dummyProcessor = try {
         processorFactory()
@@ -73,35 +75,37 @@ private[lagom] class ReadSideImpl @Inject() (
         case None      => throw new IllegalArgumentException(s"ReadSideProcessor ${clazz.getName} returned 0 tags")
       }
 
-      val globalPrepareTask: ClusterStartupTask =
-        ClusterStartupTask(
-          system,
-          s"readSideGlobalPrepare-$encodedReadSideName",
-          () => processorFactory().buildHandler().globalPrepare().toScala,
-          config.globalPrepareTimeout,
-          config.role,
-          config.minBackoff,
-          config.maxBackoff,
-          config.randomBackoffFactor
+      cluster.registerOnMemberUp {
+        val globalPrepareTask: ClusterStartupTask =
+          ClusterStartupTask(
+            system,
+            s"readSideGlobalPrepare-$encodedReadSideName",
+            () => processorFactory().buildHandler().globalPrepare().toScala,
+            config.globalPrepareTimeout,
+            config.role,
+            config.minBackoff,
+            config.maxBackoff,
+            config.randomBackoffFactor
+          )
+
+        val readSideProps =
+          ReadSideActor.props(
+            config,
+            eventClass,
+            globalPrepareTask,
+            registry.eventStream[Event],
+            processorFactory
+          )
+
+        val shardingSettings = ClusterShardingSettings(system).withRole(config.role)
+
+        ClusterDistribution(system).start(
+          readSideName,
+          readSideProps,
+          entityIds.toSet,
+          ClusterDistributionSettings(system).copy(clusterShardingSettings = shardingSettings)
         )
-
-      val readSideProps =
-        ReadSideActor.props(
-          config,
-          eventClass,
-          globalPrepareTask,
-          registry.eventStream[Event],
-          processorFactory
-        )
-
-      val shardingSettings = ClusterShardingSettings(system).withRole(config.role)
-
-      ClusterDistribution(system).start(
-        readSideName,
-        readSideProps,
-        entityIds.toSet,
-        ClusterDistributionSettings(system).copy(clusterShardingSettings = shardingSettings)
-      )
+      }
     }
 
   }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistenceModule.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistenceModule.scala
@@ -4,8 +4,8 @@
 
 package com.lightbend.lagom.javadsl.persistence
 
-import com.lightbend.lagom.internal.javadsl.persistence.{ ReadSideConfigProvider, ReadSideImpl }
-import com.lightbend.lagom.internal.persistence.ReadSideConfig
+import com.lightbend.lagom.internal.javadsl.persistence.{ PersistenceConfigProvider, ReadSideConfigProvider, ReadSideImpl }
+import com.lightbend.lagom.internal.persistence.{ PersistenceConfig, ReadSideConfig }
 import play.api.{ Configuration, Environment }
 import play.api.inject.{ Binding, Module }
 
@@ -17,7 +17,8 @@ class PersistenceModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
     bind[ReadSideImpl].toSelf,
     bind[ReadSide].to(bind[ReadSideImpl]),
-    bind[ReadSideConfig].toProvider[ReadSideConfigProvider]
+    bind[ReadSideConfig].toProvider[ReadSideConfigProvider],
+    bind[PersistenceConfig].toProvider[PersistenceConfigProvider]
   )
 
 }

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
@@ -15,7 +15,7 @@ import akka.testkit.ImplicitSender
 import akka.util.Timeout
 import akka.{ Done, NotUsed }
 import com.lightbend.lagom.internal.javadsl.persistence.{ PersistentEntityActor, ReadSideActor }
-import com.lightbend.lagom.internal.persistence.ReadSideConfig
+import com.lightbend.lagom.internal.persistence.{ PersistenceConfig, ReadSideConfig }
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
@@ -24,6 +24,7 @@ import com.lightbend.lagom.persistence.ActorSystemSpec
 import org.scalatest.BeforeAndAfter
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import akka.pattern._
+
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration._
 
@@ -37,6 +38,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
 
   implicit val mat = ActorMaterializer()
 
+  protected val persistenceConfig = PersistenceConfig(system.settings.config.getConfig("lagom.persistence"))
   protected val persistentEntityRegistry: PersistentEntityRegistry
 
   def eventStream[Event <: AggregateEvent[Event]](

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
  *
  * Akka persistence plugins can extend this to implement a custom registry.
  */
-class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEntityRegistry {
+class AbstractPersistentEntityRegistry(system: ActorSystem, config: PersistenceConfig) extends PersistentEntityRegistry {
 
   protected val name: Option[String] = None
   protected val journalPluginId: String = ""
@@ -37,7 +37,6 @@ class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEn
     queryPluginId.map(id => PersistenceQuery(system).readJournalFor[EventsByTagQuery](id))
 
   private val sharding = ClusterSharding(system)
-  protected val config = PersistenceConfig(system.settings.config.getConfig("lagom.persistence"))
   private val shardingSettings = ClusterShardingSettings(system).withRole(config.runEntitiesOnRole)
 
   private val extractEntityId: ShardRegion.ExtractEntityId = {

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistenceComponents.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistenceComponents.scala
@@ -6,7 +6,7 @@ package com.lightbend.lagom.scaladsl.persistence
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import com.lightbend.lagom.internal.persistence.ReadSideConfig
+import com.lightbend.lagom.internal.persistence.{ PersistenceConfig, ReadSideConfig }
 import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideImpl
 import com.lightbend.lagom.scaladsl.cluster.ClusterComponents
 import play.api.Configuration
@@ -23,6 +23,10 @@ trait PersistenceComponents extends ReadSidePersistenceComponents
  */
 trait WriteSidePersistenceComponents extends ClusterComponents {
   def persistentEntityRegistry: PersistentEntityRegistry
+  def configuration: Configuration
+
+  lazy val persistenceConfig: PersistenceConfig = PersistenceConfig(configuration.underlying.getConfig("lagom.persistence"))
+
 }
 
 /**
@@ -32,8 +36,6 @@ trait ReadSidePersistenceComponents extends WriteSidePersistenceComponents {
   def actorSystem: ActorSystem
   def executionContext: ExecutionContext
   def materializer: Materializer
-
-  def configuration: Configuration
 
   lazy val readSideConfig: ReadSideConfig = ReadSideConfig(configuration.underlying.getConfig("lagom.persistence.read-side"))
   lazy val readSide: ReadSide = new ReadSideImpl(actorSystem, readSideConfig, persistentEntityRegistry, None)(

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -11,7 +11,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.testkit.ImplicitSender
 import akka.{ Done, NotUsed }
-import com.lightbend.lagom.internal.persistence.ReadSideConfig
+import com.lightbend.lagom.internal.persistence.{ PersistenceConfig, ReadSideConfig }
 import com.lightbend.lagom.internal.persistence.cluster.ClusterDistribution.EnsureActive
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTaskActor.Execute
@@ -36,6 +36,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
 
   implicit val mat = ActorMaterializer()
 
+  protected val persistenceConfig = PersistenceConfig(system.settings.config.getConfig("lagom.persistence"))
   protected val persistentEntityRegistry: PersistentEntityRegistry
 
   def eventStream[Event <: AggregateEvent[Event]](


### PR DESCRIPTION
Fixes #1268

This delays the startup of all features that depend on a cluster. It ensures that all cluster sharding and cluster singletons are not created until the cluster is started up.

I haven't put a huge amount of thought into this, I've just searched for all uses of cluster distribution, cluster startup task, cluster sharding and cluster singleton and wrapped the startup in a `cluster.registerOnMemberUp`. We'll see what CI says about whether that works.