### PR TITLE
Adds AkkaDiscoveryServiceLocatorSpec

### DIFF
--- a/akka-service-locator/scaladsl/src/test/resources/application.conf
+++ b/akka-service-locator/scaladsl/src/test/resources/application.conf
@@ -1,0 +1,16 @@
+akka {
+  discovery {
+    method = config
+
+    config.services = {
+      fake-service = {
+        endpoints = [
+          {
+            host = "fake-service-host"
+            port = 9119
+          }
+        ]
+      }
+    }
+  }
+}

--- a/akka-service-locator/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryServiceLocatorSpec.scala
+++ b/akka-service-locator/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryServiceLocatorSpec.scala
@@ -35,7 +35,7 @@ class AkkaDiscoveryServiceLocatorSpec extends AsyncWordSpec with Matchers with B
     new LagomTestApplication(ctx)
   }
 
-  override protected def afterAll() = server.stop()
+  protected override def afterAll() = server.stop()
 
   class LagomTestApplication(ctx: LagomApplicationContext)
       extends LagomApplication(ctx)

--- a/akka-service-locator/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryServiceLocatorSpec.scala
+++ b/akka-service-locator/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/akka/discovery/AkkaDiscoveryServiceLocatorSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.scaladsl.akka.discovery
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api.Service
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+import com.lightbend.lagom.scaladsl.api.ServiceLocator
+import com.lightbend.lagom.scaladsl.server.LagomApplication
+import com.lightbend.lagom.scaladsl.server.LagomApplicationContext
+import com.lightbend.lagom.scaladsl.server.LagomServer
+import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
+import com.lightbend.lagom.scaladsl.testkit.ServiceTest
+import org.scalatest._
+import play.api.libs.ws.WSClient
+import play.api.libs.ws.ahc.AhcWSComponents
+
+import scala.concurrent.Future
+
+class AkkaDiscoveryServiceLocatorSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll with OptionValues {
+
+  "ServiceLocator" should {
+    "retrieve registered services" in {
+      val serviceLocator = server.application.serviceLocator
+
+      serviceLocator.locate("fake-service").map { res =>
+        res.value.toString shouldBe "http://fake-service-host:9119"
+      }
+    }
+  }
+
+  private val server = ServiceTest.startServer(ServiceTest.defaultSetup) { ctx =>
+    new LagomTestApplication(ctx)
+  }
+
+  override protected def afterAll() = server.stop()
+
+  class LagomTestApplication(ctx: LagomApplicationContext)
+      extends LagomApplication(ctx)
+      with AhcWSComponents
+      with AkkaDiscoveryComponents {
+
+    override def lagomServer: LagomServer = serverFor[TestService](new TestServiceImpl)
+  }
+
+  trait TestService extends Service {
+    def hello(name: String): ServiceCall[NotUsed, String]
+
+    override def descriptor = {
+      import Service._
+      named("test-service")
+        .withCalls(
+          pathCall("/hello/:name", hello _)
+        )
+        .withAutoAcl(true)
+    }
+  }
+
+  class TestServiceImpl extends TestService {
+    override def hello(name: String) = ServiceCall { _ =>
+      Future.successful(s"Hello $name")
+    }
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -649,6 +649,7 @@ lazy val `akka-discovery-service-locator-core` = (project in file("akka-service-
     name := "lagom-akka-discovery-service-locator-core",
     Dependencies.`lagom-akka-discovery-service-locator-core`
   )
+
 lazy val `akka-discovery-service-locator-javadsl` = (project in file("akka-service-locator/javadsl"))
   .dependsOn(`akka-discovery-service-locator-core`)
   .dependsOn(`client-javadsl`)
@@ -660,6 +661,7 @@ lazy val `akka-discovery-service-locator-javadsl` = (project in file("akka-servi
   .settings(
     name := "lagom-javadsl-akka-discovery-service-locator"
   )
+
 lazy val `akka-discovery-service-locator-scaladsl` = (project in file("akka-service-locator/scaladsl"))
   .dependsOn(`akka-discovery-service-locator-core`)
   .dependsOn(`client-scaladsl`)
@@ -669,8 +671,10 @@ lazy val `akka-discovery-service-locator-scaladsl` = (project in file("akka-serv
   // .settings(mimaSettings: _*)
   .enablePlugins(RuntimeLibPlugins)
   .settings(
-    name := "lagom-scaladsl-akka-discovery-service-locator"
+    name := "lagom-scaladsl-akka-discovery-service-locator",
+    Dependencies.`lagom-akka-discovery-service-locator-scaladsl`
   )
+  .dependsOn(`testkit-scaladsl`)
 
 lazy val `akka-management-core` = (project in file("akka-management/core"))
   .settings(runtimeLibCommon: _*)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -619,6 +619,7 @@ object Dependencies {
     "io.netty"  % "netty-transport-native-epoll" % Versions.Netty,
     "io.netty"  % "netty-transport-native-unix-common" % Versions.Netty
   )
+
   val `lagom-akka-discovery-service-locator-core` = libraryDependencies ++= Seq(
     akkaDiscovery,
     slf4jApi,
@@ -626,6 +627,11 @@ object Dependencies {
     // Upgrades needed to match whitelist
     scalaJava8Compat,
     scalaXml
+  )
+
+
+  val `lagom-akka-discovery-service-locator-scaladsl` = libraryDependencies ++= Seq(
+    scalaTest % Test
   )
 
   val `akka-management-core` = libraryDependencies ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -629,7 +629,6 @@ object Dependencies {
     scalaXml
   )
 
-
   val `lagom-akka-discovery-service-locator-scaladsl` = libraryDependencies ++= Seq(
     scalaTest % Test
   )


### PR DESCRIPTION
Originally intended to be added in https://github.com/lagom/lagom-akka-discovery-service-locator/pull/80

This doesn't need to be backported as any further change is expected to happen in `master` and regressions expected to be caught by this test.

There is no Java counterpart because the `ServiceTest` wires its own `ServiceLocator`, making it hard to test it. If we really want it tested in Java we will need to refractor the `ServiceTest` for Java. 