### PR TITLE
Shutdown actor system and jvm on unsuccessful cluster join

### DIFF
--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -15,9 +15,12 @@ lagom.cluster {
   join-self = ${lagom.defaults.cluster.join-self}
 
   # Exit the JVM forcefully when the ActorSystem has been terminated.
-  # This is by default off, but you may want to turn it on in production
-  # to restart the process.
-  exit-jvm-when-system-terminated = off
+  exit-jvm-when-system-terminated = on
+
 
 }
 lagom.defaults.cluster.join-self = off
+
+# shutdown the actor system if it can't join a cluster after 60s
+# useful in production environments to let the deployment orchestration solutions restart the service
+akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 60s

--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/LagomConfig.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/LagomConfig.scala
@@ -22,6 +22,7 @@ object LagomConfig {
     "lagom.akka.dev-mode.actor-system.name" -> s"$name-internal-dev-mode",
     "play.akka.actor-system" -> s"$name-application",
     "lagom.defaults.cluster.join-self" -> "on",
+    "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
     "lagom.cluster.bootstrap.enabled" -> "off",
     "akka.discovery.method" -> "com.lightbend.lagom.internal.registry.DevModeSimpleServiceDiscovery"
   )

--- a/docs/src/test/scala/com/lightbend/lagom/docs/ServiceSupport.scala
+++ b/docs/src/test/scala/com/lightbend/lagom/docs/ServiceSupport.scala
@@ -31,7 +31,9 @@ trait ServiceSupport extends WordSpecLike with Matchers {
 
     val application =
       applicationBuilder
-        .configure("lagom.cluster.bootstrap.enabled" -> "off")
+        .configure(
+          "lagom.cluster.bootstrap.enabled" -> "off",
+          "lagom.cluster.exit-jvm-when-system-terminated" -> "off")
         .bindings(bind[TestServiceLocatorPort].to(testServiceLocatorPort))
         .overrides(bind[ServiceLocator].to(classOf[TestServiceLocator]))
         .disable(classOf[ServiceTestModule]) // enabled in application.conf

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceModuleSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceModuleSpec.scala
@@ -35,6 +35,7 @@ class JdbcPersistenceModuleSpec
             // Correct configuration, but the database is not available
             "db.default.driver" -> "org.h2.Driver",
             "db.default.url" -> "jdbc:h2:tcp://localhost/~/notavailable",
+            "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
             "lagom.cluster.bootstrap.enabled" -> "off"
           )
           .build()
@@ -55,6 +56,7 @@ class JdbcPersistenceModuleSpec
             "db.default.url" -> "jdbc:h2:tcp://localhost/~/notavailable",
             // And it is configured to fail fast
             "play.db.prototype.hikaricp.initializationFailTimeout" -> "1",
+            "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
             "lagom.cluster.bootstrap.enabled" -> "off"
           )
           .build()

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -60,6 +60,9 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       # multi-jvm tests forms the cluster programmatically
       # therefore we disable Akka Cluster Bootstrap
       lagom.cluster.bootstrap.enabled = off
+
+      # no jvm exit on tests
+      lagom.cluster.exit-jvm-when-system-terminated = off
     """
   ).withFallback(ConfigFactory.parseResources("play/reference-overrides.conf"))))
 

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -55,6 +55,9 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       # multi-jvm tests forms the cluster programmatically
       # therefore we disable Akka Cluster Bootstrap
       lagom.cluster.bootstrap.enabled = off
+
+      # no jvm exit on tests
+      lagom.cluster.exit-jvm-when-system-terminated = off
     """
   ).withFallback(ConfigFactory.parseResources("play/reference-overrides.conf"))))
 

--- a/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
+++ b/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
@@ -20,6 +20,7 @@ private[lagom] object PersistenceTestConfig {
     "akka.remote.netty.tcp.hostname" -> "127.0.0.1",
     "akka.remote.netty.tcp.port" -> "0",
     "lagom.cluster.join-self" -> "on",
+    "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
     "lagom.cluster.bootstrap.enabled" -> "off"
   ) ++ BasicConfigMap
 

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -63,6 +63,7 @@ class JavadslKafkaApiSpec extends WordSpecLike
         "akka.persistence.journal.plugin" -> "akka.persistence.journal.inmem",
         "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
         "lagom.cluster.join-self" -> "on",
+        "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
         "lagom.cluster.bootstrap.enabled" -> "off",
         "lagom.services.kafka_native" -> s"tcp://localhost:${KafkaLocalServer.DefaultPort}"
       )

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -53,6 +53,7 @@ class ScaladslKafkaApiSpec extends WordSpecLike
           "akka.remote.netty.tcp.hostname" -> "127.0.0.1",
           "akka.persistence.journal.plugin" -> "akka.persistence.journal.inmem",
           "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
+          "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
           "lagom.cluster.bootstrap.enabled" -> "off",
           "lagom.services.kafka_native" -> s"tcp://localhost:${KafkaLocalServer.DefaultPort}"
         ).asJava)


### PR DESCRIPTION
We need to discuss if we want it on 1.5.0 release or not. Since is a change in behavior, either it gets shipped with 1.5.0 or we postpone it to 1.6.0.

If we choose to have it in 1.5.0, we need to add a notice on the migration guide. Otherwise, we need a documentation section explaining that this needs to be correctly configured in production environments. 

(for now, I'm adding to 1.5.0 milestone)