### PR TITLE
Document another alternative to use Akka Discovery Service Locator feature for Lagom 1.5.x

### DIFF
--- a/docs/manual/java/guide/production/AkkaDiscoveryIntegration.md
+++ b/docs/manual/java/guide/production/AkkaDiscoveryIntegration.md
@@ -22,6 +22,10 @@ In sbt:
 
 The example above uses `LagomVersion.current` in order to guarantee that dependency stays aligned with your current Lagom plugin version.
 
+Another alternative to use this feature in SBT would be using the `lagomJavadslAkkaDiscovery` variable declared in [LagomImport](https://github.com/lagom/lagom/blob/master/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala) object where the dependency is imported via ID.
+
+@[akka-discovery-dependency](code/akka-discovery-dependency-using-module-id.sbt)
+
 ## Configuration
 
 The Guice module [AkkaDiscoveryServiceLocatorModule](api/index.html?com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocatorModule.html) will be added by default to your project, but will only wire in the [AkkaDiscoveryServiceLocator](api/index.html?com/lightbend/lagom/javadsl/akka/discovery/AkkaDiscoveryServiceLocator.html) when running in production mode.

--- a/docs/manual/java/guide/production/code/akka-discovery-dependency-using-module-id.sbt
+++ b/docs/manual/java/guide/production/code/akka-discovery-dependency-using-module-id.sbt
@@ -1,0 +1,5 @@
+//#akka-discovery-dependency
+
+libraryDependencies += lagomJavadslAkkaDiscovery
+
+//#akka-discovery-dependency

--- a/docs/manual/scala/guide/production/AkkaDiscoveryIntegration.md
+++ b/docs/manual/scala/guide/production/AkkaDiscoveryIntegration.md
@@ -10,6 +10,10 @@ To use this feature add the following in your project's build:
 
 The example above uses `LagomVersion.current` in order to guarantee that dependency stays aligned with your current Lagom plugin version.
 
+Another alternative to use this feature would be using the `lagomScaladslAkkaDiscovery` variable declared in [LagomImport](https://github.com/lagom/lagom/blob/master/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala) object where the dependency is imported via ID.
+
+@[akka-discovery-dependency](code/akka-discovery-dependency-using-module-id.sbt)
+
 ## Configuration
 
 Once you have it in your project you can add the component to your `LagomApplicationLoader`.

--- a/docs/manual/scala/guide/production/code/akka-discovery-dependency-using-module-id.sbt
+++ b/docs/manual/scala/guide/production/code/akka-discovery-dependency-using-module-id.sbt
@@ -1,0 +1,5 @@
+//#akka-discovery-dependency
+
+libraryDependencies += lagomScaladslAkkaDiscovery
+
+//#akka-discovery-dependency


### PR DESCRIPTION
## Purpose
The purpose of this PR is provide a simplified alternative to add Akka Discovery ServiceLocator feature to project without specify the Lagom version in the SBT definition. 