### PR TITLE
Setup JVM for docs build

### DIFF
--- a/docs/.jvmopts
+++ b/docs/.jvmopts
@@ -1,4 +1,4 @@
-# This is used to configure sbt in development
-# Note that you need to use version 0.13.13+ of the sbt launcher
--Xms1536M
--Xmx1536M
+-Xms2G
+-Xmx2G
+-Xss2M
+-XX:MaxMetaspaceSize=1G


### PR DESCRIPTION
https://github.com/lagom/lagom/pull/1886 setup `.jvmopts` on the root build but the OOME we're observing on the nightly machine are on the `docs/` build (I think), so still happen every now and then.

Haven't tested this, yet.