### PR TITLE
Fewer stages + Java11 is 1st class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ jobs:
       name: "Run tests for Scala 2.11"
     - script: bin/test-2.12
       name: "Run tests for Scala 2.12"
+    - script: bin/test-2.12
+      env: TRAVIS_JDK=adopt@1.11.0-2
+      name: "Run tests for Scala 2.12 and Java 11"
     - script: bin/test-documentation
       name: "Documentation validations and tests"
     - stage: test-build-tools
@@ -34,15 +37,11 @@ jobs:
       name: "Scripted tests for sbt 0.13"
     - script: bin/test-sbt-1.0
       name: "Scripted tests for sbt 1"
-    - script: bin/test-maven
-      name: "PublishM2 and test Maven"
-    - stage: java-11
-      script: bin/test-2.12
-      env: TRAVIS_JDK=adopt@1.11.0-2
-      name: "Run tests for Scala 2.12 and Java 11"
     - script: bin/test-sbt-1.0
       env: TRAVIS_JDK=adopt@1.11.0-2
       name: "Scripted tests for sbt 1 and Java 11"
+    - script: bin/test-maven
+      name: "PublishM2 and test Maven"
 
 cache:
   directories:


### PR DESCRIPTION
## Purpose

With the migration to Travis CI.com and the promotion of Java 11 I think it makes more sense to have fewer, beefier stages _and_ also have Java 11 treated as a 1st class citizen.

## Background Context

Moving away from the 5-worker limit in travis-ci.org's released a constraint motivating the creation of stages with a small number of jobs. This PR still splits the job list in two stages but considering the total number of jobs (9) is still smaller than the number of travis workers (13) I think that could be removed and have all jobs just run free.
