### PR TITLE
[1.5.x] Use LagomVersion.current

### DIFF
--- a/docs/manual/java/guide/production/AkkaDiscoveryIntegration.md
+++ b/docs/manual/java/guide/production/AkkaDiscoveryIntegration.md
@@ -20,6 +20,8 @@ In sbt:
 
 @[akka-discovery-dependency](code/akka-discovery-dependency.sbt)
 
+The example above uses `LagomVersion.current` in order to guarantee that dependency stays aligned with your current Lagom plugin version.
+
 ## Configuration
 
 The Guice module [AkkaDiscoveryServiceLocatorModule](api/index.html?com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocatorModule.html) will be added by default to your project, but will only wire in the [AkkaDiscoveryServiceLocator](api/index.html?com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocator.html) when running in production mode.

--- a/docs/manual/java/guide/production/code/akka-discovery-dependency.sbt
+++ b/docs/manual/java/guide/production/code/akka-discovery-dependency.sbt
@@ -1,4 +1,6 @@
 //#akka-discovery-dependency
-libraryDependencies +=  "com.lightbend.lagom" %% "lagom-javadsl-akka-discovery-service-locator" % "1.5.1"
+import com.lightbend.lagom.core.LagomVersion
+
+libraryDependencies +=  "com.lightbend.lagom" %% "lagom-javadsl-akka-discovery-service-locator" % LagomVersion.current
 //#akka-discovery-dependency
 

--- a/docs/manual/scala/guide/production/AkkaDiscoveryIntegration.md
+++ b/docs/manual/scala/guide/production/AkkaDiscoveryIntegration.md
@@ -8,6 +8,8 @@ To use this feature add the following in your project's build:
 
 @[akka-discovery-dependency](code/akka-discovery-dependency.sbt)
 
+The example above uses `LagomVersion.current` in order to guarantee that dependency stays aligned with your current Lagom plugin version.
+
 ## Configuration
 
 Once you have it in your project you can add the component to your `LagomApplicationLoader`.

--- a/docs/manual/scala/guide/production/code/akka-discovery-dependency.sbt
+++ b/docs/manual/scala/guide/production/code/akka-discovery-dependency.sbt
@@ -1,4 +1,6 @@
 //#akka-discovery-dependency
-libraryDependencies += "com.lightbend.lagom" %% "lagom-scaladsl-akka-discovery-service-locator" % "1.5.1"
+import com.lightbend.lagom.core.LagomVersion
+
+libraryDependencies += "com.lightbend.lagom" %% "lagom-scaladsl-akka-discovery-service-locator" % LagomVersion.current
 //#akka-discovery-dependency
 


### PR DESCRIPTION
Minor improvement that guarantees that dependency is kept aligned with Lagom plugin version