### PR TITLE
Change most live references to lagom-recipes to lagom-samples

### DIFF
--- a/docs/manual/common/gettingstarted/LagomExamples.md
+++ b/docs/manual/common/gettingstarted/LagomExamples.md
@@ -1,11 +1,12 @@
 # Learning more from Lagom examples
 
-After getting started with Hello World, you can learn more about Lagom by downloading and running one of the following examples from GitHub:
+After getting started with Lagom's Hello World example, you can learn more about Lagom by downloading and
+running Lagom's "Shopping Cart" example (either [shopping-cart-scala][] or [shopping-cart-java][]).
 
-* [Chirper](https://github.com/search?utf8=%E2%9C%93&q=Lagom+chirper) demonstrates a Twitter-like application and is available for Java and Scala, with Java variations that demonstrate use of JPA and JDBC.
-* [Online Auction](https://github.com/search?utf8=%E2%9C%93&q=lagom%2Fonline+auction&type=Repositories&ref=searchresults) demonstrates an eBay-like application and is also available for both Java and Scala.
+[shopping-cart-scala]: https://github.com/lagom/lagom-samples/tree/1.5.x/shopping-cart/shopping-cart-scala
+[shopping-cart-java]: https://github.com/lagom/lagom-samples/tree/1.5.x/shopping-cart/shopping-cart-java
 
-Some of the Lagom features you can observe in these examples include:
+Some of the Lagom features you can observe include:
 
 Feature |Chirper| Online Auction |
 --------|:--------:|:-------------:|
@@ -29,6 +30,3 @@ For focused examples, check the [lagom-samples](https://github.com/lagom/lagom-s
 * How do I configure the Circuit Breaker Panel for a Lagom Java application? (Java/Maven example)
 * How do I deploy a Lagom Maven application in Kubernetes? (Java/Maven example)
 * How do I use Lagom with Couchbase both write-side and read-side? Java Maven and Scala Sbt) (Couchbase Persistence is NOT production ready yet)
-
-
-

--- a/docs/manual/common/gettingstarted/LagomExamples.md
+++ b/docs/manual/common/gettingstarted/LagomExamples.md
@@ -16,7 +16,7 @@ How streaming service calls work | Y | N
 How to develop a Play app with Lagom | Y | Y
 How to consume Lagom services from a front-end Play app | N | Y
 
-For focused examples, check the [lagom-recipes](https://github.com/lagom/lagom-recipes) repository on GitHub. Each recipe describes how to achieve a particular goal, such as:
+For focused examples, check the [lagom-samples](https://github.com/lagom/lagom-samples) repository on GitHub. Each sample describes how to achieve a particular goal, such as:
 
 * How do I enable CORS? (using Lagom's javadsl or scaladsl)
 * How do I create a Subscriber only service? (also referred to as consumer service)

--- a/docs/manual/common/guide/production/LightbendPlatform.md
+++ b/docs/manual/common/guide/production/LightbendPlatform.md
@@ -31,7 +31,7 @@ To use these with Lagom, the Lightbend Telemetry agent must be included as a dep
 * [Java example project](https://developer.lightbend.com/docs/telemetry/current/getting-started/lagom_java.html)
 * [Scala example project](https://developer.lightbend.com/docs/telemetry/current/getting-started/lagom_scala.html)
 
-See [Integrating Lagom with Lightbend Telemetry](https://github.com/lagom/lagom-recipes/blob/master/lightbend-telemetry/lightbend-telemetry-java-mvn/README.md) for a Java example of integrating Telemetry into a Lagom service.
+See [Integrating Lagom with Lightbend Telemetry](https://github.com/lagom/lagom-samples/blob/1.5.x/lightbend-telemetry/lightbend-telemetry-java-mvn/README.md) for a Java example of integrating Telemetry into a Lagom service.
 
 ## Configuring a Lagom build for Lightbend Platform
 

--- a/docs/manual/java/guide/cluster/PersistentEntity.md
+++ b/docs/manual/java/guide/cluster/PersistentEntity.md
@@ -32,7 +32,7 @@ Lagom is compatible with the following databases:
 
 For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project. If you wish to use Couchbase, proceed to the [Lagom section of the Akka Persistence Couchbase site](https://doc.akka.io/docs/akka-persistence-couchbase/current/lagom-persistent-entity.html) for all the details.
 
-To see how to combine Cassandra for write-side persistence and JPA for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-recipes/blob/master/mixed-persistence/mixed-persistence-java-sbt/README.md) recipe.
+To see how to combine Cassandra for write-side persistence and JPA for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-samples/blob/1.5.x/mixed-persistence/mixed-persistence-java-sbt/README.md) sample.
 
 Lagom provides out of the box support for running Cassandra in a development environment - developers do not need to install, configure or manage Cassandra at all themselves when using Lagom, which makes for great developer velocity, and it means gone are the days where developers spend days setting up their development environment before they can start to be productive on a project.
 

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -32,7 +32,7 @@ Lagom is compatible with the following databases:
 
 For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project. If you wish to use Couchbase, proceed to the [Lagom section of the plugin site](https://doc.akka.io/docs/akka-persistence-couchbase/current/lagom-persistent-entity.html) for all the details.
 
-To see how to combine Cassandra for write-side persistence and JDBC for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-recipes/blob/master/mixed-persistence/mixed-persistence-scala-sbt/README.md) recipe.
+To see how to combine Cassandra for write-side persistence and JDBC for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-samples/blob/1.5.x/mixed-persistence/mixed-persistence-scala-sbt/README.md) example.
 
 Lagom provides out of the box support for running Cassandra in a development environment - developers do not need to install, configure or manage Cassandra at all themselves when using Lagom, which makes for great developer velocity, and it means gone are the days where developers spend days setting up their development environment before they can start to be productive on a project.
 


### PR DESCRIPTION
Fixes #1921

There's a few left over.  First the ones in the 1.5 migration guide, which are fine to point to the
archived recipes, but there are also a few others.