### PR TITLE
Update sbt-sonatype to version 2.5

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 // of the build. To validate your changes on the release plugins don't
 // affect the release process, review https://github.com/lagom/lagom/issues/1496#issuecomment-408398508
 addSbtPlugin("de.heikoseeberger" % "sbt-header"   % "5.2.0")
-addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.3")
+addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype" % "2.5")
 addSbtPlugin("com.github.gseitz" % "sbt-release"  % "1.0.11")
 addSbtPlugin("com.jsuereth"      % "sbt-pgp"      % "1.1.2")
 addSbtPlugin("org.foundweekends" % "sbt-bintray"  % "0.5.5")


### PR DESCRIPTION
## Fixes

This hopefully fixes a problem with sbt-sonatype where multiple staging repositories are created when releasing Lagom.