### PR TITLE
Use a Java 11 friendly lombok version

### DIFF
--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/pom.xml
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/pom.xml
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.16.10</version>
+                <version>1.18.8</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Using lagom/lagom-java.g8 on Java 11 I got multiple runtime errors caused by an old version of lombok. Bumping to latest version `1.18.8` gets the job done.

See https://github.com/lagom/lagom-java.g8/pull/54