### PR TITLE
[WIP] Use Akka's Serialized Execution

### DIFF
--- a/persistence-cassandra/core/src/main/scala/akka/lagom/internal/SerializedExecutionAccessor.scala
+++ b/persistence-cassandra/core/src/main/scala/akka/lagom/internal/SerializedExecutionAccessor.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+package akka.lagom.internal
+
+import scala.concurrent.ExecutionContext
+import akka.annotation.InternalApi
+
+import scala.concurrent.Future
+import akka.Done
+
+/**
+ *
+ */
+@InternalApi object SerializedExecutionAccessor {
+
+  def serializedExecution(
+      recur: () => Future[Done],
+      exec: () => Future[Done]
+  )(implicit ec: ExecutionContext): Future[Done] = {
+
+    akka.persistence.cassandra.session.scaladsl.CassandraSession.serializedExecution(
+      recur,
+      exec
+    )
+  }
+}

--- a/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickProvider.scala
+++ b/persistence-jdbc/core/src/main/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickProvider.scala
@@ -234,7 +234,7 @@ private[lagom] class SlickProvider(system: ActorSystem)(implicit ec: ExecutionCo
   }
 
   /**
-   * Ensure the tables are created if configured.
+   * Ensure the Journal and Snapshot tables are created if configured.
    */
   def ensureTablesCreated(): Future[Done] = {
     createTablesTask match {

--- a/persistence/core/src/main/scala/com/lightbend/lagom/spi/persistence/OffsetStore.scala
+++ b/persistence/core/src/main/scala/com/lightbend/lagom/spi/persistence/OffsetStore.scala
@@ -16,6 +16,13 @@ import scala.collection.concurrent
 trait OffsetStore {
 
   /**
+   * Globally prepare the Offset Store. This usually means ensuring the backing table exists.
+   *
+   * @return Done when completed
+   */
+  def globalPrepare(): Future[Done]
+
+  /**
    * Prepare this offset store to process the given ID and tag.
    *
    * @param eventProcessorId The ID of the event processor.
@@ -50,6 +57,8 @@ trait OffsetDao {
 class InMemoryOffsetStore extends OffsetStore {
   private final val store: concurrent.Map[String, Offset] = concurrent.TrieMap.empty
 
+  override def globalPrepare(): Future[Done] = Future.successful(Done)
+
   override def prepare(eventProcessorId: String, tag: String): Future[OffsetDao] = {
     val key = s"$eventProcessorId-$tag"
     Future.successful(new OffsetDao {
@@ -60,4 +69,5 @@ class InMemoryOffsetStore extends OffsetStore {
       override val loadedOffset: Offset = store.getOrElse(key, NoOffset)
     })
   }
+
 }

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -51,11 +51,11 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       # increase default timeouts to leave wider margin for Travis.
       # 30s to 60s
       akka.testconductor.barrier-timeout=60s
-      # 5s to 10s
-      lagom.persistence.ask-timeout = 9s
-      # 5s to 10s
+      # 5s to 17s // 9s proved too aggressive for Travis.
+      lagom.persistence.ask-timeout = 17s
+      # 5s to 11s
       akka.test.single-expect-default = 11s
-      ## use 9s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
+      ## use 17s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
       ## Also, make the Akka expect() timeouts higher since this tests often expect over an ask operation.
 
       # Don't terminate the actor system when doing a coordinated shutdown

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -48,11 +48,11 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
       # increase default timeouts to leave wider margin for Travis.
       # 30s to 60s
       akka.testconductor.barrier-timeout=60s
-      # 5s to 9s
-      lagom.persistence.ask-timeout = 9s
+      # 5s to 17s // 9s proved too aggressive for Travis.
+      lagom.persistence.ask-timeout = 17s
       # 5s to 11s
       akka.test.single-expect-default = 11s
-      ## use 9s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
+      ## use 17s and 11s for the above timeout because it's coprime values and it'll be easier to spot interferences.
       ## Also, make the Akka expect() timeouts higher since this tests often expect over an ask operation.
 
       # Don't terminate the actor system when doing a coordinated shutdown

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.13-SNAPSHOT"
+version in ThisBuild := "1.4.13-a5bd71c7"


### PR DESCRIPTION
This is a blind attempt at reducing the odds of the infamous `Column family ID mismatch`. We've found no way to build a reproducer.

This is an open invitation to users to check out this branch and build lagom locally using `sbt +publishLocal` to test this fix in their (flaky) environments.

See https://github.com/lagom/lagom/issues/1889

This PR does two things:

1. use `akka-persistence-cassandra`'s `CassandraSession.serializedExecution` so the Lagom read-side doesn't try to create the read-side `KEYSPACE` at the same time other threads create the journal of the snapshot `KEYSPACE`'s (all three may be the same `KEYSPACE`)
2. adds `globalPrepare` to Lagom's `OffsertStore`. Before this PR, the cluster-wide OffsetStore creation was already implemented as a `ClusterStartupTask` but would run sneakily as part of `OfffsetStore#prepare`. Having separate methods makes it cleaner. The `OffsetStore#globalPrepare` is used to ensure no user code runs until the `offsetStore` is already created. Before this PR user's `globalPrepare` would usually run before the offsetStore creation and could even execute concurrently if the Lagom service had both topic producers and read side processors. 