### PR TITLE
Alpakka Kafka 1.0.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,7 +44,7 @@ object Dependencies {
     val Netty                = "4.1.34.Final"
     val NettyReactiveStreams = "2.0.3"
     val Kafka                = "2.1.1"
-    val AlpakkaKafka         = "1.0.2"
+    val AlpakkaKafka         = "1.0.3"
     val Curator              = "2.12.0"
     val Immutables           = "2.3.10"
     val HibernateCore        = "5.3.7.Final"


### PR DESCRIPTION
Upgrade to the latest patch release of Alpakka Kafka.

[Release notes](https://doc.akka.io/docs/alpakka-kafka/1.0.3/release-notes/1.0.x.html#1-0-3)