### PR TITLE
[1.4.x] Integrates akka discovery service locator in Lagom

### DIFF
--- a/akka-service-locator/.gitignore
+++ b/akka-service-locator/.gitignore
@@ -1,6 +1,0 @@
-target
-.idea/
-*.iml
-.classpath
-.project
-.settings

--- a/akka-service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/AkkaDiscoveryHelper.scala
+++ b/akka-service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/AkkaDiscoveryHelper.scala
@@ -1,7 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package com.lightbend.lagom.internal.client
 
 import java.net.URI
@@ -19,10 +18,12 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 /**
-  * Helper for implementing Akka Discovery based service locators in Lagom.
-  */
+ * Helper for implementing Akka Discovery based service locators in Lagom.
+ */
 private[lagom] class AkkaDiscoveryHelper(config: Config, serviceDiscovery: ServiceDiscovery)(
-    implicit ec: ExecutionContext) {
+  implicit
+  ec: ExecutionContext
+) {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
 
@@ -48,13 +49,14 @@ private[lagom] class AkkaDiscoveryHelper(config: Config, serviceDiscovery: Servi
     val scheme = lookup.scheme.orNull
 
     try {
-      new URI(scheme, // scheme
-              null, // userInfo
-              resolvedTarget.host, // host
-              port, // port
-              null, // path
-              null, // query
-              null // fragment
+      new URI(
+        scheme, // scheme
+        null, // userInfo
+        resolvedTarget.host, // host
+        port, // port
+        null, // path
+        null, // query
+        null // fragment
       )
     } catch {
       case e: URISyntaxException => throw new RuntimeException(e)

--- a/akka-service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
+++ b/akka-service-locator/core/src/main/scala/com/lightbend/lagom/internal/client/ServiceNameMapper.scala
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package com.lightbend.lagom.internal.client
 
 import akka.discovery.Lookup
@@ -49,7 +48,8 @@ private[lagom] class ServiceNameMapper(config: Config) {
       .map { entry =>
         if (entry.getValue.valueType != ConfigValueType.OBJECT) {
           throw new IllegalArgumentException(
-            s"Illegal value type in service-name-mappings: ${entry.getKey} - ${entry.getValue.valueType}")
+            s"Illegal value type in service-name-mappings: ${entry.getKey} - ${entry.getValue.valueType}"
+          )
         }
         val configEntry = entry.getValue.asInstanceOf[ConfigObject].toConfig
 
@@ -62,7 +62,7 @@ private[lagom] class ServiceNameMapper(config: Config) {
         // otherwise honour user settings.
         val scheme =
           readConfigValue(configEntry, "scheme") match {
-            case Undefined => defaultScheme
+            case Undefined       => defaultScheme
             // this is the case the user explicitly set the scheme to empty string
             case Empty           => None
             case NonEmpty(value) => Option(value)

--- a/akka-service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
+++ b/akka-service-locator/core/src/test/scala/com/lightbend/lagom/internal/client/ServiceNameMapperSpec.scala
@@ -1,7 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package com.lightbend.lagom.internal.client
 
 import akka.discovery.Lookup

--- a/akka-service-locator/javadsl/src/main/java/com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocator.java
+++ b/akka-service-locator/javadsl/src/main/java/com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocator.java
@@ -1,7 +1,6 @@
 /*
  * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package com.lightbend.lagom.javadsl.akka.discovery;
 
 import akka.actor.ActorSystem;

--- a/akka-service-locator/javadsl/src/main/java/com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocatorModule.java
+++ b/akka-service-locator/javadsl/src/main/java/com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocatorModule.java
@@ -1,7 +1,6 @@
 /*
- * Copyright (C) 2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package com.lightbend.lagom.javadsl.akka.discovery;
 
 import com.lightbend.lagom.javadsl.api.ServiceLocator;

--- a/akka-service-locator/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryComponents.scala
+++ b/akka-service-locator/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryComponents.scala
@@ -1,16 +1,15 @@
 /*
- * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package com.lightbend.lagom.scaladsl.akka.discovery
 
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.client.CircuitBreakerComponents
 
 /**
-  * Mix this into your application cake to get the Akka Discovery based implementation of the Lagom
-  * [[ServiceLocator]].
-  */
+ * Mix this into your application cake to get the Akka Discovery based implementation of the Lagom
+ * [[ServiceLocator]].
+ */
 trait AkkaDiscoveryComponents extends CircuitBreakerComponents {
   lazy val serviceLocator: ServiceLocator =
     new AkkaDiscoveryServiceLocator(circuitBreakersPanel, actorSystem)(executionContext)

--- a/akka-service-locator/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryServiceLocator.scala
+++ b/akka-service-locator/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryServiceLocator.scala
@@ -1,7 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
-
 package com.lightbend.lagom.scaladsl.akka.discovery
 
 import java.net.URI
@@ -18,11 +17,13 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 /**
-  * Akka discovery based implementation of the [[ServiceLocator]].
-  */
+ * Akka discovery based implementation of the [[ServiceLocator]].
+ */
 class AkkaDiscoveryServiceLocator(circuitBreakers: CircuitBreakersPanel, actorSystem: ActorSystem)(
-    implicit ec: ExecutionContext)
-    extends CircuitBreakingServiceLocator(circuitBreakers) {
+  implicit
+  ec: ExecutionContext
+)
+  extends CircuitBreakingServiceLocator(circuitBreakers) {
 
   private val helper: AkkaDiscoveryHelper = new AkkaDiscoveryHelper(
     actorSystem.settings.config.getConfig("lagom.akka.discovery"),

--- a/build.sbt
+++ b/build.sbt
@@ -310,6 +310,7 @@ val javadslProjects = Seq[Project](
   `broker-javadsl`,
   `kafka-client-javadsl`,
   `kafka-broker-javadsl`,
+  `akka-discovery-service-locator-javadsl`,
   `cluster-javadsl`,
   `persistence-javadsl`,
   `persistence-cassandra-javadsl`,
@@ -329,6 +330,7 @@ val scaladslProjects = Seq[Project](
   `kafka-client-scaladsl`,
   `kafka-broker-scaladsl`,
   `server-scaladsl`,
+  `akka-discovery-service-locator-scaladsl`,
   `cluster-scaladsl`,
   `persistence-scaladsl`,
   `persistence-cassandra-scaladsl`,
@@ -345,6 +347,7 @@ val coreProjects = Seq[Project](
   client,
   server,
   spi,
+  `akka-discovery-service-locator-core`,
   `cluster-core`,
   `kafka-client`,
   `kafka-broker`,
@@ -662,6 +665,33 @@ def singleTestsGrouping(tests: Seq[TestDefinition]) = {
     )
   }
 }
+
+lazy val `akka-discovery-service-locator-core` = (project in file("akka-service-locator/core"))
+  .settings(runtimeLibCommon: _*)
+  // .settings(mimaSettings: _*)
+  .enablePlugins(RuntimeLibPlugins)
+  .settings(
+    name := "lagom-akka-discovery-service-locator-core",
+    Dependencies.`lagom-akka-discovery-service-locator-core`
+  )
+lazy val `akka-discovery-service-locator-javadsl` = (project in file("akka-service-locator/javadsl"))
+  .dependsOn(`akka-discovery-service-locator-core`)
+  .dependsOn(`client-javadsl`)
+  .settings(runtimeLibCommon: _*)
+  // .settings(mimaSettings: _*)
+  .enablePlugins(RuntimeLibPlugins)
+  .settings(
+    name := "lagom-javadsl-akka-discovery-service-locator"
+  )
+lazy val `akka-discovery-service-locator-scaladsl` = (project in file("akka-service-locator/scaladsl"))
+  .dependsOn(`akka-discovery-service-locator-core`)
+  .dependsOn(`client-scaladsl`)
+  .settings(runtimeLibCommon: _*)
+  // .settings(mimaSettings: _*)
+  .enablePlugins(RuntimeLibPlugins)
+  .settings(
+    name := "lagom-scaladsl-akka-discovery-service-locator"
+  )
 
 lazy val `cluster-core` = (project in file("cluster/core"))
   .settings(runtimeLibCommon: _*)

--- a/build.sbt
+++ b/build.sbt
@@ -668,6 +668,8 @@ def singleTestsGrouping(tests: Seq[TestDefinition]) = {
 
 lazy val `akka-discovery-service-locator-core` = (project in file("akka-service-locator/core"))
   .settings(runtimeLibCommon: _*)
+  // TODO: after this get released, we must enable the mima settings
+  // that artifact doesn't exist in previous jar, so it doesn't make sense to check it
   // .settings(mimaSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
@@ -678,6 +680,8 @@ lazy val `akka-discovery-service-locator-javadsl` = (project in file("akka-servi
   .dependsOn(`akka-discovery-service-locator-core`)
   .dependsOn(`client-javadsl`)
   .settings(runtimeLibCommon: _*)
+  // TODO: after this get released, we must enable the mima settings
+  // that artifact doesn't exist in previous jar, so it doesn't make sense to check it
   // .settings(mimaSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
@@ -687,6 +691,8 @@ lazy val `akka-discovery-service-locator-scaladsl` = (project in file("akka-serv
   .dependsOn(`akka-discovery-service-locator-core`)
   .dependsOn(`client-scaladsl`)
   .settings(runtimeLibCommon: _*)
+  // TODO: after this get released, we must enable the mima settings
+  // that artifact doesn't exist in previous jar, so it doesn't make sense to check it
   // .settings(mimaSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala
@@ -16,6 +16,7 @@ object LagomImport extends LagomImportCompat {
 
   val lagomJavadslApi = component("lagom-javadsl-api")
   val lagomJavadslClient = component("lagom-javadsl-client")
+  val lagomJavadslAkkaDiscovery = component("akka-discovery-service-locator-javadsl")
   val lagomJavadslIntegrationClient = component("lagom-javadsl-integration-client")
   val lagomJavadslCluster = component("lagom-javadsl-cluster")
   // Scoped to `Provided` because it's needed only at compile-time.
@@ -36,6 +37,7 @@ object LagomImport extends LagomImportCompat {
 
   val lagomScaladslApi = component("lagom-scaladsl-api")
   val lagomScaladslClient = component("lagom-scaladsl-client")
+  val lagomScaladslAkkaDiscovery = component("akka-discovery-service-locator-scaladsl")
   val lagomScaladslServer = component("lagom-scaladsl-server")
   val lagomScaladslDevMode = component("lagom-scaladsl-dev-mode")
   val lagomScaladslCluster = component("lagom-scaladsl-cluster")

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -92,6 +92,8 @@ lazy val docs = project
     kafkaBrokerScaladsl,
     playJson,
     pubsubScaladsl,
+    akkaDiscoveryJavadsl,
+    akkaDiscoveryScaladsl,
     immutables % "test->compile",
     theme % "run-markdown",
     devmodeScaladsl
@@ -112,6 +114,8 @@ lazy val playJson = ProjectRef(parentDir, "play-json")
 lazy val kafkaBrokerScaladsl = ProjectRef(parentDir, "kafka-broker-scaladsl")
 lazy val devmodeScaladsl = ProjectRef(parentDir, "devmode-scaladsl")
 lazy val pubsubScaladsl = ProjectRef(parentDir, "pubsub-scaladsl")
+lazy val akkaDiscoveryJavadsl = ProjectRef(parentDir, "akka-discovery-service-locator-javadsl")
+lazy val akkaDiscoveryScaladsl = ProjectRef(parentDir, "akka-discovery-service-locator-scaladsl")
 
 // Needed to compile test classes using immutables annotation
 lazy val immutables = ProjectRef(parentDir, "immutables")

--- a/docs/manual/java/guide/production/AkkaDiscoveryIntegration.md
+++ b/docs/manual/java/guide/production/AkkaDiscoveryIntegration.md
@@ -1,0 +1,31 @@
+# Using Akka Discovery
+
+Lagom 1.4.12 contains a backport of `Akka Discovery Service Locator`, a component introduced in Lagom 1.5.1. It provides a built-in integration with [Akka Discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html) throught a  [ServiceLocator](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html) implmentation that wraps Akka Discovery. This is the recommended implementation for production specially for users targeting Kubernetes and DC/OS (Marathon).
+
+## Dependency
+
+To use this feature add the following in your project's build:
+
+In Maven:
+
+```xml
+<dependency>
+    <groupId>com.lightbend.lagom</groupId>
+    <artifactId>lagom-javadsl-akka-discovery-service-locator_${scala.binary.version}</artifactId>
+    <version>${lagom.version}</version>
+</dependency>
+```
+
+In sbt:
+
+@[akka-discovery-dependency](code/akka-discovery-dependency.sbt)
+
+## Configuration
+
+The Guice module [AkkaDiscoveryServiceLocatorModule](api/index.html?com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocatorModule.html) will be added by default to your project, but will only wire in the [AkkaDiscoveryServiceLocator](api/index.html?com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocator.html) when running in production mode.
+
+In development, your Lagom application will keep using the Lagom's dev-mode [`ServiceLocator`](api/index.html?com/lightbend/lagom/javadsl/api/ServiceLocator.html).
+
+Next, you will need to choose one of the available Akka Discovery implementations and configure it in your `application.conf` file. Consult the [Akka Discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html) documentation for further instructions.
+
+Note: this component was [previous published](https://github.com/lagom/lagom-akka-discovery-service-locator) as an independent library. If you have it on your classpath it's recommended to remove it and use the one being provided by Lagom directly.

--- a/docs/manual/java/guide/production/ProductionOverview.md
+++ b/docs/manual/java/guide/production/ProductionOverview.md
@@ -30,6 +30,8 @@ The production environment determines the methods for packaging your services, m
 
     * For simple deployments, Lagom includes a built-in service locator that uses addresses specified in the service configuration ([described below](#Using-static-values-for-services-and-Cassandra)).
 
+    * Since Lagom 1.4.12, you can use  [[Akka Discovery Service Locator|AkkaDiscoveryIntegration]] that integrates with the service discovery features of Kubernetes or DC/OS, or any other environment supported by [Akka's Service Discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html).
+
     * Lightbend Orchestration provides an open-source [`ServiceLocator` implementation](https://developer.lightbend.com/docs/lightbend-orchestration/current/features/service-location.html) that integrates with the service discovery features of Kubernetes or DC/OS, or any other environment that supports service discovery via DNS.
 
     * Otherwise, you can implement the interface yourself to integrate with a service registry of your choosing (such as [Consul](https://www.consul.io/), [ZooKeeper](https://zookeeper.apache.org/), or [etcd](https://coreos.com/etcd/)) or start with an open-source example implementation such as [`lagom-service-locator-consul`](https://github.com/jboner/lagom-service-locator-consul) or [`lagom-service-locator-zookeeper`](https://github.com/jboner/lagom-service-locator-zookeeper).

--- a/docs/manual/java/guide/production/code/akka-discovery-dependency.sbt
+++ b/docs/manual/java/guide/production/code/akka-discovery-dependency.sbt
@@ -1,0 +1,4 @@
+//#akka-discovery-dependency
+libraryDependencies += lagomJavadslAkkaDiscovery
+//#akka-discovery-dependency
+

--- a/docs/manual/java/guide/production/index.toc
+++ b/docs/manual/java/guide/production/index.toc
@@ -1,3 +1,4 @@
 ProductionOverview:Production Overview
+AkkaDiscoveryIntegration:Akka Discovery Integration
 LightbendPlatform:Lightbend Platform
 

--- a/docs/manual/scala/guide/production/AkkaDiscoveryIntegration.md
+++ b/docs/manual/scala/guide/production/AkkaDiscoveryIntegration.md
@@ -1,0 +1,19 @@
+# Using Akka Discovery
+
+Lagom 1.4.12 contains a backport of `Akka Discovery Service Locator`, a component introduced in Lagom 1.5.1. It provides a built-in integration with [Akka Discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html) throught a  [ServiceLocator](api/com/lightbend/lagom/scaladsl/api/ServiceLocator.html) implmentation that wraps Akka Discovery. This is the recommended implementation for production specially for users targeting Kubernetes and DC/OS (Marathon).
+
+## Dependency
+
+To use this feature add the following in your project's build:
+
+@[akka-discovery-dependency](code/akka-discovery-dependency.sbt)
+
+## Configuration
+
+Once you have it in your project you can add the component to your `LagomApplicationLoader`.
+
+@[akka-discovery-service-locator](code/AkkaDiscoveryIntegration.scala)
+
+Next, you will need to choose one of the available Akka Discovery implementations and configure it in your `application.conf` file. Consult the [Akka Discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html) documentation for further instructions.
+
+Note: this component was [previous published](https://github.com/lagom/lagom-akka-discovery-service-locator) as an independent library. If you have it on your classpath it's recommended to remove it and use the one being provided by Lagom directly.

--- a/docs/manual/scala/guide/production/ProductionOverview.md
+++ b/docs/manual/scala/guide/production/ProductionOverview.md
@@ -22,6 +22,8 @@ The production environment determines the methods for packaging your services, m
 
     * For simple deployments, Lagom includes a built-in service locator that uses addresses specified in the service configuration ([described below](#Using-static-values-for-services-and-Cassandra)).
 
+    * Since Lagom 1.4.12, you can use  [[Akka Discovery Service Locator|AkkaDiscoveryIntegration]] that integrates with the service discovery features of Kubernetes or DC/OS, or any other environment supported by [Akka's Service Discovery](https://doc.akka.io/docs/akka/2.5/discovery/index.html).
+
     * Lightbend Orchestration provides an open-source [`ServiceLocator` implementation](https://developer.lightbend.com/docs/lightbend-orchestration/current/features/service-location.html) that integrates with the service discovery features of Kubernetes or DC/OS, or any other environment that supports service discovery via DNS.
 
     * Otherwise, you can implement the interface yourself to integrate with a service registry of your choosing (such as [Consul](https://www.consul.io/), [ZooKeeper](https://zookeeper.apache.org/), or [etcd](https://coreos.com/etcd/)) or start with an open-source example implementation such as [`lagom-service-locator-consul`](https://github.com/jboner/lagom-service-locator-consul) or [`lagom-service-locator-zookeeper`](https://github.com/jboner/lagom-service-locator-zookeeper).

--- a/docs/manual/scala/guide/production/code/AkkaDiscoveryIntegration.scala
+++ b/docs/manual/scala/guide/production/code/AkkaDiscoveryIntegration.scala
@@ -1,0 +1,22 @@
+package docs.scaladsl.production.overview
+
+package akkadiscoveryservicelocator {
+
+  import docs.scaladsl.services.lagomapplication.HelloApplication
+
+  //#akka-discovery-service-locator
+  import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+  import com.lightbend.lagom.scaladsl.server._
+  import com.lightbend.lagom.scaladsl.akka.discovery.AkkaDiscoveryComponents
+
+  class HelloApplicationLoader extends LagomApplicationLoader {
+
+    override def load(context: LagomApplicationContext) =
+      new HelloApplication(context) with AkkaDiscoveryComponents
+
+    override def loadDevMode(context: LagomApplicationContext) =
+      new HelloApplication(context) with LagomDevModeComponents
+
+  }
+  //#akka-discovery-service-locator
+}

--- a/docs/manual/scala/guide/production/code/akka-discovery-dependency.sbt
+++ b/docs/manual/scala/guide/production/code/akka-discovery-dependency.sbt
@@ -1,0 +1,4 @@
+//#akka-discovery-dependency
+libraryDependencies += lagomScaladslAkkaDiscovery
+//#akka-discovery-dependency
+

--- a/docs/manual/scala/guide/production/index.toc
+++ b/docs/manual/scala/guide/production/index.toc
@@ -1,3 +1,4 @@
 ProductionOverview:Production Overview
+AkkaDiscoveryIntegration:Akka Discovery Integration
 LightbendPlatform:Lightbend Platform
 

--- a/docs/manual/scala/guide/services/ScalaComponents.md
+++ b/docs/manual/scala/guide/services/ScalaComponents.md
@@ -29,6 +29,7 @@ This is a list of available Components you may use to build your application cak
 | [ConfigurationServiceLocatorComponents](api/com/lightbend/lagom/scaladsl/client/ConfigurationServiceLocatorComponents.html)| provides a Service Locator based on `application.conf` files. See [[Using static values for services and Cassandra to simulate a managed runtime|ProductionOverview#Using-static-values-for-services-and-Cassandra]].|
 | [RoundRobinServiceLocatorComponents](api/com/lightbend/lagom/scaladsl/client/RoundRobinServiceLocatorComponents.html)| provides a Service Locator that applies a Round Robin over the passed in sequence of URI. |
 | [CircuitBreakerComponents](api/com/lightbend/lagom/scaladsl/client/CircuitBreakerComponents.html)| implementors of a Service Locator will need to extend this to reuse the Circuit Breaker config provided by Lagom.|
+| [AkkaDiscoveryComponents](api/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryComponents.html)| implementors of a Service Locator based on Akka Discovery. Available as [[opt-in dependency|AkkaDiscoveryIntegration]]. It is the recommended implementation for production specially for users targeting Kubernetes and DC/OS (Marathon).|
 
 ##### Third party Components
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -87,6 +87,8 @@ object Dependencies {
   private val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
   private val reactiveStreams = "org.reactivestreams" % "reactive-streams" % "1.0.2"
 
+  private val akkaDiscovery = "com.typesafe.akka" %% "akka-discovery" % AkkaVersion
+
   private val akkaPersistenceJdbc = "com.github.dnvriend" %% "akka-persistence-jdbc" % AkkaPersistenceJdbcVersion excludeAll (excludeSlf4j: _*)
 
   // latest version of APC depend on a Cassandra driver core that's not compatible with Lagom (newer netty/guava/etc... under the covers)
@@ -227,7 +229,7 @@ object Dependencies {
     ) ++ jacksonFamily ++ crossLibraryFamily("com.typesafe.akka", AkkaVersion)(
       "akka-actor", "akka-cluster", "akka-cluster-sharding", "akka-cluster-tools", "akka-distributed-data",
       "akka-multi-node-testkit", "akka-persistence", "akka-persistence-query", "akka-protobuf", "akka-remote",
-      "akka-slf4j", "akka-stream", "akka-stream-testkit", "akka-testkit", "akka-coordination"
+      "akka-slf4j", "akka-stream", "akka-stream-testkit", "akka-testkit", "akka-coordination", "akka-discovery"
 
     ) ++ libraryFamily("com.typesafe.play", PlayVersion)(
       "build-link", "play-exceptions", "play-netty-utils"
@@ -301,7 +303,7 @@ object Dependencies {
 
   // Dependencies for each module
   val api = libraryDependencies ++= Seq(
-    "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
+    scalaParserCombinators,
     scalaXml,
     akkaActor,
     akkaSlf4j,
@@ -453,6 +455,16 @@ object Dependencies {
     playAkkaHttpServer,
     "com.novocode" % "junit-interface" % "0.11" % Test,
     scalaTest
+  )
+  val `lagom-akka-discovery-service-locator-core` = libraryDependencies ++= Seq(
+    akkaDiscovery,
+    slf4jApi,
+    scalaTest % Test,
+
+    // Upgrades needed to match whitelist
+    scalaParserCombinators,
+    scalaJava8Compat,
+    scalaXml
   )
 
   val `cluster-core` = libraryDependencies ++= Seq(


### PR DESCRIPTION
This PR brings in the whole history of http://github.com/lagom/lagom-akka-discovery-service-locator which explain the long list of commits.

@lagom/core, when reviewing you should concentrate on the 5 last commits. All the rest is code migrated from http://github.com/lagom/lagom-akka-discovery-service-locator.

The 5 last commits here are very similar to those in #1883, except for the `Production Overview` and `Akka Discovery Integration` pages that are slightly different for 1.4.x

To visualise the changes on a browser you will need to publish locally a new version of lightbend-markdown containing this PR https://github.com/lightbend/lightbend-markdown/pull/12 and update `docs/project/plugins.sbt`