### PR TITLE
[WIP] Enabled Akka HTTP management by default

### DIFF
--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -3,16 +3,14 @@ lagom.cluster {
   # Enables Akka Cluster Bootstrap.
   # https://developer.lightbend.com/docs/akka-management/current/bootstrap/
   #
-  # In dev-mode this setting will be off, otherwise the default is on.
-  # Moreover, Akka Cluster Bootstrap only works if akka.cluster.seed-nodes is not configured.
-  # It's possible to override that by defining akka.cluster.seed-nodes or set this property to off in
-  # the application.conf
+  # This setting is only honored if `akka.cluster.seed-nodes` is not configured. So if you define
+  # `akka.cluster.seed-nodes` Akka Cluster Bootstrap won't run.
+  # In dev-mode this setting will be off.
   bootstrap.enabled = on
 
-  # The cluster node will join itself if akka.cluster.seed-nodes is not configured.
-  # In dev-mode this setting will be on, otherwise the default is off. It's possible
-  # to override that by defining akka.cluster.seed-nodes or set this property to off in
-  # the application.conf
+  # Instruct the process to form an Akka cluster with itself. This setting is not recommended for production.
+  # The cluster node will only join itself if akka.cluster.seed-nodes is not configured.
+  # In dev-mode this setting will be on, otherwise the default is off.
   join-self = ${lagom.defaults.cluster.join-self}
 
   # Exit the JVM forcefully when the ActorSystem has been terminated.

--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -20,7 +20,10 @@ lagom.cluster {
   # to restart the process.
   exit-jvm-when-system-terminated = off
 
-
-
 }
 lagom.defaults.cluster.join-self = off
+
+# Enables Health Checks routes. When combined with Akka Cluster Bootstrap,
+# this will add the readiness check `akka.management.cluster.scaladsl.ClusterMembershipCheck`
+# that returns true when node is either Up or WeaklyUp
+akka.management.http.route-providers += "akka.management.HealthCheckRoutes"

--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -20,8 +20,3 @@ lagom.cluster {
 
 }
 lagom.defaults.cluster.join-self = off
-
-# Enables Health Checks routes. When combined with Akka Cluster Bootstrap,
-# this will add the readiness check `akka.management.cluster.scaladsl.ClusterMembershipCheck`
-# that returns true when node is either Up or WeaklyUp
-akka.management.http.route-providers += "akka.management.HealthCheckRoutes"

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -43,17 +43,19 @@ private[lagom] object JoinClusterImpl {
     }
 
     /*
-     * There are four ways to form a cluster in Lagom
-     *  1. lagom.cluster.join-self - Lagom's dev mode forms a single node cluster
+     * There are several ways to form a cluster in Lagom
+     *  1. Declared seed-nodes. Highest priority setting.
      *  2. lagom.cluster.bootstrap.enabled - Lagom's prod default. Uses Akka Cluster Bootstrap and Akka Management
-     *  3. Declared seed-nodes. Overrides the optoins above
+     *  3. lagom.cluster.join-self - Lagom's dev mode forms a single node cluster (unrecommended for production)
      *  4. Programmatically: No seed-nodes, join-self = false and bootstrap.enabled = false. User is on its own to form the cluster
      *
-     *  Last option is rather unusual, but we should not block users willing to do so. We also use that option in multi-jvm tests.
+     *  Last option is rather unusual but allows users to fallback to plain Akka cluster formation API. This option
+     *  is used in Lagom tests, for example.
      *  In order to join programmatically, one need to disable all flags.
      *
-     *  The code below make it possible by only forming the cluster if
-     *  there is no seed-nodes and bootstrap or join-self are enabled.
+     *  The code below will form the cluster if there are no seed-nodes and bootstrap or join-self are enabled. Forming
+     *  the cluster when seed-nodes are defined is already handled by Akka internally so there's no need to add
+     *  extra code in Lagom's codebase.
      */
     if (cluster.settings.SeedNodes.isEmpty) {
 

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -63,14 +63,11 @@ private[lagom] object JoinClusterImpl {
         // we should only run ClusterBootstrap if the user didn't configure the seed-needs
         // and left clusterBootstrapEnabled on true (default)
         // if the user has seed-nodes configured, we should not add AkkaManagement on their behalf
-
-        // TODO: move AkkaManagement to Guice module
-        AkkaManagement(system.asInstanceOf[ExtendedActorSystem]).start()
         ClusterBootstrap(system.asInstanceOf[ExtendedActorSystem]).start()
-
       } else if (joinSelf) {
         cluster.join(cluster.selfAddress)
       }
+
     }
 
     CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseClusterShutdown, "exit-jvm-when-downed") {

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -50,7 +50,7 @@ private[lagom] object JoinClusterImpl {
      *  4. Programmatically: No seed-nodes, join-self = false and bootstrap.enabled = false. User is on its own to form the cluster
      *
      *  Last option is rather unusual, but we should not block users willing to do so. We also use that option in multi-jvm tests.
-     *  In order to join programmatically, when need to disable all flags.
+     *  In order to join programmatically, one need to disable all flags.
      *
      *  The code below make it possible by only forming the cluster if
      *  there is no seed-nodes and bootstrap or join-self are enabled.

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -57,7 +57,7 @@ private[lagom] object JoinClusterImpl {
      */
     if (cluster.settings.SeedNodes.isEmpty) {
 
-      if(clusterBootstrapEnabled) {
+      if (clusterBootstrapEnabled) {
         // we should only run ClusterBootstrap if the user didn't configure the seed-needs
         // and left clusterBootstrapEnabled on true (default)
         // if the user has seed-nodes configured, we should not add AkkaManagement on their behalf

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -74,13 +74,11 @@ akka.management.cluster.bootstrap {
 For more detailed and advanced configurations options, please consult the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) documentation and its [reference.conf](https://github.com/akka/akka-management/blob/v1.0.0-RC2/cluster-bootstrap/src/main/resources/reference.conf) file.
 
 
-#### Cluster Http Management
+#### Akka Management
 
-[Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html) to form a cluster.
+[Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) to form a cluster.
 
-Akka Management Cluster HTTP is an [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) extension that allows interaction with an akka-cluster through an HTTP interface. This management extension exposes different operations to manage nodes in a cluster (by default only read-only operations are exposed) as well as health checks based on the cluster state.
-
-Therefore, Akka Management will also be enabled and will run on http port `8558`. You can configured it to another port by setting property `akka.management.http.port` in your `application.conf` file.
+[Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) is an extension that opens a dedicated HTTP interface. This management extension allows dedicated plugins to include their routes. Akka Cluster Bootstrap uses this mechanism to expose a route. Akka Management will be enabled when the cluster joining mechanism is Cluster Http Management and it will run on http port `8558`. You can configure it to another port by setting property `akka.management.http.port` in your `application.conf` file.
 
 #### Health Checks
 

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -36,11 +36,15 @@ You could imagine using cluster features across different services, but we recom
 
 A service instance joins a cluster when the service starts up.
 
-### Joining during development
+1. **Joining during development**:  In development you are typically only running the service on one cluster node. No explicit joining is necessary; the [[Lagom Development Environment|DevEnvironment]] handles it automatically and creates a single-node cluster.
 
-In development you are typically only running the service on one cluster node. No explicit joining is necessary; the [[Lagom Development Environment|DevEnvironment]] handles it automatically.
+1. **Joining during production**: There are several mechanisms available to create a cluster in production. This documentation covers the two recommended approaches:
+    1. Akka Cluster Bootstrap (recommended)
+    2. Manual Cluster Formation (a.k.a. a static list of `seed-nodes`)
 
-### Joining during production
+The sections below cover the two options for Cluster Joining during Production in more detail.
+
+### Joining during production (Akka Cluster Bootstrap)
 
 Starting from version 1.5.0, Lagom offers support for [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/). Akka Cluster Bootstrap is enabled by default in production mode and disabled in development and test mode.
 
@@ -74,7 +78,7 @@ For more detailed and advanced configurations options, please consult the [Akka 
 
 [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html) to form a cluster.
 
-Akka Management Cluster HTTP is a [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) extension that allows interaction with an akka-cluster through an HTTP interface. This management extension exposes different operations to manage nodes in a cluster (by default only read-only operations are exposed) as well as health checks based on the cluster state.
+Akka Management Cluster HTTP is an [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) extension that allows interaction with an akka-cluster through an HTTP interface. This management extension exposes different operations to manage nodes in a cluster (by default only read-only operations are exposed) as well as health checks based on the cluster state.
 
 Therefore, Akka Management will also be enabled and will run on http port `8558`. You can configured it to another port by setting property `akka.management.http.port` in your `application.conf` file.
 
@@ -102,7 +106,7 @@ For further information on Akka Cluster Bootstrap and Health Checks, consult Akk
  * [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html)
  * [Health Checks](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/healthchecks.html)
 
-### Manual Cluster Formation
+### Joining during production (Manual Cluster Formation)
 
 If you prefer to not use **Akka Cluster Bootstrap** and handle the cluster formation yourself, you can configure the Akka Cluster seed nodes statically.
 

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -65,7 +65,7 @@ akka.management.cluster.bootstrap {
   }
 }
 ```
-Other existing implementations are: DNS, AWS, Consul, Marathon API and static Configuration. It's also possible to implement your own Akka Discovery implementation if needed.
+[Other existing implementations](https://developer.lightbend.com/docs/akka-management/current/discovery/index.html) are: DNS, AWS, Consul, Marathon API and static Configuration. It's also possible to implement your own Akka Discovery implementation if needed.
 
 For more detailed and advanced configurations options, please consult the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) documentation and its [reference.conf](https://github.com/akka/akka-management/blob/v1.0.0-RC2/cluster-bootstrap/src/main/resources/reference.conf) file.
 

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -70,7 +70,7 @@ Other existing implementations are: DNS, AWS, Consul, Marathon API and static Co
 For more detailed and advanced configurations options, please consult the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) documentation and its [reference.conf](https://github.com/akka/akka-management/blob/v1.0.0-RC2/cluster-bootstrap/src/main/resources/reference.conf) file.
 
 
-#### Clustter Http Management
+#### Cluster Http Management
 
 [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html) to form a cluster.
 

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -54,7 +54,7 @@ Akka Cluster Bootstrap, in Lagom, can be disabled through the property `lagom.cl
 
 In order to find the peer nodes and form a cluster, Akka Cluster Bootstrap need to be configured to use one of the existing Akka Discovery implementations.
 
-The snippet bellow explifies how to configure the Akka Cluster Boostrap to use the Akka Discovery Kubernetes API.
+The snippet below exemplifies how to configure the Akka Cluster Boostrap to use the Akka Discovery Kubernetes API.
 
 ```
 akka.management.cluster.bootstrap {

--- a/docs/manual/java/guide/cluster/Cluster.md
+++ b/docs/manual/java/guide/cluster/Cluster.md
@@ -48,7 +48,7 @@ Akka Cluster Bootstrap helps forming (or joining to) a cluster by using [Akka Di
 
 It builds on the flexibility of Akka Discovery, leveraging a range of discovery mechanisms depending on the environment you want to run your cluster in.
 
-Akka Cluster Bootstrap, in Lagom, can be disabled though property `lagom.cluster.bootstrap.enabled = false`. Note that this configuration flag has no effect if you declare seed-nodes explicitly in which case Akka Cluster Bootstrap won't be used.
+Akka Cluster Bootstrap, in Lagom, can be disabled through the property `lagom.cluster.bootstrap.enabled = false`. Note that this configuration flag has no effect if you declare seed-nodes explicitly in which case Akka Cluster Bootstrap won't be used.
 
 #### Akka Discovery
 

--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -62,6 +62,13 @@ If you are using ConductR in production and need assistance migrating to other s
 
 TODO (new version required)
 
+## Cluster Formation
+
+A new mechanism to form and [[join an Akka Cluster|Cluster#Joining]] is introduced in Lagom 1.5. Apart from the original `Manual Cluster Formation` the new `Akka Cluster Bootstrap` is now supported. This new mechanism is introduced with lower precedence than `Manual Cluster Formation` so if you rely on the use of a list of `seed-nodes` then everything will work as before. On the other hand, `Akka Cluster Bootstrap` takes precedence over the `join-self` cluster formation for single-node clusters. If you use single-node clusters via `join-self` you will have to explicitly disable `Akka Cluster Bootstrap`:
+
+```
+lagom.cluster.bootstrap.enabled = false
+```
 
 ## Upgrading a production system
 

--- a/docs/manual/scala/guide/cluster/Cluster.md
+++ b/docs/manual/scala/guide/cluster/Cluster.md
@@ -41,7 +41,19 @@ A service instance joins a cluster when the service starts up.
 In development you are typically only running the service on one cluster node. No explicit joining is necessary; the [[Lagom Development Environment|DevEnvironment]] handles it automatically.
 
 
-### Joining during production
+## Joining
+
+A service instance joins a cluster when the service starts up.
+
+1. **Joining during development**:  In development you are typically only running the service on one cluster node. No explicit joining is necessary; the [[Lagom Development Environment|DevEnvironment]] handles it automatically and creates a single-node cluster.
+
+1. **Joining during production**: There are several mechanisms available to create a cluster in production. This documentation covers the two recommended approaches:
+    1. Akka Cluster Bootstrap (recommended)
+    2. Manual Cluster Formation (a.k.a. a static list of `seed-nodes`)
+
+The sections below cover the two options for Cluster Joining during Production in more detail.
+
+### Joining during production (Akka Cluster Bootstrap)
 
 Starting from version 1.5.0, Lagom offers support for [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/). Akka Cluster Bootstrap is enabled by default in production mode and disabled in development and test mode.
 
@@ -102,7 +114,7 @@ For further information on Akka Cluster Bootstrap and Health Checks, consult Akk
  * [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html)
  * [Health Checks](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/healthchecks.html)
 
-### Manual Cluster Formation
+### Joining during production (Manual Cluster Formation)
 
 If you prefer to not use **Akka Cluster Bootstrap** and handle the cluster formation yourself, you can configure the Akka Cluster seed nodes statically.
 

--- a/docs/manual/scala/guide/cluster/Cluster.md
+++ b/docs/manual/scala/guide/cluster/Cluster.md
@@ -40,25 +40,74 @@ A service instance joins a cluster when the service starts up.
 
 In development you are typically only running the service on one cluster node. No explicit joining is necessary; the [[Lagom Development Environment|DevEnvironment]] handles it automatically.
 
+
 ### Joining during production
 
-Starting from version 1.5.0, Lagom offers support for [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/current/bootstrap/). Akka Cluster Bootstrap is enabled by default in production mode and disabled in development and test mode.
+Starting from version 1.5.0, Lagom offers support for [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/). Akka Cluster Bootstrap is enabled by default in production mode and disabled in development and test mode.
 
-Akka Cluster Bootstrap helps forming (or joining to) a cluster by using [Akka Discovery](https://doc.akka.io/docs/akka/current/discovery/index.html) to discover peer nodes. It is an alternative to configuring static seed-nodes in dynamic deployment environments such as on Kubernetes or AWS.
+Akka Cluster Bootstrap helps forming (or joining to) a cluster by using [Akka Discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html) to discover peer nodes. It is an alternative to configuring static seed-nodes in dynamic deployment environments such as on Kubernetes or AWS.
 
 It builds on the flexibility of Akka Discovery, leveraging a range of discovery mechanisms depending on the environment you want to run your cluster in.
 
+Akka Cluster Bootstrap, in Lagom, can be disabled though property `lagom.cluster.bootstrap.enabled = false`. Note that this configuration flag has no effect if you declare seed-nodes explicitly in which case Akka Cluster Bootstrap won't be used.
+
+#### Akka Discovery
+
+In order to find the peer nodes and form a cluster, Akka Cluster Bootstrap need to be configured to use one of the existing Akka Discovery implementations.
+
+The snippet bellow explifies how to configure the Akka Cluster Boostrap to use the Akka Discovery Kubernetes API.
+
+```
+akka.management.cluster.bootstrap {
+  # example using kubernetes-api
+  contact-point-discovery {
+    discovery-method = kubernetes-api
+    service-name = "hello-lagom"
+  }
+}
+```
+Other existing implementations are: DNS, AWS, Consul, Marathon API and static Configuration. It's also possible to implement your own Akka Discovery implementation if needed.
+
+For more detailed and advanced configurations options, please consult the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) documentation and its [reference.conf](https://github.com/akka/akka-management/blob/v1.0.0-RC2/cluster-bootstrap/src/main/resources/reference.conf) file.
+
+
+#### Clustter Http Management
+
+[Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html) to form a cluster.
+
+Akka Management Cluster HTTP is a [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) extension that allows interaction with an akka-cluster through an HTTP interface. This management extension exposes different operations to manage nodes in a cluster (by default only read-only operations are exposed) as well as health checks based on the cluster state.
+
+Therefore, Akka Management will also be enabled and will run on http port `8558`. You can configured it to another port by setting property `akka.management.http.port` in your `application.conf` file.
+
+#### Health Checks
+
+Akka Management supports two kinds of [health checks](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/healthchecks.html):
+
+  * Readiness checks: should the application receive external traffic, for example waiting for the cluster to form.
+  * Liveness checks: should the application be left running
+
+Readiness checks can be used to decide if a load balancer should route traffic where as liveness checks can be used in environments which can restart a hung process.
+
+By default, Lagom enables the Cluster Health Check. This health check includes a readiness check that returns `true` when the node is either `Up` or `WeaklyUp`.
+
+All readiness checks are hosted on `/ready` and liveness checks are hosted on `/alive` on the Akka Management endpoint (port 8558 by default). You can change the paths by configuring it your `application.conf` file:
+
+```
+akka.management.health-checks {
+  readiness-path = "health/ready"
+  liveness-path = "health/alive"
+}
+```
+For further information on Akka Cluster Bootstrap and Health Checks, consult Akka Managment documentation:
+ * [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/)
+ * [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html)
+ * [Health Checks](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/healthchecks.html)
+
 ### Manual Cluster Formation
 
-If you prefer to not use **Akka Cluster Bootstrap** and handle the cluster formation yourself, you can disable it in your `application.conf` file and configure the Akka Cluster seed nodes statically.
+If you prefer to not use **Akka Cluster Bootstrap** and handle the cluster formation yourself, you can configure the Akka Cluster seed nodes statically.
 
-First, disable the cluster bootstrap:
-
-```
-lagom.cluster.bootstrap.enabled = false
-```
-
-Then, define some initial contact points of the cluster, so-called seed nodes in your `application.conf`:
+You can define some initial contact points of the cluster, so-called seed nodes in your `application.conf`:
 
 ```
 akka.cluster.seed-nodes = [

--- a/docs/manual/scala/guide/cluster/Cluster.md
+++ b/docs/manual/scala/guide/cluster/Cluster.md
@@ -36,15 +36,6 @@ You could imagine using cluster features across different services, but we recom
 
 A service instance joins a cluster when the service starts up.
 
-### Joining during development
-
-In development you are typically only running the service on one cluster node. No explicit joining is necessary; the [[Lagom Development Environment|DevEnvironment]] handles it automatically.
-
-
-## Joining
-
-A service instance joins a cluster when the service starts up.
-
 1. **Joining during development**:  In development you are typically only running the service on one cluster node. No explicit joining is necessary; the [[Lagom Development Environment|DevEnvironment]] handles it automatically and creates a single-node cluster.
 
 1. **Joining during production**: There are several mechanisms available to create a cluster in production. This documentation covers the two recommended approaches:
@@ -81,14 +72,11 @@ akka.management.cluster.bootstrap {
 [Other existing implementations](https://developer.lightbend.com/docs/akka-management/current/discovery/index.html) are: DNS, AWS, Consul, Marathon API and static Configuration. It's also possible to implement your own Akka Discovery implementation if needed.
 For more detailed and advanced configurations options, please consult the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) documentation and its [reference.conf](https://github.com/akka/akka-management/blob/v1.0.0-RC2/cluster-bootstrap/src/main/resources/reference.conf) file.
 
+#### Akka Management
 
-#### Cluster Http Management
+[Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) to form a cluster.
 
-[Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html) to form a cluster.
-
-Akka Management Cluster HTTP is an [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) extension that allows interaction with an akka-cluster through an HTTP interface. This management extension exposes different operations to manage nodes in a cluster (by default only read-only operations are exposed) as well as health checks based on the cluster state.
-
-Therefore, Akka Management will also be enabled and will run on http port `8558`. You can configured it to another port by setting property `akka.management.http.port` in your `application.conf` file.
+[Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) is an extension that opens a dedicated HTTP interface. This management extension allows dedicated plugins to include their routes. Akka Cluster Bootstrap uses this mechanism to expose a route. Akka Management will be enabled when the cluster joining mechanism is Cluster Http Management and it will run on http port `8558`. You can configure it to another port by setting property `akka.management.http.port` in your `application.conf` file.
 
 #### Health Checks
 

--- a/docs/manual/scala/guide/cluster/Cluster.md
+++ b/docs/manual/scala/guide/cluster/Cluster.md
@@ -49,13 +49,13 @@ Akka Cluster Bootstrap helps forming (or joining to) a cluster by using [Akka Di
 
 It builds on the flexibility of Akka Discovery, leveraging a range of discovery mechanisms depending on the environment you want to run your cluster in.
 
-Akka Cluster Bootstrap, in Lagom, can be disabled though property `lagom.cluster.bootstrap.enabled = false`. Note that this configuration flag has no effect if you declare seed-nodes explicitly in which case Akka Cluster Bootstrap won't be used.
+Akka Cluster Bootstrap, in Lagom, can be disabled through the property `lagom.cluster.bootstrap.enabled = false`. Note that this configuration flag has no effect if you declare seed-nodes explicitly in which case Akka Cluster Bootstrap won't be used.
 
 #### Akka Discovery
 
 In order to find the peer nodes and form a cluster, Akka Cluster Bootstrap need to be configured to use one of the existing Akka Discovery implementations.
 
-The snippet bellow explifies how to configure the Akka Cluster Boostrap to use the Akka Discovery Kubernetes API.
+The snippet below exemplifies how to configure the Akka Cluster Boostrap to use the Akka Discovery Kubernetes API.
 
 ```
 akka.management.cluster.bootstrap {
@@ -66,8 +66,7 @@ akka.management.cluster.bootstrap {
   }
 }
 ```
-Other existing implementations are: DNS, AWS, Consul, Marathon API and static Configuration. It's also possible to implement your own Akka Discovery implementation if needed.
-
+[Other existing implementations](https://developer.lightbend.com/docs/akka-management/current/discovery/index.html) are: DNS, AWS, Consul, Marathon API and static Configuration. It's also possible to implement your own Akka Discovery implementation if needed.
 For more detailed and advanced configurations options, please consult the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) documentation and its [reference.conf](https://github.com/akka/akka-management/blob/v1.0.0-RC2/cluster-bootstrap/src/main/resources/reference.conf) file.
 
 
@@ -75,7 +74,7 @@ For more detailed and advanced configurations options, please consult the [Akka 
 
 [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html) to form a cluster.
 
-Akka Management Cluster HTTP is a [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) extension that allows interaction with an akka-cluster through an HTTP interface. This management extension exposes different operations to manage nodes in a cluster (by default only read-only operations are exposed) as well as health checks based on the cluster state.
+Akka Management Cluster HTTP is an [Akka Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/akka-management.html) extension that allows interaction with an akka-cluster through an HTTP interface. This management extension exposes different operations to manage nodes in a cluster (by default only read-only operations are exposed) as well as health checks based on the cluster state.
 
 Therefore, Akka Management will also be enabled and will run on http port `8558`. You can configured it to another port by setting property `akka.management.http.port` in your `application.conf` file.
 

--- a/docs/manual/scala/guide/cluster/Cluster.md
+++ b/docs/manual/scala/guide/cluster/Cluster.md
@@ -71,7 +71,7 @@ Other existing implementations are: DNS, AWS, Consul, Marathon API and static Co
 For more detailed and advanced configurations options, please consult the [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) documentation and its [reference.conf](https://github.com/akka/akka-management/blob/v1.0.0-RC2/cluster-bootstrap/src/main/resources/reference.conf) file.
 
 
-#### Clustter Http Management
+#### Cluster Http Management
 
 [Akka Cluster Bootstrap](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/bootstrap/) relies on [Http Cluster Management](https://developer.lightbend.com/docs/akka-management/1.0.0-RC2/cluster-http-management.html) to form a cluster.
 

--- a/docs/manual/scala/releases/Migration15.md
+++ b/docs/manual/scala/releases/Migration15.md
@@ -49,11 +49,17 @@ If you are not using Kubernetes or DC/OS, you must configure your services in a 
 
 If you are using ConductR in production and need assistance migrating to other solutions please [contact Lightbend](https://www.lightbend.com/contact).
 
-
 ## Lightbend Orchestration
 
 TODO (new version required)
 
+## Cluster Formation
+
+A new mechanism to form and [[join an Akka Cluster|Cluster#Joining]] is introduced in Lagom 1.5. Apart from the original `Manual Cluster Formation` the new `Akka Cluster Bootstrap` is now supported. This new mechanism is introduced with lower precedence than `Manual Cluster Formation` so if you rely on the use of a list of `seed-nodes` then everything will work as before. On the other hand, `Akka Cluster Bootstrap` takes precedence over the `join-self` cluster formation for single-node clusters. If you use single-node clusters via `join-self` you will have to explicitly disable `Akka Cluster Bootstrap`:
+
+```
+lagom.cluster.bootstrap.enabled = false
+```
 
 ## Upgrading a production system
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -517,11 +517,13 @@ object Dependencies {
   val server = libraryDependencies ++= Nil
 
   val `server-javadsl` = libraryDependencies ++= Seq(
+    akkaManagement,
     slf4jApi,
     commonsLang
   )
 
   val `server-scaladsl` = libraryDependencies ++= Seq(
+    akkaManagement,
     slf4jApi,
     scalaTest % Test
   )

--- a/service/core/server/src/main/resources/reference.conf
+++ b/service/core/server/src/main/resources/reference.conf
@@ -1,0 +1,4 @@
+# Enables Health Checks routes. When combined with Akka Cluster Bootstrap,
+# this will add the readiness check `akka.management.cluster.scaladsl.ClusterMembershipCheck`
+# that returns true when node is either Up or WeaklyUp
+akka.management.http.route-providers += "akka.management.HealthCheckRoutes"

--- a/service/javadsl/server/src/main/resources/reference.conf
+++ b/service/javadsl/server/src/main/resources/reference.conf
@@ -4,3 +4,12 @@ lagom.status-endpoint.enabled = on
 lagom.tools.service-discovery=com.lightbend.lagom.internal.javadsl.server.JavadslServiceDiscovery
 
 play.modules.enabled += com.lightbend.lagom.internal.javadsl.server.ServerModule
+
+
+## By default, any Lagom service exposes the Akka Management HTTP endpoints
+play.modules.enabled += com.lightbend.lagom.internal.javadsl.server.AkkaManagementModule
+
+# Enables Health Checks routes. When combined with Akka Cluster Bootstrap,
+# this will add the readiness check `akka.management.cluster.scaladsl.ClusterMembershipCheck`
+# that returns true when node is either Up or WeaklyUp
+akka.management.http.route-providers += "akka.management.HealthCheckRoutes"

--- a/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/AkkaManagementModule.scala
+++ b/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/AkkaManagementModule.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.javadsl.server
+
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.management.scaladsl.AkkaManagement
+import javax.inject.{ Inject, Provider, Singleton }
+import play.api.inject.{ Binding, Module }
+import play.api.{ Configuration, Environment }
+
+class AkkaManagementModule extends Module {
+
+  override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
+    bind[AkkaManagement].toProvider[AkkaManagementProvider].eagerly()
+  )
+
+}
+
+@Singleton
+class AkkaManagementProvider @Inject() (system: ActorSystem) extends Provider[AkkaManagement] {
+  override def get(): AkkaManagement = {
+    val akkaManagement = AkkaManagement(system.asInstanceOf[ExtendedActorSystem])
+    akkaManagement.start()
+    akkaManagement
+  }
+}

--- a/service/scaladsl/server/src/main/resources/reference.conf
+++ b/service/scaladsl/server/src/main/resources/reference.conf
@@ -1,0 +1,5 @@
+
+# Enables Health Checks routes. When combined with Akka Cluster Bootstrap,
+# this will add the readiness check `akka.management.cluster.scaladsl.ClusterMembershipCheck`
+# that returns true when node is either Up or WeaklyUp
+akka.management.http.route-providers += "akka.management.HealthCheckRoutes"

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/AkkaManagementComponents.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/AkkaManagementComponents.scala
@@ -1,0 +1,12 @@
+package com.lightbend.lagom.scaladsl.server
+
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.management.scaladsl.AkkaManagement
+
+trait AkkaManagementComponents {
+
+  def actorSystem: ActorSystem
+
+  AkkaManagement(actorSystem.asInstanceOf[ExtendedActorSystem]).start()
+
+}

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -230,7 +230,8 @@ abstract class LagomApplication(context: LagomApplicationContext)
   with ProvidesJsonSerializerRegistry
   with LagomServerComponents
   with LagomServiceClientComponents
-  with LagomConfigComponent {
+  with LagomConfigComponent
+  with AkkaManagementComponents {
 
   override val httpFilters: Seq[EssentialFilter] = Nil
 


### PR DESCRIPTION
This PR is built on top of https://github.com/lagom/lagom/pull/1738 and https://github.com/lagom/lagom/pull/1725
to enable Akka HTTP Management by default. This also will expose HealthCheck routes by default which allows the 
user  and library providers to add their health checks.

Other routes:

 * when cluster is available, cluster HTTP management routs will be exposed
 * when cluster is available, cluster bootstrap routes will be exposed (even if the mechanism to form the cluster is not Akka Bootstrap)
 * when cluster is available, cluster membership health cheks will be registered in thhe health check mechanism

TODO:

- [ ] review docs inherited from #1738 
- [ ] support multiple akka HTTP management servers during dev mode (randomize port bound + publish on service locator) - 
- [ ] `scripted` tests for dev mode

 NOTE: This is a separate PR (not part of https://github.com/lagom/lagom/pull/1738) to avoid polluting the work there.