### PR TITLE
Start using dynver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1154,7 +1154,7 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
         .exclude("org.slf4j", "slf4j-simple")
     ),
     // This ensure that files in sbt-test are also included
-    headerSources in Compile ++= (sbtTestDirectory.value ** ("*.scala" || "*.java")).get(),
+    headerSources in Compile ++= (sbtTestDirectory.value ** ("*.scala" || "*.java")).get,
     scriptedDependencies := {
       val () = scriptedDependencies.value
 
@@ -1230,7 +1230,7 @@ lazy val `maven-plugin` = (project in file("dev") / "maven-plugin")
     crossPaths := false,
     mavenClasspath := (externalDependencyClasspath in (`maven-launcher`, Compile)).value.map(_.data),
     // This ensure that files in maven-test are also included
-    headerSources in Compile ++= (sourceDirectory.value / "maven-test" ** ("*.scala" || "*.java")).get(),
+    headerSources in Compile ++= (sourceDirectory.value / "maven-test" ** ("*.scala" || "*.java")).get,
     mavenTestArgs := Seq(
       "-Xmx768m",
       "-XX:MaxMetaspaceSize=384m",

--- a/build.sbt
+++ b/build.sbt
@@ -93,15 +93,9 @@ def releaseSettings: Seq[Setting[_]] = Seq(
 
     Seq[ReleaseStep](
       checkSnapshotDependencies,
-      inquireVersions,
-      setReleaseVersion,
-      commitReleaseVersion,
-      tagRelease,
       releaseStepCommandAndRemaining("+publishSigned"),
       releaseStepTask(bintrayRelease in thisProjectRef.value),
-      releaseStepCommand("sonatypeRelease"),
-      setNextVersion,
-      commitNextVersion,
+      // releaseStepCommand("sonatypeRelease"),
       pushChanges
     )
   }

--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,7 @@ def releaseSettings: Seq[Setting[_]] = Seq(
       checkSnapshotDependencies,
       releaseStepCommandAndRemaining("+publishSigned"),
       releaseStepTask(bintrayRelease in thisProjectRef.value),
-      // releaseStepCommand("sonatypeRelease"),
+      releaseStepCommand("sonatypeRelease"),
       pushChanges
     )
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,4 +19,4 @@ addSbtPlugin("com.lightbend"    % "sbt-whitesource"      % "0.1.14")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.0.0")
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")
+addSbtPlugin("com.dwijnand"      % "sbt-dynver"         % "3.3.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,3 +19,4 @@ addSbtPlugin("com.lightbend"    % "sbt-whitesource"      % "0.1.14")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.0.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.3.0")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.6.0-SNAPSHOT"


### PR DESCRIPTION
Just a quick trial to see how Lagom will behave with dynver. 

That will probably not work when releasing in vegemite. We may want to test this branch in vegemite eventually.

Another issue is that we are not prefixing the tags with a `v`, so to have it really working we will have to retroactively add prefixed tags. Unless there is a way to tweak dynver to now require a `v`.