### PR TITLE
Sync GitHub's settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,4 +1,4 @@
-# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/.
 repository:
   topics: lagom, distributed-systems, akka, play, playframework, java, scala, microservices, reactive
   private: false


### PR DESCRIPTION
I think the settings I set aren't being synced because I added the intergration after the configuration was merged, aka https://github.com/probot/settings/issues/1.

So poke the file.