### PR TITLE
make explicit noTrigger in plugins, minor deprecation fix and typo

### DIFF
--- a/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
+++ b/dev/build-tool-support/src/main/scala/com/lightbend/lagom/dev/Servers.scala
@@ -68,7 +68,7 @@ private[lagom] object Servers {
         }
       }
 
-      // use CompletionStage / Runable / Thread in case scala equivalent are not available on classloader.
+      // use CompletionStage / Runnable / Thread in case scala equivalent are not available on classloader.
       private val promise: CompletableFuture[Int] = new CompletableFuture[Int]()
       new Thread(new Runnable {
         override def run(): Unit = {

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -24,6 +24,7 @@ import sbt.plugins.{ CorePlugin, IvyPlugin, JvmPlugin }
  */
 object Lagom extends AutoPlugin {
   override def requires = LagomReloadableService && JavaAppPackaging
+  override def trigger = noTrigger
   val autoImport = LagomImport
 }
 
@@ -110,7 +111,7 @@ object LagomScala extends AutoPlugin {
  * }}}
  */
 object LagomPlay extends AutoPlugin {
-  override def requires = LagomReloadableService && Play
+  override def requires = LagomReloadableService && PlayWeb
   override def trigger = noTrigger
 
   import LagomReloadableService.autoImport._
@@ -167,6 +168,7 @@ object LagomNettyServer extends AutoPlugin {
   // This plugin has not trigger. Lagom provides LagomNettyServer as an OptIn
   // backend but default to LagomAkkaHttpServer
   override def requires = Lagom
+  override def trigger = noTrigger
 
   override def projectSettings = Seq(
     libraryDependencies ++= {
@@ -700,6 +702,7 @@ object LagomLogback extends AutoPlugin {
 
 object LagomLog4j2 extends AutoPlugin {
   override def requires = LagomPlugin
+  override def trigger = noTrigger
 
   override def projectSettings = Seq(
     libraryDependencies += LagomImport.lagomLog4j2


### PR DESCRIPTION
All other plugins in `LagomPlugin.scala` specify explicitly the `noTrigger` (which is good)