### PR TITLE
Support for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ jobs:
       name: "Run tests for Scala 2.12"
     - script: bin/test-documentation
       name: "Documentation validations and tests"
+
     - stage: test-build-tools
       script: bin/test-sbt-0.13
       name: "Scripted tests for sbt 0.13"
@@ -30,10 +31,29 @@ jobs:
       name: "Scripted tests for sbt 1"
     - script: bin/test-maven
       name: "PublishM2 and test Maven"
+
     - stage: java-11
-      script: bin/test-2.12
+      script: bin/test-code-style
       env: TRAVIS_JDK=adopt@1.11.0-1
-      name: "Run tests for Scala 2.12 and Java 11"
+      name: "Code validations (format, binary compatibilty, whitesource, etc.)"
+    - script: bin/test-2.11
+      env: TRAVIS_JDK=adopt@1.11.0-1
+      name: "Run tests for Scala 2.11"
+    - script: bin/test-2.12
+      env: TRAVIS_JDK=adopt@1.11.0-1
+      name: "Run tests for Scala 2.12"
+    - script: bin/test-documentation
+      env: TRAVIS_JDK=adopt@1.11.0-1
+      name: "Documentation validations and tests"
+    - script: bin/test-sbt-0.13
+      env: TRAVIS_JDK=adopt@1.11.0-1
+      name: "Scripted tests for sbt 0.13"
+    - script: bin/test-sbt-1.0
+      env: TRAVIS_JDK=adopt@1.11.0-1
+      name: "Scripted tests for sbt 1"
+    - script: bin/test-maven
+      env: TRAVIS_JDK=adopt@1.11.0-1
+      name: "PublishM2 and test Maven"
 
 before_install:
   # See https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-239493916

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,6 @@ jobs:
       env: TRAVIS_JDK=adopt@1.11.0-1
       name: "Run tests for Scala 2.12 and Java 11"
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: TRAVIS_JDK=adopt@1.11.0-1 # not fully supported but allows problem discovery
-
 before_install:
   # See https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-239493916
   - rm ~/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,11 @@ env:
     # the following `secure` is WHITESOURCE_PASSWORD which is the same for all branches.
     - secure: "A4xDS51pB8ERJPR/a5Lui//E//1L9pJ9Eg1kcRm/OR2izg7rx7p8Wemfp9gRhz8trn1mIrXDSMSK9iwENsfIP1bc/6AgtTWKBPm9DKjG0HW3swFFMBzzd6gxmOi4JD8rOtVc62Cf4qnURz+hsPRcI5C8aAW1fNi/5x1Q3HcAMtxE8EdPR7tU6Ve8utieOFPpqNQMktcL1aFusu+QddO14ZpQ944uAg0YdRRYFMG9SCbTkNDLt66AHTF4rKyZfkbM1tadqvvDez7Uo2eGK+KoQxTyrjct8W4Gqh+obOTyj1ngaPZEKvgbIJowFCrBzY5W+oNl6S+qa6PyAwq1MWKFqyUZt4P9fk3N9MDOYvuaS+YJCQd3VS4qCL9MEWahXNc3ZT+m8u5HT5axuPy+2qiKL/wrGzAXd74K9gNKuZJD7s+79Pwn34ZEbNMZ13AxyF6QkavU+Xcr5tQNwwZ+8P+k5OGoVsJOqZ3J7M+igGDRZh0fD693Wdp+mfORQqIvJFKED4daJYgTLufwt4tBLUxPUvlUZOWZFPn8DSQqTE7vsE9VPdpKSXTv1MyHxeMTiAX+XPabEWoazB8/4rljkC/EPxAButPD+AtUatfa6fIXpyGxHIvX8CFa2UnOQe9YbTRnxqa8TYvyMsWNQn1Q1eQMkvXCetqoefW5hA0UHTU5Zy4="
   matrix:
-    - TRAVIS_JDK=adopt@1.8.192-12
+    - TRAVIS_JDK=adopt@1.11.0-1
 
 stages:
   - validations-and-test
   - test-build-tools
-  - java-11
 
 jobs:
   include:
@@ -30,29 +29,6 @@ jobs:
     - script: bin/test-sbt-1.0
       name: "Scripted tests for sbt 1"
     - script: bin/test-maven
-      name: "PublishM2 and test Maven"
-
-    - stage: java-11
-      script: bin/test-code-style
-      env: TRAVIS_JDK=adopt@1.11.0-1
-      name: "Code validations (format, binary compatibilty, whitesource, etc.)"
-    - script: bin/test-2.11
-      env: TRAVIS_JDK=adopt@1.11.0-1
-      name: "Run tests for Scala 2.11"
-    - script: bin/test-2.12
-      env: TRAVIS_JDK=adopt@1.11.0-1
-      name: "Run tests for Scala 2.12"
-    - script: bin/test-documentation
-      env: TRAVIS_JDK=adopt@1.11.0-1
-      name: "Documentation validations and tests"
-    - script: bin/test-sbt-0.13
-      env: TRAVIS_JDK=adopt@1.11.0-1
-      name: "Scripted tests for sbt 0.13"
-    - script: bin/test-sbt-1.0
-      env: TRAVIS_JDK=adopt@1.11.0-1
-      name: "Scripted tests for sbt 1"
-    - script: bin/test-maven
-      env: TRAVIS_JDK=adopt@1.11.0-1
       name: "PublishM2 and test Maven"
 
 before_install:

--- a/docs/manual/java/releases/Highlights15.md
+++ b/docs/manual/java/releases/Highlights15.md
@@ -27,3 +27,12 @@ Lagom 1.5 introduces support for cross-service gRPC communication. [gRPC](https:
 ## Deployment
 
 Neither ConductR not [Lightbend Orchestration](https://developer.lightbend.com/docs/lightbend-orchestration/current/) are supported in Lagom 1.5. See the [[Deployment|Migration15#Deployment]] section on the migration guide for more details.
+
+## Java 11 reflection fix
+
+Lagom 1.5.0 brings a [fix](lagom/lagom#1780) to the java reflection strategy Lagom uses to read the service
+descriptor, so that reflection works on JDK 11 (as well as JDK 9 and JDK 10).  We're happy to announce this fix
+in the Lagom 1.5.0 highlights and will be completing the necessary changes to fully support Java 11 in the next
+releases.
+
+[lagom/lagom#1780]: https://github.com/lagom/lagom/pull/1780

--- a/docs/manual/scala/releases/Highlights15.md
+++ b/docs/manual/scala/releases/Highlights15.md
@@ -27,3 +27,12 @@ Lagom 1.5 introduces support for cross-service gRPC communication. [gRPC](https:
 ## Deployment
 
 Neither ConductR not [Lightbend Orchestration](https://developer.lightbend.com/docs/lightbend-orchestration/current/) are supported in Lagom 1.5. See the [[Deployment|Migration15#Deployment]] section on the migration guide for more details.
+
+## Java 11 reflection fix
+
+Lagom 1.5.0 brings a [fix](lagom/lagom#1780) to the java reflection strategy Lagom uses to read the service
+descriptor, so that reflection works on JDK 11 (as well as JDK 9 and JDK 10).  We're happy to announce this fix
+in the Lagom 1.5.0 highlights and will be completing the necessary changes to fully support Java 11 in the next
+releases.
+
+[lagom/lagom#1780]: https://github.com/lagom/lagom/pull/1780

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistentEntityActorSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistentEntityActorSpec.scala
@@ -1,9 +1,0 @@
-/*
- * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
- */
-
-package com.lightbend.lagom.javadsl.persistence.cassandra
-
-import com.lightbend.lagom.javadsl.persistence.AbstractPersistentEntityActorSpec
-
-class CassandraPersistentEntityActorSpec extends CassandraPersistenceSpec with AbstractPersistentEntityActorSpec

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistentEntityActorSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistentEntityActorSpec.scala
@@ -1,9 +1,0 @@
-/*
- * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
- */
-
-package com.lightbend.lagom.scaladsl.persistence.cassandra
-
-import com.lightbend.lagom.scaladsl.persistence.{ AbstractPersistentEntityActorSpec, TestEntitySerializerRegistry }
-
-class CassandraPersistentEntityActorSpec extends CassandraPersistenceSpec(TestEntitySerializerRegistry) with AbstractPersistentEntityActorSpec

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -147,10 +147,10 @@ object Dependencies {
   private val playFileWatch = "com.lightbend.play" %% "play-file-watch" % Versions.PlayFileWatch excludeAll (excludeSlf4j: _*)
 
   private val pcollections = "org.pcollections" % "pcollections" % Versions.PCollections
-
+  private val jsr250 = "javax.annotation" % "jsr250-api" % "1.0"
   private val junit = "junit" % "junit" % Versions.JUnit
   private val commonsLang = "org.apache.commons" % "commons-lang3" % "3.8.1"
-
+  private val javaxAnnotationApi = "javax.annotation" % "javax.annotation-api" % "1.3.2"
   private val dropwizardMetricsCore = "io.dropwizard.metrics" % "metrics-core" % "3.2.6" excludeAll (excludeSlf4j: _*)
 
   private val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.11.0"
@@ -264,7 +264,7 @@ object Dependencies {
       "org.eclipse.jetty" % "jetty-xml" % Versions.jetty,
       "org.eclipse.jetty.websocket" % "websocket-common" % Versions.jetty,
       "org.eclipse.jetty.websocket" % "websocket-api" % Versions.jetty,
-
+      jsr250,
       "com.typesafe.play" %% "twirl-api" % Versions.Twirl,
       "com.typesafe.slick" %% "slick" % Versions.Slick,
       "com.typesafe.slick" %% "slick-hikaricp" % Versions.Slick,
@@ -306,7 +306,7 @@ object Dependencies {
       "org.typelevel" %% "macro-compat" % "1.1.1",
       "org.xerial.snappy" % "snappy-java" % "1.1.7.2",
       "tyrex" % "tyrex" % "1.0.1",
-
+      javaxAnnotationApi,
       "org.scala-lang.modules" %% "scala-collection-compat" % "0.1.1",
       "com.google.guava" % "failureaccess" % "1.0",
       "com.google.guava" % "listenablefuture" % "9999.0-empty-to-avoid-conflict-with-guava",
@@ -353,7 +353,7 @@ object Dependencies {
     "antlr" % "antlr" % "2.7.7",
     "com.fasterxml" % "classmate" % "1.3.4",
     "org.dom4j" % "dom4j" % "2.1.1",
-    "javax.annotation" % "jsr250-api" % "1.0",
+    jsr250,
     "javax.el" % "el-api" % "2.2",
     "javax.enterprise" % "cdi-api" % "1.1",
     "org.apache.geronimo.specs" % "geronimo-jta_1.1_spec" % "1.1.1",
@@ -515,7 +515,8 @@ object Dependencies {
   val `server-javadsl` = libraryDependencies ++= Seq(
     akkaManagement,
     slf4jApi,
-    commonsLang
+    commonsLang,
+    javaxAnnotationApi
   )
 
   val `server-scaladsl` = libraryDependencies ++= Seq(
@@ -734,6 +735,7 @@ object Dependencies {
 
   val `persistence-cassandra-javadsl` = libraryDependencies ++= Seq(
     junit % Test,
+    jsr250,
     // Upgrades needed to match whitelist
     cassandraDriverCore
   )

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -98,7 +98,6 @@ object UnidocRoot extends AutoPlugin {
     target in (ScalaUnidoc, unidoc) := target.value / "unidoc",
     scalacOptions in (ScalaUnidoc, unidoc) ++= Seq("-skip-packages", "com.lightbend.lagom.internal"),
     javacOptions in doc := Seq(
-      "-windowtitle", "Lagom Services API",
       // Adding a user agent when we run `javadoc` is necessary to create link docs
       // with Akka (at least, maybe play too) because doc.akka.io is served by Cloudflare
       // which blocks requests without a User-Agent header.


### PR DESCRIPTION
The additional dependencies is to let the projects compile on Java 11.
I think it's a Java 9+ module system thing.  Specifically:

* persistence-cassandra-javadsl needs javax.annotation.PostConstruct which is in the jsr250 jar
* server-javadsl needs the javax annotation api jar

Fixes #1417