### PR TITLE
Initial fixes for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,9 @@ jobs:
       script: bin/test-2.12
       env: TRAVIS_JDK=adopt@1.11.0-1
       name: "Run tests for Scala 2.12 and Java 11"
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: TRAVIS_JDK=adopt@1.11.0-1 # not fully supported but allows problem discovery
+    - script: bin/test-sbt-1.0
+      env: TRAVIS_JDK=adopt@1.11.0-1
+      name: "Scripted tests for sbt 1 and Java 11"
 
 before_install:
   # See https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-239493916

--- a/bin/test-sbt-1.0
+++ b/bin/test-sbt-1.0
@@ -4,5 +4,6 @@
 
 SCALA_VERSION="2.12.8"
 
-runSbt "+++ ${SCALA_VERSION} publishLocal"
-runSbtNoisy "++${SCALA_VERSION} scripted"
+# disable publishing javadoc for scripted
+runSbt ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ;+++ ${SCALA_VERSION} publishLocal"
+runSbtNoisy ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ;++${SCALA_VERSION} scripted"

--- a/docs/manual/java/releases/Highlights15.md
+++ b/docs/manual/java/releases/Highlights15.md
@@ -27,3 +27,14 @@ Lagom 1.5 introduces support for cross-service gRPC communication. [gRPC](https:
 ## Deployment
 
 Neither ConductR not [Lightbend Orchestration](https://developer.lightbend.com/docs/lightbend-orchestration/current/) are supported in Lagom 1.5. See the [[Deployment|Migration15#Deployment]] section on the migration guide for more details.
+
+## Initial support for Java 11
+
+Lagom 1.5 introduces [Incubating][] support for Java 11, starting with a [change][lagom/lagom#1803] in the use
+of Java reflection in Lagom's Java DSL that removes a known obstacle for running on Java 11.  Running Lagom on
+Java 11 will be limited to the use of external services that either fully support Java 11 too or run as a
+separate process to the Lagom app's Java 11 VM.  For instance, Lagom dev mode may not be able to run an embedded
+Cassandra node, requiring it instead be run as a separate process.
+
+[Incubating]: https://developer.lightbend.com/docs/reactive-platform/2.0/support-terminology/index.html#incubating
+[lagom/lagom#1803]: https://github.com/lagom/lagom/pull/1803

--- a/docs/manual/scala/releases/Highlights15.md
+++ b/docs/manual/scala/releases/Highlights15.md
@@ -27,3 +27,14 @@ Lagom 1.5 introduces support for cross-service gRPC communication. [gRPC](https:
 ## Deployment
 
 Neither ConductR not [Lightbend Orchestration](https://developer.lightbend.com/docs/lightbend-orchestration/current/) are supported in Lagom 1.5. See the [[Deployment|Migration15#Deployment]] section on the migration guide for more details.
+
+## Initial support for Java 11
+
+Lagom 1.5 introduces [Incubating][] support for Java 11, starting with a [change][lagom/lagom#1803] in the use
+of Java reflection in Lagom's Java DSL that removes a known obstacle for running on Java 11.  Running Lagom on
+Java 11 will be limited to the use of external services that either fully support Java 11 too or run as a
+separate process to the Lagom app's Java 11 VM.  For instance, Lagom dev mode may not be able to run an embedded
+Cassandra node, requiring it instead be run as a separate process.
+
+[Incubating]: https://developer.lightbend.com/docs/reactive-platform/2.0/support-terminology/index.html#incubating
+[lagom/lagom#1803]: https://github.com/lagom/lagom/pull/1803

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -147,10 +147,10 @@ object Dependencies {
   private val playFileWatch = "com.lightbend.play" %% "play-file-watch" % Versions.PlayFileWatch excludeAll (excludeSlf4j: _*)
 
   private val pcollections = "org.pcollections" % "pcollections" % Versions.PCollections
-
+  private val jsr250 = "javax.annotation" % "jsr250-api" % "1.0"
   private val junit = "junit" % "junit" % Versions.JUnit
   private val commonsLang = "org.apache.commons" % "commons-lang3" % "3.8.1"
-
+  private val javaxAnnotationApi = "javax.annotation" % "javax.annotation-api" % "1.3.2"
   private val dropwizardMetricsCore = "io.dropwizard.metrics" % "metrics-core" % "3.2.6" excludeAll (excludeSlf4j: _*)
 
   private val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.11.0"
@@ -264,7 +264,7 @@ object Dependencies {
       "org.eclipse.jetty" % "jetty-xml" % Versions.jetty,
       "org.eclipse.jetty.websocket" % "websocket-common" % Versions.jetty,
       "org.eclipse.jetty.websocket" % "websocket-api" % Versions.jetty,
-
+      jsr250,
       "com.typesafe.play" %% "twirl-api" % Versions.Twirl,
       "com.typesafe.slick" %% "slick" % Versions.Slick,
       "com.typesafe.slick" %% "slick-hikaricp" % Versions.Slick,
@@ -306,7 +306,7 @@ object Dependencies {
       "org.typelevel" %% "macro-compat" % "1.1.1",
       "org.xerial.snappy" % "snappy-java" % "1.1.7.2",
       "tyrex" % "tyrex" % "1.0.1",
-
+      javaxAnnotationApi,
       "org.scala-lang.modules" %% "scala-collection-compat" % "0.1.1",
       "com.google.guava" % "failureaccess" % "1.0",
       "com.google.guava" % "listenablefuture" % "9999.0-empty-to-avoid-conflict-with-guava",
@@ -353,7 +353,7 @@ object Dependencies {
     "antlr" % "antlr" % "2.7.7",
     "com.fasterxml" % "classmate" % "1.3.4",
     "org.dom4j" % "dom4j" % "2.1.1",
-    "javax.annotation" % "jsr250-api" % "1.0",
+    jsr250,
     "javax.el" % "el-api" % "2.2",
     "javax.enterprise" % "cdi-api" % "1.1",
     "org.apache.geronimo.specs" % "geronimo-jta_1.1_spec" % "1.1.1",
@@ -515,7 +515,8 @@ object Dependencies {
   val `server-javadsl` = libraryDependencies ++= Seq(
     akkaManagement,
     slf4jApi,
-    commonsLang
+    commonsLang,
+    javaxAnnotationApi
   )
 
   val `server-scaladsl` = libraryDependencies ++= Seq(
@@ -734,6 +735,7 @@ object Dependencies {
 
   val `persistence-cassandra-javadsl` = libraryDependencies ++= Seq(
     junit % Test,
+    jsr250,
     // Upgrades needed to match whitelist
     cassandraDriverCore
   )


### PR DESCRIPTION
Add some dependencies to let all the projects compile on Java 11.  I
believe these are necessary due to deprecations and changes around
Java's 9+ platform module system (JPMS).  Specifically:

* persistence-cassandra-javadsl needs javax.annotation.PostConstruct
  which is in the jsr250 jar
* server-javadsl needs the javax annotation api jar

We validate the fixes by running unit tests and scripted tests on Java
11.  Some of the other parts of CI validation (e.g. documentation tests)
aren't possible due to the fact Lagom still uses sbt 0.13 and also there
are still some issues with using sbt 1 on Java 11.

Fixes #1417