### PR TITLE
[WIP] JsonSerializerRegistry supports non-static serializers

### DIFF
--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
@@ -35,14 +35,14 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
   private val compressLargerThan: Long = conf.getBytes("compress-larger-than")
 
   /** maps a manifestClassName to a suitable play-json Format */
-  private val formatters: Map[String, Format[AnyRef]] = {
-    registry.serializers.map((entry: JsonSerializer[_]) =>
+  private lazy val formatters: Map[String, Format[AnyRef]] = {
+    serializers.values.map((entry: JsonSerializer[_]) =>
       (entry.entityClass.getName, entry.format.asInstanceOf[Format[AnyRef]])).toMap
   }
 
   /** maps a manifestClassName to the serializer provided by the user */
-  private val serializers: Map[String, JsonSerializer[_]] = {
-    registry.serializers.map {
+  private lazy val serializers: Map[String, JsonSerializer[_]] = {
+    (registry.serializers ++ registry.serializers(system)).map {
       entry => entry.entityClass.getName -> entry
     }.toMap
   }


### PR DESCRIPTION
Historically, `play-json` serialisers provided via `JsonSerialiserRegistry` were static. This was usually enough but with the arrival of Akka Typed it presents a limitation:

 - messages sent to an actor via `ask` must include a field `replyTo: ActorRef[_]` which must be serialised too.

The `JsonSerializers` now may need an instance of a `ActorSystem`. Deserializing a `String` into an `ActorRef` requires the `ActorSystem` where the new actor will be running in.

TODO:

- [ ] docs
- [ ] tests

Won't do: jackson serialisers may need a similar improvement. Will do on a separate PR.