### PR TITLE
Fix sbt setup link in the Lightbend Platform documentation

### DIFF
--- a/docs/manual/common/guide/production/LightbendPlatform.md
+++ b/docs/manual/common/guide/production/LightbendPlatform.md
@@ -37,7 +37,7 @@ See [Integrating Lagom with Lightbend Telemetry](https://github.com/lagom/lagom-
 
 Bintray credentials are required to build applications using the Lightbend Platform. Lightbend customers should log into the [support portal](https://portal.lightbend.com/ReactivePlatform/EnterpriseSuiteCredentials) to obtain their credentials. Follow the links below to see how to supply the credentials when using sbt or Maven.
 
-* [Lightbend Platform setup for sbt](https://developer.lightbend.com/docs/lightbend-platform/2.0/setup/setup-maven.html)
+* [Lightbend Platform setup for sbt](https://developer.lightbend.com/docs/lightbend-platform/2.0/setup/setup-sbt.html)
 * [Lightbend Platform setup for Maven](https://developer.lightbend.com/docs/lightbend-platform/2.0/setup/setup-maven.html)
 
 


### PR DESCRIPTION
See https://github.com/lagom/lagom/pull/1834#discussion_r269813097

Also fixed for `1.4.x` in #1836 and `master` in #1837, so no back or forward porting is required.