### PR TITLE
Remove usage of deprecated APIs from Play

### DIFF
--- a/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaPersistenceModule.java
+++ b/persistence-jpa/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/jpa/JpaPersistenceModule.java
@@ -6,18 +6,18 @@ package com.lightbend.lagom.javadsl.persistence.jpa;
 
 import com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaReadSideImpl;
 import com.lightbend.lagom.internal.javadsl.persistence.jpa.JpaSessionImpl;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.inject.Module;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class JpaPersistenceModule extends Module {
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-                bind(JpaSession.class).to(JpaSessionImpl.class),
-                bind(JpaReadSide.class).to(JpaReadSideImpl.class)
+    public List<play.inject.Binding<?>> bindings(play.Environment environment, Config config) {
+        return Arrays.asList(
+            bindClass(JpaSession.class).to(JpaSessionImpl.class),
+            bindClass(JpaReadSide.class).to(JpaReadSideImpl.class)
         );
     }
 }

--- a/service/core/server/src/main/scala/com/lightbend/lagom/internal/server/ServiceRouter.scala
+++ b/service/core/server/src/main/scala/com/lightbend/lagom/internal/server/ServiceRouter.scala
@@ -32,6 +32,8 @@ import scala.util.control.NonFatal
 object ServiceRouter {
   /** RFC 6455 Section 5.5 - maximum control frame size is 125 bytes */
   val WebSocketControlFrameMaxLength = 125
+
+  val logger = Logger(classOf[ServiceRouter])
 }
 
 private[lagom] abstract class ServiceRouter(httpConfiguration: HttpConfiguration, parsers: PlayBodyParsers)(implicit ec: ExecutionContext, mat: Materializer)
@@ -363,7 +365,7 @@ private[lagom] abstract class ServiceRouter(httpConfiguration: HttpConfiguration
           (responseHeader, response) <- invokeServiceCall(serviceCall, requestHeader, request)
         } yield {
           if (!responseHeaderIsDefault(responseHeader)) {
-            Logger.warn("Response header contains a custom status code and/or custom protocol and/or custom headers, " +
+            logger.warn("Response header contains a custom status code and/or custom protocol and/or custom headers, " +
               "but this was invoked by a transport (eg WebSockets) that does not allow sending custom headers. " +
               "This response header will be ignored: " + responseHeader)
           }

--- a/service/javadsl/kafka/client/src/main/java/com/lightbend/lagom/javadsl/broker/kafka/KafkaClientModule.java
+++ b/service/javadsl/kafka/client/src/main/java/com/lightbend/lagom/javadsl/broker/kafka/KafkaClientModule.java
@@ -5,18 +5,18 @@
 package com.lightbend.lagom.javadsl.broker.kafka;
 
 import com.lightbend.lagom.internal.javadsl.api.broker.TopicFactory;
-import play.api.Configuration;
-import play.api.Environment;
-import play.api.inject.Binding;
-import play.api.inject.Module;
-import scala.collection.Seq;
+import com.typesafe.config.Config;
+import play.inject.Module;
+
+import java.util.Collections;
+import java.util.List;
 
 public class KafkaClientModule extends Module {
 
     @Override
-    public Seq<Binding<?>> bindings(Environment environment, Configuration configuration) {
-        return seq(
-            bind(TopicFactory.class).to(KafkaTopicFactory.class)
+    public List<play.inject.Binding<?>> bindings(play.Environment environment, Config config) {
+        return Collections.singletonList(
+            bindClass(TopicFactory.class).to(KafkaTopicFactory.class)
         );
     }
 }


### PR DESCRIPTION
There are still some usages of deprecated APIs from Play (mainly `ApplicationLifecycle.stop`), but we can remove them later.