### PR TITLE
Removed gracefulShutdown depricated method from code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -269,7 +269,9 @@ def mimaSettings(since: String): Seq[Setting[_]] = {
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[Problem]("com.lightbend.lagom.internal.*"),
       ProblemFilters.exclude[Problem]("com.lightbend.lagom.*Components*"),
-      ProblemFilters.exclude[Problem]("com.lightbend.lagom.*Module*")
+      ProblemFilters.exclude[Problem]("com.lightbend.lagom.*Module*"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("*lagom.*dsl.persistence.PersistentEntityRegistry.gracefulShutdown"),
     )
   )
 }

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -47,7 +47,6 @@ class CassandraReadSideSpec
   override def getAppendCount(id: String): CompletionStage[java.lang.Long] = readSide.getAppendCount(id)
 
   override def afterAll(): Unit = {
-    persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
   }
 

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -44,7 +44,6 @@ class CassandraReadSideSpec
   override def getAppendCount(id: String): Future[Long] = readSide.getAppendCount(id)
 
   override def afterAll(): Unit = {
-    persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
   }
 }

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcReadSideSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcReadSideSpec.scala
@@ -28,7 +28,6 @@ class JdbcReadSideSpec extends JdbcPersistenceSpec with AbstractReadSideSpec {
   override def getAppendCount(id: String): CompletionStage[Long] = readSide.getAppendCount(id)
 
   override def afterAll(): Unit = {
-    persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
   }
 

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcReadSideSpec.scala
@@ -25,7 +25,6 @@ class JdbcReadSideSpec extends JdbcPersistenceSpec(TestEntitySerializerRegistry)
   override def getAppendCount(id: String): Future[Long] = readSide.getAppendCount(id)
 
   override def afterAll(): Unit = {
-    persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
   }
 

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickReadSideSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickReadSideSpec.scala
@@ -25,7 +25,6 @@ class SlickReadSideSpec extends SlickPersistenceSpec(TestEntitySerializerRegistr
   override def getAppendCount(id: String): Future[Long] = readSide.getAppendCount(id)
 
   override def afterAll(): Unit = {
-    persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
   }
 }

--- a/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImplSpec.scala
+++ b/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaReadSideImplSpec.scala
@@ -30,7 +30,6 @@ class JpaReadSideImplSpec extends JpaPersistenceSpec with AbstractReadSideSpec {
   def getAppendCount(id: String): CompletionStage[Long] = readSide.getAppendCount(id)
 
   override def afterAll(): Unit = {
-    persistentEntityRegistry.gracefulShutdown(5.seconds)
     super.afterAll()
   }
 

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -181,7 +181,4 @@ class AbstractPersistentEntityRegistry(system: ActorSystem, injector: Injector) 
    */
   protected def mapStartingOffset(storedOffset: Offset): AkkaOffset = OffsetAdapter.dslOffsetToOffset(storedOffset)
 
-  override def gracefulShutdown(timeout: FiniteDuration): CompletionStage[Done] =
-    CompletableFuture.completedFuture(Done.getInstance())
-
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
@@ -89,16 +89,4 @@ trait PersistentEntityRegistry {
     }.asJava
   }
 
-  /**
-   * No-op method that exists only for backward-compatibility reasons.
-   * Lagom now uses Akka's CoordinatedShutdown to gracefully shut down all sharded entities,
-   * including Persistent Entities.
-   *
-   * @return a completed `CompletionStage`
-   * @deprecated As of Lagom 1.4, this method has no effect and no longer needs to be called
-   *
-   */
-  @deprecated("This method has no effect and no longer needs to be called", "1.4.0")
-  def gracefulShutdown(timeout: FiniteDuration): CompletionStage[Done]
-
 }

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -239,9 +239,6 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       // beginning of the test to ensure it's run.
       enterBarrier("before-3")
 
-      runOn(node2) {
-        registry.gracefulShutdown(20.seconds).toCompletableFuture().get(20, SECONDS)
-      }
       enterBarrier("node2-left")
 
       runOn(node1) {

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -152,7 +152,4 @@ class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEn
     }
   }
 
-  override def gracefulShutdown(timeout: FiniteDuration): Future[Done] =
-    Future.successful(Done)
-
 }

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
@@ -63,16 +63,4 @@ trait PersistentEntityRegistry {
       fromOffset: Offset
   ): scaladsl.Source[EventStreamElement[Event], NotUsed]
 
-  /**
-   * No-op method that exists only for backward-compatibility reasons.
-   * Lagom now uses Akka's CoordinatedShutdown to gracefully shut down all sharded entities,
-   * including Persistent Entities.
-   *
-   * @return a completed `Future`
-   * @deprecated As of Lagom 1.4, this method has no effect and no longer needs to be called
-   *
-   */
-  @deprecated("This method has no effect and no longer needs to be called", "1.4.0")
-  def gracefulShutdown(timeout: FiniteDuration): Future[Done]
-
 }

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -238,9 +238,6 @@ abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPe
       // beginning of the test to ensure it's run.
       enterBarrier("before-3")
 
-      runOn(node2) {
-        Await.ready(registry.gracefulShutdown(20.seconds), 20.seconds)
-      }
       enterBarrier("node2-left")
 
       runOn(node1) {

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -475,9 +475,6 @@ object JavadslKafkaApiSpec {
     ): JSource[JPair[Event, JOffset], NotUsed] =
       JSource.empty()
 
-    override def gracefulShutdown(timeout: FiniteDuration): CompletionStage[Done] =
-      CompletableFuture.completedFuture(Done.getInstance())
-
     override def refFor[C](
         entityClass: Class[_ <: com.lightbend.lagom.javadsl.persistence.PersistentEntity[C, _, _]],
         entityId: String


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ Not Applicable] Have you added copyright headers to new files?
* [ Not Applicable] Have you updated the documentation?
* [ Not Applicable] Have you added tests for any changed functionality?

## Fixes

Fixes #1768
This PR contains code change where we have removed the one deprecated method from existing code.
## Purpose
To clean the code where we have removed the one deprecated method from existing code.
What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
