### PR TITLE
Update play-json to v2.7.2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -600,6 +600,7 @@ object Dependencies {
     akkaActor,
     akkaProtobuf,
     akkaSlf4j,
+    playJson,
     scalaXml,
     akkaHttpCore,
     akkaHttpRouteDsl,
@@ -607,8 +608,14 @@ object Dependencies {
     akkaParsing
   )
 
-  val `akka-management-javadsl` = libraryDependencies ++= Seq.empty[ModuleID]
-  val `akka-management-scaladsl` = libraryDependencies ++= Seq.empty[ModuleID]
+  val `akka-management-javadsl` = libraryDependencies ++= Seq(
+    // Upgrades needed to match whitelist
+    playJson
+  )
+  val `akka-management-scaladsl` = libraryDependencies ++= Seq(
+    // Upgrades needed to match whitelist
+    playJson
+  )
 
   val `cluster-core` = libraryDependencies ++= Seq(
     akkaCluster,
@@ -620,6 +627,7 @@ object Dependencies {
     "com.novocode" % "junit-interface" % "0.11" % Test,
 
     // Upgrades needed to match whitelist
+    playJson,
     sslConfig,
     scalaJava8Compat,
     scalaParserCombinators,
@@ -929,6 +937,7 @@ object Dependencies {
     akkaStream,
     akkaProtobuf,
     akkaSlf4j,
+    playJson,
     typesafeConfig,
     sslConfig,
     scalaXml

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
 
     // If you update the version of Play, you probably need to update the other Play* variables.
     val Play = "2.7.0"
-    val PlayJson = "2.7.0"
+    val PlayJson = "2.7.2"
     val PlayStandaloneWs = "2.0.1"
     val Twirl = "1.4.0"
     val PlayFileWatch = "1.1.8"


### PR DESCRIPTION
## Fixes

Update play-json to v2.7.2

## Purpose

There is a bug with the play-json v2.7.0, not compatible with older play versions <2.7.0 . Causing some "NoClassDefFoundError" on scala.collections._ classes at runtime. (see issue #1840 )