### PR TITLE
Enables akka-management by default in Prod

### DIFF
--- a/akka-management/core/src/main/resources/reference.conf
+++ b/akka-management/core/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
 # To disable Akka Management HTTP set `lagom.akka.management.enabled` to `off`. This flag
 # will be ignored if Cluster Bootstrap is enabled, in which case the Akka HTTP Management
 # server will be forced to start
-lagom.akka.management.enabled = off
+lagom.akka.management.enabled = on


### PR DESCRIPTION
In a hurry to get this ready last week, I added it by default to `off`. It should be `on`.