### PR TITLE
Fix maven-plugin pom file generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ language: scala
 # https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
 if: type != push OR tag IS present OR repo != lagom/lagom
 
+addons:
+  apt:
+    packages:
+      # Needed for `xmllint` which is used to validate pom files
+      - libxml2-utils
+      - xmlstarlet
+      # Used to download maven xsd file
+      - wget
+
 env:
   global:
     # the following `secure` is WHITESOURCE_PASSWORD which is the same for all branches.

--- a/bin/test-maven
+++ b/bin/test-maven
@@ -6,3 +6,38 @@
 
 runSbt +publishM2
 runSbtNoisy mavenTest
+
+validate_pom_files() {
+  # Let's start with success
+  exit_code=0
+
+  # Downloads maven schema file which will be used to validate the generated pom file
+  wget -c http://maven.apache.org/xsd/maven-4.0.0.xsd
+
+  for f in $(find . -name *.pom); do
+    echo "Validating file $f"
+    xmllint --noout -schema maven-4.0.0.xsd ${f}
+
+    # The xmllint comand above runs regular validation based on maven.xsd
+    # file, which allows a pom file without `scm` and `developers` tags.
+    # But when publishing to Sonatype, these tags are required. So we are
+    # also testing them here.
+    scm_count=$(xmlstarlet sel -N mvn='http://maven.apache.org/POM/4.0.0' -t -c "count(/mvn:project/mvn:scm/mvn:url)" ${f})
+    dev_count=$(xmlstarlet sel -N mvn='http://maven.apache.org/POM/4.0.0' -t -c "count(/mvn:project/mvn:developers)" ${f})
+
+    if [[ ${scm_count} == 0 ]]; then
+      echo "File ${f} is lacking /project/scm/url tag"
+      exit_code=1
+    fi
+
+    if [[ ${scm_count} == 0 ]]; then
+      echo "File ${f} is lacking /project/developers tag"
+      exit_code=1
+    fi
+  done
+
+  return $exit_code
+}
+
+printMessage "VALIDATE MAVEN POM FILES"
+validate_pom_files

--- a/build.sbt
+++ b/build.sbt
@@ -1209,10 +1209,12 @@ lazy val `maven-plugin` = (project in file("dev") / "maven-plugin")
       "-Dorg.slf4j.simpleLogger.showLogName=false",
       "-Dorg.slf4j.simpleLogger.showThreadName=false"
     ),
-    pomExtra :=
-      <prerequisites>
+    pomExtra ~= (existingPomExtra => {
+      existingPomExtra ++
+        <prerequisites>
         <maven>{Dependencies.Versions.Maven}</maven>
       </prerequisites>
+    })
   )
   .dependsOn(`build-tool-support`)
 


### PR DESCRIPTION
POM file for maven-plugin was lacking `/project/scm` and `/project/developers` tag. This fixes the problem and adds a validation on Travis.