### PR TITLE
Drop unnecessary publishLocal before scripted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ before_cache:
   # Ensure changes to the cache aren't persisted
   - rm -rf $HOME/.ivy2/cache/com.lightbend.lagom/*
   - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.lightbend.lagom/*
+  - rm -rf $HOME/.ivy2/local/com.lightbend.lagom/*
+  - rm -rf $HOME/.ivy2/local/scala_*/sbt_*/com.lightbend.lagom/*
   - rm -r $HOME/.m2/repository/com/lightbend/lagom/*
   # Delete all ivydata files since ivy touches them on each build
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete

--- a/bin/test-sbt-0.13
+++ b/bin/test-sbt-0.13
@@ -7,5 +7,4 @@
 # +publishLocal will fail.
 checkIfShouldSkip "sbt 0.13"
 
-runSbt +publishLocal
 runSbtNoisy scripted

--- a/bin/test-sbt-1.0
+++ b/bin/test-sbt-1.0
@@ -5,5 +5,4 @@
 SCALA_VERSION="2.12.8"
 
 # disable publishing javadoc for scripted
-runSbt ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ;+++ ${SCALA_VERSION} publishLocal"
 runSbtNoisy ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ;++${SCALA_VERSION} scripted"

--- a/build.sbt
+++ b/build.sbt
@@ -1179,28 +1179,47 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
     scriptedDependencies := {
       val () = scriptedDependencies.value
 
-      // javadsl projects
+      // core projects
+      val () = (publishLocal in `akka-management-core`).value
+      val () = (publishLocal in `akka-management-javadsl`).value
+      val () = (publishLocal in `akka-management-scaladsl`).value
+      val () = (publishLocal in `api`).value
       val () = (publishLocal in `api-javadsl`).value
-      val () = (publishLocal in `server-javadsl`).value
+      val () = (publishLocal in `api-scaladsl`).value
+      val () = (publishLocal in `client`).value
       val () = (publishLocal in `client-javadsl`).value
+      val () = (publishLocal in `client-scaladsl`).value
+      val () = (publishLocal in `cluster-core`).value
+      val () = (publishLocal in `cluster-javadsl`).value
+      val () = (publishLocal in `immutables`).value
+      val () = (publishLocal in `jackson`).value
+      val () = (publishLocal in `logback`).value
+      val () = (publishLocal in `persistence-core`).value
+      val () = (publishLocal in `persistence-javadsl`).value
+      val () = (publishLocal in `persistence-testkit`).value
+      val () = (publishLocal in `persistence-cassandra-core`).value
+      val () = (publishLocal in `persistence-cassandra-javadsl`).value
+      val () = (publishLocal in `play-json`).value
+      val () = (publishLocal in `server`).value
+      val () = (publishLocal in `server-javadsl`).value
+      val () = (publishLocal in `server-scaladsl`).value
+      val () = (publishLocal in `spi`).value
+
+      // dev service registry
+      val () = (publishLocal in `devmode-scaladsl`).value
+      val () = (publishLocal in `play-integration-javadsl`).value
+      val () = (publishLocal in `service-locator`).value
       val () = (publishLocal in `service-registration-javadsl`).value
+      val () = (publishLocal in `service-registry-client-core`).value
       val () = (publishLocal in `service-registry-client-javadsl`).value
 
-      // core projects
-      val () = (publishLocal in api).value
-      val () = (publishLocal in spi).value
-      val () = (publishLocal in logback).value
-      val () = (publishLocal in client).value
-      val () = (publishLocal in server).value
-      val () = (publishLocal in jackson).value
-
       // dev environment projects
+      val () = (publishLocal in `cassandra-server`).value
+      val () = (publishLocal in `dev-mode-ssl-support`).value
+      val () = (publishLocal in `kafka-server`).value
       val () = (publishLocal in `reloadable-server`).value
       val () = (publishLocal in `sbt-build-tool-support`).value
       val () = publishLocal.value
-      val () = (publishLocal in `dev-mode-ssl-support`).value
-      val () = (publishLocal in `service-locator`).value
-      val () = (publishLocal in `service-registry-client-core`).value
 
       // sbt scripted projects
       val () = (publishLocal in `sbt-scripted-library`).value


### PR DESCRIPTION
If all is setup properly with scriptedDependencies it shouldn't be
necessary to publish locally as an independent step of running scripted.