### PR TITLE
Migration from LBO to manual deployment

### DIFF
--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -78,19 +78,23 @@ ConductR tooling and Lightbend Orchestration handled all the required pieces to 
 
 In particular, ConductR tooling and Lightbend Orchestration handled some or all of the following:
 
-1. extend the your application with: cluster bootstrapping, akka management and health checks
+1. extending the application with: cluster bootstrapping, akka management and health checks
 2. Service Location
-3. setup and produce docker images
-4. prepare the deployment specs for the target orchestrator
+3. setting up and producing docker images
+4. preparing the deployment specs for the target orchestrator
 5. Secrets
 
 #### Application extensions
 
-Starting with Lagom 1.5 your application will include [[Akka management HTTP|Cluster#Akka-Management]] out of the box with [[health checks|Cluster#Health-Checks]] enabled by default. Cluster formation also supports [[Cluster Bootstrapping|Cluster#Joining-during-production-(Akka-Cluster-Bootstrap)]] as a new way to form a cluster. These new defaults may require at least two changes on your codebase. First, if you want to opt-in to cluster bootstrapping you must make sure you don't set `seed-nodes`. Second, if you use Cluster Bootstrapping, you will have to setup a [[discovery|Cluster#Akka-Discovery]] mechanism (see the [[reference guide|Cluster#Akka-Discovery]] for more details). 
+Starting with Lagom 1.5 your application will include [[Akka management HTTP|Cluster#Akka-Management]] out of the box with [[health checks|Cluster#Health-Checks]] enabled by default.  Akka management HTTP is a supporting tool for health checks, cluster bootstrap and a few other new features in Lagom 1.5. 
+
+Cluster formation now also supports [[Cluster Bootstrapping|Cluster#Joining-during-production-(Akka-Cluster-Bootstrap)]] as a new way to form a cluster. 
+
+These new defaults may require at least two changes on your codebase. First, if you want to opt-in to cluster bootstrapping you must make sure you don't set `seed-nodes`. `seed-nodes` always takes precedence over any other cluster formation mechanism. Second, if you use Cluster Bootstrapping, you will have to setup a [discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html) mechanism (see the [[Lagom Cluster reference guide|Cluster#Akka-Discovery]] for more details). 
 
 #### Service Location
 
-You will have to add a `ServiceLocator `of your choice. We recommend using the new [`lagom-akka-discovery-service-locator`](https://github.com/lagom/lagom-akka-discovery-service-locator) which is implemented using [Akka Service Discovery](https://doc.akka.io/docs/akka/current/discovery/index.html) implementations.
+You no longer have a `ServiceLocator `provided by the tooling libraries so you will have to provide one of your choice. We recommend using the new [`lagom-akka-discovery-service-locator`](https://github.com/lagom/lagom-akka-discovery-service-locator) which is implemented using [Akka Service Discovery](https://doc.akka.io/docs/akka/current/discovery/index.html) implementations.
 
 Read the [docs](https://github.com/lagom/lagom-akka-discovery-service-locator) of the new `lagom-akka-discovery-service-locator` for details on how to setup the Akka Service Discovery [method](https://doc.akka.io/docs/akka/current/discovery/index.html). For example, 
 
@@ -104,7 +108,7 @@ akka {
 
 #### Docker images and deployment specs
 
-Regarding docker images and deployment specs, once you remove external tooling you will have to setup and maintain them manually. Instead of producing the `Dockerfile`, deployment scripts produced by tooling and orchestration specs from scratch, use the tooling to create these files and add them to git. You can later review and maintain them at will.
+With the removal of ConductR or Lightbend Orchestration, the docker images and deployment specs will have to be maintained manually. Therefore the recommended migration is to take ownership of the `Dockerfile`, deployment scripts and orchestration specs created by such tooling, such as by committing them to the source repository and then maintaining them.  We also found that such maintenance can be made easier by making use of [kustomize](https://github.com/kubernetes-sigs/kustomize).
 
 For example, using `docker:stage` on your project you will generate `<project-name>/target/docker/stage/Dockerfile` and other files required to build the image. You may use these files directly or have them as a guide to tune the `sbt-native-packager` plugin to produce a similar `Dockerfile`.
 

--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -46,6 +46,18 @@ were never intended for public consumption, and therefore have been marked depre
 
 Lagom in both [[dev mode|ConfiguringServicesInDevelopment#Using-HTTPS-in-development-mode]] and [[tests|Test#How-to-use-TLS-on-tests]] supports basic usage of TLS by means of self-signed certificates provided by the framework.
 
+## Cluster Formation
+
+A new mechanism to form and [[join an Akka Cluster|Cluster#Joining]] is introduced in Lagom 1.5. Apart from the original `Manual Cluster Formation` the new `Akka Cluster Bootstrap` is now supported. This new mechanism is introduced with lower precedence than `Manual Cluster Formation` so if you rely on the use of a list of `seed-nodes` then everything will work as before. On the other hand, `Akka Cluster Bootstrap` takes precedence over the `join-self` cluster formation for single-node clusters. If you use single-node clusters via `join-self` you will have to explicitly disable `Akka Cluster Bootstrap`:
+
+```
+lagom.cluster.bootstrap.enabled = false
+```
+
+## Service Discovery
+
+When opting in to Akka Cluster Bootstrapping as a mechanism for Cluster formation you will have to setup a [[Service Discovery|Cluster#Akka-Discovery]]  method for nodes to locate each other.
+
 ## ConductR
 
 ConductR is no longer supported with Lagom 1.5.
@@ -64,13 +76,33 @@ See Deployment below.
 
 ConductR tooling and Lightbend Orchestration handled all the required pieces to deploy on ConductR and Kubernetes or DC/OS. Lagom 1.5.0 only supports a manually maintained deployment process.
 
-In particular, ConductR tooling and Lightbend Orchestration handled the following:
+In particular, ConductR tooling and Lightbend Orchestration handled some or all of the following:
 
-1. extend the your application with: cluster bootstrapping, service location, akka management and health checks
-2. setup and produce docker images
-3. prepare the deployment specs for the target orchestrator
+1. extend the your application with: cluster bootstrapping, akka management and health checks
+2. Service Location
+3. setup and produce docker images
+4. prepare the deployment specs for the target orchestrator
+5. Secrets
 
-Regarding `1.`, starting with Lagom 1.5 your application will include [[Akka management HTTP|Cluster#Akka-Management]] out of the box with [[health checks|Cluster#Health-Checks]] enabled by default. Cluster formation also supports [[Cluster Bootstrapping|Cluster#Joining-during-production-(Akka-Cluster-Bootstrap)]] as a new way to form a cluster. These new defaults may require at least two changes on your codebase. First, if you want to opt-in to cluster bootstrapping you must make sure you don't set `seed-nodes`. Second, if you use Cluster Bootstrapping, you will have to setup a [[discovery|Cluster#Akka-Discovery]] mechanism (see the [[reference guide|Cluster#Akka-Discovery]] for more details).
+#### Application extensions
+
+Starting with Lagom 1.5 your application will include [[Akka management HTTP|Cluster#Akka-Management]] out of the box with [[health checks|Cluster#Health-Checks]] enabled by default. Cluster formation also supports [[Cluster Bootstrapping|Cluster#Joining-during-production-(Akka-Cluster-Bootstrap)]] as a new way to form a cluster. These new defaults may require at least two changes on your codebase. First, if you want to opt-in to cluster bootstrapping you must make sure you don't set `seed-nodes`. Second, if you use Cluster Bootstrapping, you will have to setup a [[discovery|Cluster#Akka-Discovery]] mechanism (see the [[reference guide|Cluster#Akka-Discovery]] for more details). 
+
+#### Service Location
+
+You will have to add a `ServiceLocator `of your choice. We recommend using the new [`lagom-akka-discovery-service-locator`](https://github.com/lagom/lagom-akka-discovery-service-locator) which is implemented using [Akka Service Discovery](https://doc.akka.io/docs/akka/current/discovery/index.html) implementations.
+
+Read the [docs](https://github.com/lagom/lagom-akka-discovery-service-locator) of the new `lagom-akka-discovery-service-locator` for details on how to setup the Akka Service Discovery [method](https://doc.akka.io/docs/akka/current/discovery/index.html). For example, 
+
+```
+akka {
+  discovery {
+   method = akka-dns
+  }
+}
+```
+
+#### Docker images and deployment specs
 
 Regarding docker images and deployment specs, once you remove external tooling you will have to setup and maintain them manually. Instead of producing the `Dockerfile`, deployment scripts produced by tooling and orchestration specs from scratch, use the tooling to create these files and add them to git. You can later review and maintain them at will.
 
@@ -78,17 +110,15 @@ For example, using `docker:stage` on your project you will generate `<project-na
 
 Similarly, with a docker image produced with Lightbend Orchestration still enabled, you may use `rp generate-kubernetes-resources …` to produce Kubernetes YAML files that you can keep under SCM.
 
-### Cluster Formation
+#### Secrets
 
-A new mechanism to form and [[join an Akka Cluster|Cluster#Joining]] is introduced in Lagom 1.5. Apart from the original `Manual Cluster Formation` the new `Akka Cluster Bootstrap` is now supported. This new mechanism is introduced with lower precedence than `Manual Cluster Formation` so if you rely on the use of a list of `seed-nodes` then everything will work as before. On the other hand, `Akka Cluster Bootstrap` takes precedence over the `join-self` cluster formation for single-node clusters. If you use single-node clusters via `join-self` you will have to explicitly disable `Akka Cluster Bootstrap`:
+Lightbend Orchestration supported declaring [secrets](https://developer.lightbend.com/docs/lightbend-orchestration/current/features/secrets.html) on `build.sbt`  which user's code could then read from a file in the pod. Starting from Lagom 1.5 there is no specific support for secrets and the recommendation is to use the default option suggested by each target orchestrator. For example, when deploying to Kubernetes or OpenShift [declare the secret as an environment variable](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables) on your `Deployment` and inject the environment variable in your `application.conf`. For example:
 
 ```
-lagom.cluster.bootstrap.enabled = false
+my-database {
+  password = "${DB_PASSWORD}"
+}
 ```
-
-### Service Discovery
-
-When opting in to Akka Cluster Bootstrapping as a mechanism for Cluster formation you will have to setup a [[Service Discovery|Cluster#Akka-Discovery]]  method for nodes to locate each other.
 
 ## Upgrading a production system
 

--- a/docs/manual/scala/releases/Migration15.md
+++ b/docs/manual/scala/releases/Migration15.md
@@ -70,19 +70,25 @@ ConductR tooling and Lightbend Orchestration handled all the required pieces to 
 
 In particular, ConductR tooling and Lightbend Orchestration handled some or all of the following:
 
-1. extend the your application with: cluster bootstrapping, akka management and health checks
+1. extending the application with: cluster bootstrapping, akka management and health checks
 2. Service Location
-3. setup and produce docker images
-4. prepare the deployment specs for the target orchestrator
+3. setting up and producing docker images
+4. preparing the deployment specs for the target orchestrator
 5. Secrets
 
 #### Application extensions
 
-Starting with Lagom 1.5 your application will include [[Akka management HTTP|Cluster#Akka-Management]] out of the box with [[health checks|Cluster#Health-Checks]] enabled by default. Cluster formation also supports [[Cluster Bootstrapping|Cluster#Joining-during-production-(Akka-Cluster-Bootstrap)]] as a new way to form a cluster. These new defaults may require at least two changes on your codebase. First, if you want to opt-in to cluster bootstrapping you must make sure you don't set `seed-nodes`. Second, if you use Cluster Bootstrapping, you will have to setup a [[discovery|Cluster#Akka-Discovery]] mechanism (see the [[reference guide|Cluster#Akka-Discovery]] for more details). 
+Starting with Lagom 1.5 your application will include [[Akka management HTTP|Cluster#Akka-Management]] out of the box with [[health checks|Cluster#Health-Checks]] enabled by default.  Akka management HTTP is a supporting tool for health checks, cluster bootstrap and a few other new features in Lagom 1.5. 
+
+Cluster formation now also supports [[Cluster Bootstrapping|Cluster#Joining-during-production-(Akka-Cluster-Bootstrap)]] as a new way to form a cluster. 
+
+These new defaults may require at least two changes on your codebase. First, if you want to opt-in to cluster bootstrapping you must make sure you don't set `seed-nodes`. `seed-nodes` always takes precedence over any other cluster formation mechanism. Second, if you use Cluster Bootstrapping, you will have to setup a [discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html) mechanism (see the [[Lagom Cluster reference guide|Cluster#Akka-Discovery]] for more details). 
 
 #### Service Location
 
-You will have to add a `ServiceLocator `of your choice. We recommend using the new [`lagom-akka-discovery-service-locator`](https://github.com/lagom/lagom-akka-discovery-service-locator) which is implemented using [Akka Service Discovery](https://doc.akka.io/docs/akka/current/discovery/index.html) implementations. This means you will have to change you `Loader` code:
+You no longer have a `ServiceLocator `provided by the tooling libraries so you will have to provide one of your choice. We recommend using the new [`lagom-akka-discovery-service-locator`](https://github.com/lagom/lagom-akka-discovery-service-locator) which is implemented using [Akka Service Discovery](https://doc.akka.io/docs/akka/current/discovery/index.html) implementations.
+
+This means you will have to change you `Loader` code:
 
 ```scala
 // before 
@@ -111,7 +117,7 @@ Read the [docs](https://github.com/lagom/lagom-akka-discovery-service-locator) o
 
 #### Docker images and deployment specs
 
-Regarding docker images and deployment specs, once you remove external tooling you will have to setup and maintain them manually. Instead of producing the `Dockerfile`, deployment scripts produced by tooling and orchestration specs from scratch, use the tooling to create these files and add them to git. You can later review and maintain them at will.
+With the removal of ConductR or Lightbend Orchestration, the docker images and deployment specs will have to be maintained manually. Therefore the recommended migration is to take ownership of the `Dockerfile`, deployment scripts and orchestration specs created by such tooling, such as by committing them to the source repository and then maintaining them.  We also found that such maintenance can be made easier by making use of [kustomize](https://github.com/kubernetes-sigs/kustomize).
 
 For example, using `docker:stage` on your project you will generate `<project-name>/target/docker/stage/Dockerfile` and other files required to build the image. You may use these files directly or have them as a guide to tune the `sbt-native-packager` plugin to produce a similar `Dockerfile`.
 

--- a/docs/manual/scala/releases/Migration15.md
+++ b/docs/manual/scala/releases/Migration15.md
@@ -42,19 +42,35 @@ Lagom in both [[dev mode|ConfiguringServicesInDevelopment#Using-HTTPS-in-develop
 
 ConductR is no longer supported with Lagom 1.5.
 
-We recommend migrating to Kubernetes, DC/OS or another deployment solution before upgrading.
+We recommend migrating to Kubernetes, DC/OS or another deployment solution before upgrading. If you are using ConductR in production and need assistance migrating to other solutions please [contact Lightbend](https://www.lightbend.com/contact).
 
-[Lighbend Orchestration](https://developer.lightbend.com/docs/lightbend-orchestration/current/) is an open-source suite of tools that helps you deploy Lagom services to Kubernetes and DC/OS. It provides an easy way to create Docker images for your applications and introduces an automated process for generating Kubernetes and DC/OS resource and configuration files for you from those images. This process helps reduce the friction between development and operations. If you are using Kubernetes or DC/OS, or interested in trying one of these platforms, we encourage you to read the Lightbend Orchestration documentation to understand how to use it with Lagom and other components of the [Lightbend Reactive Platform](https://www.lightbend.com/products/reactive-platform).
-
-If you are not using Kubernetes or DC/OS, you must configure your services in a way that suits your production environment. See [[Running Lagom in production|ProductionOverview]] for more information.
-
-If you are using ConductR in production and need assistance migrating to other solutions please [contact Lightbend](https://www.lightbend.com/contact).
+See Deployment below.
 
 ## Lightbend Orchestration
 
-TODO (new version required)
+[Lightbend Orchestration](https://developer.lightbend.com/docs/lightbend-orchestration/current/) is not supported with Lagom 1.5. If you used Lightbend Orchestration for your deployment you will have to migrate to a manual process. This migration may happen on the same commit where you upgrade to Lagom 1.5.0 or you can upgrade your deployment process on a first step (still using Lagom 1.4.x) and later upgrade to Lagom 1.5.0.
 
-## Cluster Formation
+See Deployment below.
+
+## Deployment
+
+ConductR tooling and Lightbend Orchestration handled all the required pieces to deploy on ConductR and Kubernetes or DC/OS. Lagom 1.5.0 only supports a manually maintained deployment process.
+
+In particular, ConductR tooling and Lightbend Orchestration handled the following:
+
+1. extend the your application with: cluster bootstrapping, service location, akka management and health checks
+2. setup and produce docker images
+3. prepare the deployment specs for the target orchestrator
+
+Regarding `1.`, starting with Lagom 1.5 your application will include [[Akka management HTTP|Cluster#Akka-Management]] out of the box with [[health checks|Cluster#Health-Checks]] enabled by default. Cluster formation also supports [[Cluster Bootstrapping|Cluster#Joining-during-production-(Akka-Cluster-Bootstrap)]] as a new way to form a cluster. These new defaults may require at least two changes on your codebase. First, if you want to opt-in to cluster bootstrapping you must make sure you don't set `seed-nodes`. Second, if you use Cluster Bootstrapping, you will have to setup a [[discovery|Cluster#Akka-Discovery]] mechanism (see the [[reference guide|Cluster#Akka-Discovery]] for more details).
+
+Regarding docker images and deployment specs, once you remove external tooling you will have to setup and maintain them manually. Instead of producing the `Dockerfile`, deployment scripts produced by tooling and orchestration specs from scratch, use the tooling to create these files and add them to git. You can later review and maintain them at will.
+
+For example, using `docker:stage` on your project you will generate `<project-name>/target/docker/stage/Dockerfile` and other files required to build the image. You may use these files directly or have them as a guide to tune the `sbt-native-packager` plugin to produce a similar `Dockerfile`.
+
+Similarly, with a docker image produced with Lightbend Orchestration still enabled, you may use `rp generate-kubernetes-resources …` to produce Kubernetes YAML files that you can keep under SCM.
+
+### Cluster Formation
 
 A new mechanism to form and [[join an Akka Cluster|Cluster#Joining]] is introduced in Lagom 1.5. Apart from the original `Manual Cluster Formation` the new `Akka Cluster Bootstrap` is now supported. This new mechanism is introduced with lower precedence than `Manual Cluster Formation` so if you rely on the use of a list of `seed-nodes` then everything will work as before. On the other hand, `Akka Cluster Bootstrap` takes precedence over the `join-self` cluster formation for single-node clusters. If you use single-node clusters via `join-self` you will have to explicitly disable `Akka Cluster Bootstrap`:
 
@@ -62,7 +78,11 @@ A new mechanism to form and [[join an Akka Cluster|Cluster#Joining]] is introduc
 lagom.cluster.bootstrap.enabled = false
 ```
 
-## Upgrading a production system
+### Service Discovery
+
+When opting in to Akka Cluster Bootstrapping as a mechanism for Cluster formation you will have to setup a [[Service Discovery|Cluster#Akka-Discovery]]  method for nodes to locate each other.
+
+##Upgrading a production system
 
 TODO
 


### PR DESCRIPTION
Moving away from LBO: produce reference guide content and link from the Migration15.md 
  - [x] cluster bootstrap mechanisms
  - [x] health checks
  - [x] Lagom 1.5 won't work with LBO
  - [x] inter-service discovery (akka-discovery-service-locator)
  - [x] secret management
