### PR TITLE
Add Akka snapshots repo to java-archetype maven test too

### DIFF
--- a/dev/maven-plugin/src/maven-test/java-archetype-2.12/pom.xml
+++ b/dev/maven-plugin/src/maven-test/java-archetype-2.12/pom.xml
@@ -6,6 +6,16 @@
 
     <packaging>pom</packaging>
 
+    <repositories>
+        <repository>
+            <id>akka-snapshots</id>
+            <name>Akka Snapshots</name>
+            <url>https://repo.akka.io/snapshots/</url>
+            <layout>default</layout>
+            <snapshots><enabled>false</enabled></snapshots> <!-- as in, no -SNAPSHOT dependencies -->
+        </repository>
+    </repositories>
+
     <profiles>
         <!-- The my-lagom-system module doesn't exist until after running the archetype:generate, so we need to activate
          it in a profile -->


### PR DESCRIPTION
As the java-archetype project is POM I thought it might not be necessary, but https://travis-ci.com/lagom/lagom/jobs/201351645 proved me wrong.