### PR TITLE
Bumps akka to 2.5.22

### DIFF
--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -82,7 +82,8 @@ private[lagom] object JoinClusterImpl {
         val reasons: Seq[Reason] = Seq(
           ClusterDowningReason,
           ClusterJoinUnsuccessfulReason,
-          IncompatibleConfigurationDetectedReason)
+          IncompatibleConfigurationDetectedReason
+        )
 
         val reasonIsDowning: Boolean = shutdownReason.exists(reasons.contains)
 

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -76,8 +76,13 @@ private[lagom] object JoinClusterImpl {
 
     CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseClusterShutdown, "exit-jvm-when-downed") {
       () =>
-        val reasonIsDowning = CoordinatedShutdown(system)
-          .shutdownReason().contains(CoordinatedShutdown.ClusterDowningReason)
+        val shutdownReason = CoordinatedShutdown(system).shutdownReason()
+
+        val reasons = Seq(CoordinatedShutdown.ClusterDowningReason,
+          CoordinatedShutdown.ClusterJoinUnsuccessfulReason,
+          CoordinatedShutdown.IncompatibleConfigurationDetectedReason)
+
+        val reasonIsDowning = shutdownReason.find(reasons.contains)
 
         // if 'exitJvm' is enabled and the trigger (aka Reason) for CoordinatedShutdown is ClusterDowning
         // we must exit the JVM. This can lead to the cluster closing before the `Application` but we're

--- a/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
+++ b/cluster/core/src/main/scala/com/lightbend/lagom/internal/cluster/JoinClusterImpl.scala
@@ -6,6 +6,7 @@ package com.lightbend.lagom.internal.cluster
 
 import akka.Done
 import akka.actor.{ ActorSystem, CoordinatedShutdown, ExtendedActorSystem }
+import akka.actor.CoordinatedShutdown._
 import akka.cluster.Cluster
 import akka.management.cluster.bootstrap.ClusterBootstrap
 import com.lightbend.lagom.internal.akka.management.AkkaManagementTrigger
@@ -74,25 +75,39 @@ private[lagom] object JoinClusterImpl {
 
     }
 
-    CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseClusterShutdown, "exit-jvm-when-downed") {
+    CoordinatedShutdown(system).addTask(PhaseClusterShutdown, "exit-jvm-when-downed") {
       () =>
-        val shutdownReason = CoordinatedShutdown(system).shutdownReason()
+        val shutdownReason: Option[Reason] = CoordinatedShutdown(system).shutdownReason()
 
-        val reasons = Seq(CoordinatedShutdown.ClusterDowningReason,
-          CoordinatedShutdown.ClusterJoinUnsuccessfulReason,
-          CoordinatedShutdown.IncompatibleConfigurationDetectedReason)
+        val reasons: Seq[Reason] = Seq(
+          ClusterDowningReason,
+          ClusterJoinUnsuccessfulReason,
+          IncompatibleConfigurationDetectedReason)
 
-        val reasonIsDowning = shutdownReason.find(reasons.contains)
+        val reasonIsDowning: Boolean = shutdownReason.exists(reasons.contains)
 
-        // if 'exitJvm' is enabled and the trigger (aka Reason) for CoordinatedShutdown is ClusterDowning
-        // we must exit the JVM. This can lead to the cluster closing before the `Application` but we're
-        // out of the cluster (downed) already so the impact is acceptable. This will be improved when
-        // Play delegates all shutdown logic to CoordinatedShutdown in Play 2.7.x.
+        // if 'exitJvm' is enabled and the trigger (aka Reason) for CoordinatedShutdown is ClusterDowning,
+        // JoinUnsuccessful, etc... we must exit the JVM. This can lead to the cluster closing before
+        // the `Application` but we're out of the cluster (downed) already so the impact is acceptable.
         if (exitJvm && reasonIsDowning) {
-          // In case ActorSystem shutdown takes longer than 10 seconds,
-          // exit the JVM forcefully anyway.
-          // We must spawn a separate thread to not block current thread,
-          // since that would have blocked the shutdown of the ActorSystem.
+
+          // If this code is running, it means CoordinatedShutdown was triggered. CoordinatedShutdown of
+          // a given actor system can only be invoked once: further invocations block until the initial
+          // one completes. The code below works as following:
+          //   - create a new Thread and invoke System.exit(-1)
+          //   - terminate the "exit-jvm-when-downed" task
+          //   - in parallel, the invocation of System.exit(-1) has triggered the execution of the JVM shutdown Hooks
+          //   - Play's JVM shutdown hooks proceed to stop Play which means stopping the Server and the
+          //     Application. That also involves Play's ApplicationLifecycle. In a particular step of that stop
+          //     process Play must stop its Actor System so it invokes CoordinatedShutdown. Since the
+          //     CoordinatedShutdown is already running, that operation blocks.
+          // !! At this point, there's a CoordinatedShutdown running (triggered by a Downing event) and a
+          //    reference to a CoordinatedShutdown blocked until the run completes. The thread blocked is the
+          //    JVM shutdown thread.
+          //  - When the main CoordinatedShutdown completes, the JVM keeps running because Play (and Lagom)
+          //    tune Akka's `exit-jvm=off`.
+          //  - When the main CoordinatedShutdown completes, the thread blocked on the main CoordinatedShutdown
+          //    unblocks and completes the execution of `System.exit`.
           val t = new Thread(new Runnable {
             override def run(): Unit = {
               // exit code when shutting down because of a cluster Downing event must be non-zero

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,6 +1,6 @@
 val ScalaVersion = "2.12.8"
 
-val AkkaVersion: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.21")
+val AkkaVersion: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.22")
 val JUnitVersion = "4.12"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion = "3.0.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     val Twirl = "1.4.0"
     val PlayFileWatch = "1.1.8"
 
-    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.21")
+    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.22")
     val AkkaHttp = "10.1.8"
     val Aeron = "1.15.1"
 
@@ -316,7 +316,7 @@ object Dependencies {
     ) ++ jacksonFamily ++ crossLibraryFamily("com.typesafe.akka", Versions.Akka)(
       "akka-actor", "akka-cluster", "akka-cluster-sharding", "akka-cluster-tools", "akka-distributed-data",
       "akka-multi-node-testkit", "akka-persistence", "akka-persistence-query", "akka-protobuf", "akka-remote",
-      "akka-slf4j", "akka-stream", "akka-stream-testkit", "akka-testkit"
+      "akka-slf4j", "akka-stream", "akka-stream-testkit", "akka-testkit", "akka-coordination"
 
     ) ++ libraryFamily("com.typesafe.play", Versions.Play)(
       "build-link", "play-exceptions", "play-netty-utils"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -626,8 +626,9 @@ object Dependencies {
     scalaXml,
     akkaSlf4j,
 
-    // transitive dependencies from Akka Management,
-    // must be explicitly bumped to Akka 2.5.20
+    // transitive dependencies from Akka Management 
+    // may not match the Akka version in use so 
+    // must be explicitly bumped
     akkaDiscovery,
     akkaClusterSharding,
     akkaDistributedData,


### PR DESCRIPTION
## Purpose

Bumps Akka to `2.5.22`. It also adopts the new Shutdown reasons and improves the comments wrt how and why shutdown works in case of a cluster event (downing, join nonsuccessful, etc...)

Fixes #1849