### PR TITLE
Fix compile warning

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -66,8 +66,8 @@ lazy val docs = project
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     // This is needed so that Java APIs that use immutables will typecheck by the Scala compiler
     compileOrder in Test := CompileOrder.JavaThenScala,
-    sourceDirectories in format in Test ++= (unmanagedSourceDirectories in Test).value,
-    sourceDirectories in format in Test ++= (unmanagedResourceDirectories in Test).value,
+    sourceDirectories in javafmt in Test ++= (unmanagedSourceDirectories in Test).value,
+    sourceDirectories in javafmt in Test ++= (unmanagedResourceDirectories in Test).value,
     markdownDocumentation := {
       val javaUnidocTarget = parentDir / "target" / "javaunidoc"
       val unidocTarget     = parentDir / "target" / "unidoc"


### PR DESCRIPTION
```
/home/play/deploy/lagom/docs/build.sbt:69: warning: value format in object JavaFormatterKeys is      deprecated (since 0.4.4): Use javafmt
    sourceDirectories in format in Test ++= (unmanagedSourceDirectories in Test).value,
                             ^
/home/play/deploy/lagom/docs/build.sbt:70: warning: value format in object JavaFormatterKeys is      deprecated (since 0.4.4): Use javafmt
    sourceDirectories in format in Test ++= (unmanagedResourceDirectories in Test).value,
                          ^

```