### PR TITLE
Build only the tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: scala
 
+# Only build PRs and tags: https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
+if: type = pull_request OR tag IS present
+
 env:
   global:
     # the following `secure` is WHITESOURCE_PASSWORD which is the same for all branches.


### PR DESCRIPTION
Firstly this avoids building random branches in the repo (such as
Mergify's backport/forwardport branches).

Disable building the master, 1.5.x and 1.4.x branches.  This avoids that
every merge into those branches kicks off a build.  This isn't necessary
because we use Mergify's ["strict merge workflow"][] which means the PR
is up-to-date with the target branch before it gets merged.  As an
additional safe-guard I've changed the branch protection in GitHub to
require PRs to be up-to-date before merging, also.

["strict merge workflow"]: https://doc.mergify.io/strict-workflow.html