### PR TITLE
Use Akka 2.6.0-M1

### DIFF
--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -16,7 +16,7 @@ EXTRA_OPTS=""
 # Check if it is a scheduled build
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     # `sort` is not necessary, but it is good to make it predictable.
-    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.5-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.6-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
 
     echo "Using Akka SNAPSHOT ${AKKA_VERSION}"
 

--- a/dev/reloadable-server/src/main/resources/play/reference-overrides.conf
+++ b/dev/reloadable-server/src/main/resources/play/reference-overrides.conf
@@ -1,3 +1,3 @@
-# Overriding Akka's defaults so that services are assigned different tcp ports. 
-akka.remote.netty.tcp.port = 0
-akka.remote.netty.tcp.hostname = "127.0.0.1"
+# Overriding Akka's defaults so that services are assigned different tcp ports.
+akka.remote.artery.canonical.port = 0
+akka.remote.artery.canonical.hostname = "127.0.0.1"

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,6 +1,6 @@
 val ScalaVersion = "2.12.8"
 
-val AkkaVersion: String   = sys.props.getOrElse("lagom.build.akka.version", "2.5.22")
+val AkkaVersion: String   = sys.props.getOrElse("lagom.build.akka.version", "2.6.0-M1")
 val JUnitVersion          = "4.12"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion      = "3.0.8-RC2"

--- a/docs/manual/java/releases/Migration15.md
+++ b/docs/manual/java/releases/Migration15.md
@@ -10,7 +10,6 @@ For a detailed list of version upgrades of other libraries Lagom builds on such 
 
 To migrate from Lagom 1.4 we recommend first migrating to latest version of Lagom 1.4 before upgrading to Lagom 1.5. Refer to the [release notes](https://github.com/lagom/lagom/releases) for details upgrading to latest version of Lagom 1.4.
 
-
 ## Build changes
 
 ### Maven

--- a/docs/manual/java/releases/Migration16.md
+++ b/docs/manual/java/releases/Migration16.md
@@ -1,0 +1,30 @@
+
+# Lagom 1.6 Migration Guide
+
+This guide explains how to migrate from Lagom 1.5 to Lagom 1.6. If you are upgrading from an earlier version, be sure to review previous migration guides.
+
+Lagom 1.6 updates to the latest major versions of Play (2.8), Akka (2.6) and Akka HTTP (10.1). We have highlighted the changes that are relevant to most Lagom users, but you may need to change code in your services that uses Play APIs directly. You'll also need to update any Play services in your Lagom project repositories to be compatible with Play 2.8. Please refer to the [Play 2.8 migration guide](https://www.playframework.com/documentation/2.8.0-M1/Migration28), [Akka Migration Guide 2.5.x to 2.6.x](https://doc.akka.io/docs/akka/2.6.0-M1/project/migration-guide-2.5.x-2.6.x.html) and the [Akka HTTP 10.1.x release announcements](https://akka.io/blog/news-archive.html) for more details.
+
+For a detailed list of version upgrades of other libraries Lagom builds on such as for Slick, Kafka and others, refer to the [release notes](https://github.com/lagom/lagom/releases).
+
+## Migrating from Lagom 1.5
+
+To migrate from Lagom 1.5 we recommend first migrating to latest version of Lagom 1.5 before upgrading to Lagom 1.6. Refer to the [release notes](https://github.com/lagom/lagom/releases) for details upgrading to latest version of Lagom 1.5.
+
+## Build changes
+
+### Maven
+
+If you're using a `lagom.version` property in the `properties` section of your root `pom.xml`, then simply update that to `1.6.0`. Otherwise, you'll need to go through every place that a Lagom dependency, including plugins, is used, and set the version there.
+
+> **Note:** Lagom 1.6 requires, at least,  Maven `3.6.0`. Please update your environments.
+
+### sbt
+
+The version of Lagom can be updated by editing the `project/plugins.sbt` file, and updating the version of the Lagom sbt plugin. For example:
+
+```scala
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0")
+```
+
+We also recommend upgrading to sbt 1.2.8 or later, by updating the `sbt.version` in `project/build.properties`.

--- a/docs/manual/java/releases/index.toc
+++ b/docs/manual/java/releases/index.toc
@@ -1,4 +1,5 @@
 Highlights15:What's new in Lagom 1.5
+Migration16:Lagom 1.6 Migration Guide
 Migration15:Lagom 1.5 Migration Guide
 Migration14:Lagom 1.4 Migration Guide
 Migration13:Lagom 1.3 Migration Guide

--- a/docs/manual/scala/releases/Migration16.md
+++ b/docs/manual/scala/releases/Migration16.md
@@ -1,0 +1,21 @@
+# Lagom 1.6 Migration Guide
+
+This guide explains how to migrate from Lagom 1.5 to Lagom 1.6. If you are upgrading from an earlier version, be sure to review previous migration guides.
+
+Lagom 1.6 updates to the latest major versions of Play (2.8), Akka (2.6) and Akka HTTP (10.1). We have highlighted the changes that are relevant to most Lagom users, but you may need to change code in your services that uses Play APIs directly. You'll also need to update any Play services in your Lagom project repositories to be compatible with Play 2.8. Please refer to the [Play 2.8 migration guide](https://www.playframework.com/documentation/2.8.0-M1/Migration28), [Akka Migration Guide 2.5.x to 2.6.x](https://doc.akka.io/docs/akka/2.6.0-M1/project/migration-guide-2.5.x-2.6.x.html) and the [Akka HTTP 10.1.x release announcements](https://akka.io/blog/news-archive.html) for more details.
+
+For a detailed list of version upgrades of other libraries Lagom builds on such as for Slick, Kafka and others, refer to the [release notes](https://github.com/lagom/lagom/releases).
+
+## Migrating from Lagom 1.5
+
+To migrate from Lagom 1.5 we recommend first migrating to latest version of Lagom 1.5 before upgrading to Lagom 1.6. Refer to the [release notes](https://github.com/lagom/lagom/releases) for details upgrading to latest version of Lagom 1.5.
+
+## Build changes
+
+The version of Lagom can be updated by editing the `project/plugins.sbt` file, and updating the version of the Lagom sbt plugin. For example:
+
+```scala
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0")
+```
+
+We also recommend upgrading to sbt 1.2.8 or later, by updating the `sbt.version` in `project/build.properties`.

--- a/docs/manual/scala/releases/index.toc
+++ b/docs/manual/scala/releases/index.toc
@@ -1,4 +1,5 @@
 Highlights15:What's new in Lagom 1.5
+Migration16:Lagom 1.6 Migration Guide
 Migration15:Lagom 1.5 Migration Guide
 Migration14:Lagom 1.4 Migration Guide
 Migration13:Lagom 1.3 Migration Guide

--- a/docs/src/test/scala/docs/home/actor/ActorServiceSpec.scala
+++ b/docs/src/test/scala/docs/home/actor/ActorServiceSpec.scala
@@ -16,8 +16,8 @@ import java.util.concurrent.TimeUnit
 object ActorServiceSpec {
   def config = ConfigFactory.parseString("""
     akka.actor.provider = akka.cluster.ClusterActorRefProvider
-    akka.remote.netty.tcp.port = 0
-    akka.remote.netty.tcp.hostname = 127.0.0.1
+    akka.remote.artery.canonical.port = 0
+    akka.remote.artery.canonical.hostname = 127.0.0.1
     """)
 }
 
@@ -58,7 +58,7 @@ class ActorServiceSpec
       {
         val job = Job.of("123", "compute", "abc")
 
-        // might taka a while until cluster is formed and router knows about the nodes
+        // might take a while until cluster is formed and router knows about the nodes
         within(15.seconds) {
           awaitAssert {
             client.doWork().invoke(job).toCompletableFuture.get(3, TimeUnit.SECONDS) should ===(JobAccepted.of("123"))

--- a/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
+++ b/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
@@ -18,8 +18,8 @@ private[lagom] object PersistenceTestConfig {
 
   lazy val ClusterConfigMap: Map[String, AnyRef] = Map(
     "akka.actor.provider"                           -> "akka.cluster.ClusterActorRefProvider",
-    "akka.remote.netty.tcp.hostname"                -> "127.0.0.1",
-    "akka.remote.netty.tcp.port"                    -> "0",
+    "akka.remote.artery.canonical.port"             -> "0",
+    "akka.remote.artery.canonical.hostname"         -> "127.0.0.1",
     "lagom.cluster.join-self"                       -> "on",
     "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
     "lagom.cluster.bootstrap.enabled"               -> "off"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,7 @@ object Dependencies {
     val Twirl            = "1.4.1"
     val PlayFileWatch    = "1.1.8"
 
-    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.22")
+    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.6.0-M1")
     val AkkaHttp     = "10.1.8"
     val Aeron        = "1.15.1"
 

--- a/pubsub/javadsl/src/test/java/com/lightbend/lagom/javadsl/pubsub/PubSubTest.java
+++ b/pubsub/javadsl/src/test/java/com/lightbend/lagom/javadsl/pubsub/PubSubTest.java
@@ -38,8 +38,8 @@ public class PubSubTest {
     Config config =
         ConfigFactory.parseString(
             "akka.actor.provider = akka.cluster.ClusterActorRefProvider \n"
-                + "akka.remote.netty.tcp.port = 0 \n"
-                + "akka.remote.netty.tcp.hostname = 127.0.0.1 \n"
+                + "akka.remote.artery.canonical.port = 0 \n"
+                + "akka.remote.artery.canonical.hostname = 127.0.0.1 \n"
                 + "akka.loglevel = INFO \n");
 
     system = ActorSystem.create("PubSubTest", config);

--- a/pubsub/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/pubsub/PubSubSpec.scala
+++ b/pubsub/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/pubsub/PubSubSpec.scala
@@ -25,8 +25,8 @@ class PubSubSpec extends WordSpec with Matchers with BeforeAndAfterAll {
     override lazy val actorSystem = {
       val config = ConfigFactory.parseString("""
       akka.actor.provider = akka.cluster.ClusterActorRefProvider
-      akka.remote.netty.tcp.port = 0
-      akka.remote.netty.tcp.hostname = 127.0.0.1
+      akka.remote.artery.canonical.port = 0
+      akka.remote.artery.canonical.hostname = "127.0.0.1"
       akka.loglevel = INFO
     """)
       ActorSystem("PubSubTest", config)

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -80,8 +80,8 @@ class JavadslKafkaApiSpec
         bind[ServiceLocator].to[ConfigurationServiceLocator]
       )
       .configure(
-        "akka.remote.netty.tcp.port"                    -> "0",
-        "akka.remote.netty.tcp.hostname"                -> "127.0.0.1",
+        "akka.remote.artery.canonical.port"             -> "0",
+        "akka.remote.artery.canonical.hostname"         -> "127.0.0.1",
         "akka.persistence.journal.plugin"               -> "akka.persistence.journal.inmem",
         "akka.persistence.snapshot-store.plugin"        -> "akka.persistence.snapshot-store.local",
         "lagom.cluster.join-self"                       -> "on",

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -65,8 +65,8 @@ class ScaladslKafkaApiSpec
         import scala.collection.JavaConverters._
         super.additionalConfiguration ++ ConfigFactory.parseMap(
           Map(
-            "akka.remote.netty.tcp.port"                    -> "0",
-            "akka.remote.netty.tcp.hostname"                -> "127.0.0.1",
+            "akka.remote.artery.canonical.port"             -> "0",
+            "akka.remote.artery.canonical.hostname"         -> "127.0.0.1",
             "akka.persistence.journal.plugin"               -> "akka.persistence.journal.inmem",
             "akka.persistence.snapshot-store.plugin"        -> "akka.persistence.snapshot-store.local",
             "lagom.cluster.exit-jvm-when-system-terminated" -> "off",


### PR DESCRIPTION
Also, use Akka 2.6 snapshots in our nightly builds, and since Akka 2.6 does not support Scala 2.11, dropping it for Lagom as well.

## Status

Let's not merge without having some migration guide already. 