### PR TITLE
Removed extra comma from the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Lagom is a Swedish word meaning *just right, sufficient*. Microservices are about creating services that are just the right size, that is, they have just the right level of functionality and isolation to be able to adequately implement a scalable and resilient system.
 
-Lagom focuses on ensuring that your application realises the full potential of the [Reactive Manifesto](http://reactivemanifesto.org), while delivering a high productivity development environment, and seamless production deployment experience.
+Lagom focuses on ensuring that your application realises the full potential of the [Reactive Manifesto](http://reactivemanifesto.org) while delivering a high productivity development environment, and seamless production deployment experience.
 
 ## Learn More
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Lagom is a Swedish word meaning *just right, sufficient*. Microservices are about creating services that are just the right size, that is, they have just the right level of functionality and isolation to be able to adequately implement a scalable and resilient system.
 
-Lagom focuses on ensuring that your application realises the full potential of the [Reactive Manifesto](http://reactivemanifesto.org) while delivering a high productivity development environment, and seamless production deployment experience.
+Lagom focuses on ensuring that your application realizes the full potential of the [Reactive Manifesto](http://reactivemanifesto.org) while delivering a high productivity development environment, and seamless production deployment experience.
 
 ## Learn More
 


### PR DESCRIPTION
I found that there is an extra comma in the statement which I found in Grammarly extension of google chrome

# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md
![oss](https://user-images.githubusercontent.com/40783840/57712700-aeb45c00-768e-11e9-9faf-cb93dfc14758.png)
)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?
This will correct the punctuation mistake.
## Background Context

Why did you take this approach?
Many people are getting much knowledge from this repo it should be perfect
## References

Are there any relevant issues / PRs / mailing lists discussions?
No