### PR TITLE
Add protobuf akka serializers

### DIFF
--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -23,3 +23,10 @@ lagom.defaults.cluster.join-self = off
 # shutdown the actor system if it can't join a cluster after 60s
 # useful in production environments to let the deployment orchestration solutions restart the service
 akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 60s
+
+akka.actor.serialization-bindings {
+  "akka.Done"                 = akka-misc
+  "akka.NotUsed"              = akka-misc
+  "akka.actor.Address"        = akka-misc
+  "akka.remote.UniqueAddress" = akka-misc
+}


### PR DESCRIPTION
This can be ported to 1.5.x and get shipped on 1.5.2. It has no impact on rolling updates becaues those serializers are already available since Akka 2.5.8 and Lagom 1.4.x and 1.5.x have them already included.

Resolves #1270