### PR TITLE
added some ServiceTest setup clarification when mixing persistence

### DIFF
--- a/docs/manual/java/guide/services/Test.md
+++ b/docs/manual/java/guide/services/Test.md
@@ -52,7 +52,7 @@ The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and
 
 @[enable-cluster](code/docs/services/test/EnablePersistenceCluster.java)
 
-If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when when enabling one or another, cluster will also be enabled automatically.
+If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when enabling one or another, cluster will also be enabled automatically.
 
 You can't enable both (Cassandra and JDBC) at the same time for testing, which could be a problem if you are mixing persistence for write and read side. If you are using Cassandra for write-side and JDBC for read-side, just enable Cassandra.
 

--- a/docs/manual/java/guide/services/Test.md
+++ b/docs/manual/java/guide/services/Test.md
@@ -54,6 +54,8 @@ The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and
 
 If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when when enabling one or another, cluster will also be enabled automatically.
 
+You can't enable both (Cassandra and JDBC) at the same time for testing, which could be a problem if you are mixing persistence for write and read side. If you are using Cassandra for write-side and JDBC for read-side, just enable Cassandra.
+
 To enable Cassandra Persistence:
 
 @[enable-cassandra](code/docs/services/test/EnablePersistenceCassandra.java)

--- a/docs/manual/scala/guide/services/TestingServices.md
+++ b/docs/manual/scala/guide/services/TestingServices.md
@@ -58,7 +58,7 @@ The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and
 
 @[enable-cluster](code/TestingServices.scala)
 
-If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when when enabling one or another, cluster will also be enabled automatically.
+If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when enabling one or another, cluster will also be enabled automatically.
 
 You can't enable both (Cassandra and JDBC) at the same time for testing, which could be a problem if you are mixing persistence for write and read side. If you are using Cassandra for write-side and JDBC for read-side, just enable Cassandra.
 

--- a/docs/manual/scala/guide/services/TestingServices.md
+++ b/docs/manual/scala/guide/services/TestingServices.md
@@ -60,6 +60,8 @@ The server is by default running with [[pubsub|PubSub]], [[cluster|Cluster]] and
 
 If your service needs [[persistence|PersistentEntity]] you will need to enable it explicitly. This can be done by enabling Cassandra or JDBC, depending on which kind of persistence is used by your service. In any case, Lagom persistence requires clustering, so when when enabling one or another, cluster will also be enabled automatically.
 
+You can't enable both (Cassandra and JDBC) at the same time for testing, which could be a problem if you are mixing persistence for write and read side. If you are using Cassandra for write-side and JDBC for read-side, just enable Cassandra.
+
 To enable Cassandra Persistence:
 
 @[enable-cassandra](code/TestingServices.scala)


### PR DESCRIPTION
When testing with mixing persistence configuration this can be a little puzzling. This at least clarify one particular setup.