### PR TITLE
Bumps maven-core to bump transitive deps

### DIFF
--- a/docs/manual/java/gettingstarted/JavaPrereqs.md
+++ b/docs/manual/java/gettingstarted/JavaPrereqs.md
@@ -46,7 +46,7 @@ If you do not have the correct JDK, download it from the  [Oracle website](http:
 
 ## Maven
 
-Lagom requires Maven 3.5.4 or higher, we recommend that you use at least Maven 3.3. In addition to verifying the version on the command line, check that your IDE is using the correct version.
+Lagom requires Maven 3.5.4 or higher, we recommend that you use at least Maven 3.6. In addition to verifying the version on the command line, check that your IDE is using the correct version.
 
 To check the Maven version from a command line, enter:
 

--- a/docs/manual/java/gettingstarted/JavaPrereqs.md
+++ b/docs/manual/java/gettingstarted/JavaPrereqs.md
@@ -46,7 +46,7 @@ If you do not have the correct JDK, download it from the  [Oracle website](http:
 
 ## Maven
 
-Lagom requires Maven 3.5.4 or higher, we recommend that you use at least Maven 3.6. In addition to verifying the version on the command line, check that your IDE is using the correct version.
+Lagom requires Maven 3.6.0 or higher. In addition to verifying the version on the command line, check that your IDE is using the correct version.
 
 To check the Maven version from a command line, enter:
 

--- a/docs/manual/java/gettingstarted/JavaPrereqs.md
+++ b/docs/manual/java/gettingstarted/JavaPrereqs.md
@@ -45,7 +45,8 @@ If you do not have the correct JDK, download it from the  [Oracle website](http:
 
 
 ## Maven
-Lagom requires Maven 3.2.1 or higher, we recommend that you use at least Maven 3.3. In addition to verifying the version on the command line, check that your IDE is using the correct version.
+
+Lagom requires Maven 3.5.4 or higher, we recommend that you use at least Maven 3.3. In addition to verifying the version on the command line, check that your IDE is using the correct version.
 
 To check the Maven version from a command line, enter:
 

--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -15,7 +15,7 @@ To migrate from Lagom 1.4 we recommend first migrating to latest version of Lago
 
 If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.5.0`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
 
-Lagom 1.5 requires, at least,  Maven `3.5.4`. Please update your environments.
+> **Note:** Lagom 1.5 requires, at least,  Maven `3.5.4`. Please update your environments.
 
 ### sbt
 

--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -15,6 +15,8 @@ To migrate from Lagom 1.4 we recommend first migrating to latest version of Lago
 
 If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.5.0`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
 
+Lagom 1.5 requires, at least,  Maven `3.5.4`. Please update your environments.
+
 ### sbt
 
 The version of Lagom can be updated by editing the `project/plugins.sbt` file, and updating the version of the Lagom sbt plugin. For example:

--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -15,7 +15,7 @@ To migrate from Lagom 1.4 we recommend first migrating to latest version of Lago
 
 If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.5.0`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
 
-> **Note:** Lagom 1.5 requires, at least,  Maven `3.5.4`. Please update your environments.
+> **Note:** Lagom 1.5 requires, at least,  Maven `3.6.0`. Please update your environments.
 
 ### sbt
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val JacksonDatatype = Jackson
     val JacksonDatabind = Jackson
     val Guava = "27.0-jre"
-    val Maven = "3.5.4"
+    val Maven = "3.6.0"
     val Netty = "4.1.32.Final"
     val NettyReactiveStreams = "2.0.0"
     val Kafka = "2.1.1"
@@ -899,6 +899,7 @@ object Dependencies {
       .exclude("org.apache.maven.wagon", "wagon-http-shared4")
       .exclude("org.apache.httpcomponents", "httpclient")
       .exclude("org.apache.httpcomponents", "httpcore"),
+    "org.apache.maven" % "maven-compat" % Versions.Maven,
     "org.apache.maven.wagon" % "wagon-file" % "2.10",
     "org.eclipse.aether" % "aether-connector-basic" % "1.0.2.v20150114",
     "org.eclipse.aether" % "aether-transport-wagon" % "1.0.2.v20150114",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val JacksonDatatype = Jackson
     val JacksonDatabind = Jackson
     val Guava = "27.0-jre"
-    val Maven = "3.6.0"
+    val Maven = "3.5.4"
     val Netty = "4.1.32.Final"
     val NettyReactiveStreams = "2.0.0"
     val Kafka = "2.1.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -40,7 +40,7 @@ object Dependencies {
     val JacksonDatatype = Jackson
     val JacksonDatabind = Jackson
     val Guava = "27.0-jre"
-    val Maven = "3.3.9"
+    val Maven = "3.6.0"
     val Netty = "4.1.32.Final"
     val NettyReactiveStreams = "2.0.0"
     val Kafka = "2.1.1"


### PR DESCRIPTION
I'm not sure what the impact of this bump can be. /cc @jroper

The purpose of this change is to bump some transitive dependencies which are messing up with some 3rd party security analisys (whitesource)