### PR TITLE
Increase compression threshold

### DIFF
--- a/docs/manual/java/guide/cluster/Serialization.md
+++ b/docs/manual/java/guide/cluster/Serialization.md
@@ -34,7 +34,7 @@ JSON can be rather verbose and for large messages it can be beneficial to enable
 
 @[compressed-jsonable](code/docs/home/serialization/AbstractAuthor.java)
 
-The serializer will by default only compress messages that are larger than 1024 bytes. This threshold can be changed with configuration property `lagom.serialization.json.compress-larger-than`.
+The serializer will by default only compress messages that are larger than 32 Kb. This threshold can be changed with configuration property `lagom.serialization.json.compress-larger-than`.
 
 ## Schema Evolution
 

--- a/docs/manual/java/releases/Migration16.md
+++ b/docs/manual/java/releases/Migration16.md
@@ -28,3 +28,9 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0")
 ```
 
 We also recommend upgrading to sbt 1.2.8 or later, by updating the `sbt.version` in `project/build.properties`.
+
+## Minor changes
+
+### JSON Compression threshold
+
+When marking a serializable class with `CompressedJsonable` compression will only kick in when the serialized representation goes past a threshold. The default value for `lagom.serialization.json.compress-larger-than` has been increased from 1024 bytes to 32 Kilobytes. (See [#1983](https://github.com/lagom/lagom/pull/1983))

--- a/docs/manual/scala/guide/cluster/Serialization.md
+++ b/docs/manual/scala/guide/cluster/Serialization.md
@@ -39,7 +39,7 @@ JSON can be rather verbose and for large messages it can be beneficial to enable
 
 @[registry-compressed](code/docs/home/scaladsl/serialization/RegistryWithCompression.scala)
 
-The serializer will by default only compress messages that are larger than 1024 bytes. This threshold can be changed with configuration property:
+The serializer will by default only compress messages that are larger than 32Kb. This threshold can be changed with configuration property:
 
 @[compress-larger-than](../../../../../play-json/src/main/resources/reference.conf)
 

--- a/docs/manual/scala/releases/Migration16.md
+++ b/docs/manual/scala/releases/Migration16.md
@@ -19,3 +19,9 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0")
 ```
 
 We also recommend upgrading to sbt 1.2.8 or later, by updating the `sbt.version` in `project/build.properties`.
+
+## Minor changes
+
+### JSON Compression threshold
+
+When creating a serializer with `JsonSerializer.compressed[T]` compression will only kick in when the serialized representation is biger than a threshold. The default value for `lagom.serialization.json.compress-larger-than` has been increased from 1024 bytes to 32 Kilobytes. (See [#1983](https://github.com/lagom/lagom/pull/1983))

--- a/jackson/src/main/resources/reference.conf
+++ b/jackson/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ lagom.serialization.json {
   # implements the CompressedJsonable marker interface and the payload 
   # is larger than this value. Only used for remote messages within 
   # the cluster of the service.
-  compress-larger-than = 1024b
+  compress-larger-than = 32 KiB
   
   # Define data migration transformations of old formats to current 
   # format here as a mapping between the (old) class name to be

--- a/jackson/src/test/java/com/lightbend/lagom/serialization/JacksonJsonSerializerTest.java
+++ b/jackson/src/test/java/com/lightbend/lagom/serialization/JacksonJsonSerializerTest.java
@@ -29,6 +29,9 @@ import akka.testkit.javadsl.TestKit;
 
 public class JacksonJsonSerializerTest {
 
+  // Keep this number in sync with the value set up in `reference.conf`
+  private static int COMPRESSION_THRESHOLD = 32 * 1024;
+
   static ActorSystem system;
 
   @BeforeClass
@@ -107,7 +110,7 @@ public class JacksonJsonSerializerTest {
   @Test
   public void testBigCompressedJsonableMessage() {
     StringBuilder b = new StringBuilder();
-    for (int i = 0; i < 1024; i++) {
+    for (int i = 0; i < COMPRESSION_THRESHOLD; i++) {
       b.append("a");
     }
     LargeCommand msg = LargeCommand.of(b.toString());

--- a/play-json/src/main/resources/reference.conf
+++ b/play-json/src/main/resources/reference.conf
@@ -11,7 +11,7 @@ lagom.serialization.json {
   # was registered using JsonSerializer.compressed and the payload
   # is larger than this value. Only used for remote messages within
   # the cluster of the service.
-  compress-larger-than = 1024b
+  compress-larger-than = 32 KiB
 
 }
 #//#compress-larger-than

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -136,7 +136,7 @@ case class Box(surprise: Option[String])
 
 class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
-  // this is a magic number. I know longContent will compress well under this 1024.
+  // this is a magic number copied from src/main/reference.conf.
   val COMPRESSION_THRESHOLD = 32 * 1024
 
   "The PlayJsonSerializer" should {

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -136,6 +136,9 @@ case class Box(surprise: Option[String])
 
 class PlayJsonSerializerSpec extends WordSpec with Matchers {
 
+  // this is a magic number. I know longContent will compress well under this 1024.
+  val COMPRESSION_THRESHOLD = 32 * 1024
+
   "The PlayJsonSerializer" should {
 
     "pick up serializers from configured registry" in withActorSystem(TestRegistry1) { system =>
@@ -284,7 +287,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
     "use compression when enabled and payload is bigger than threshold" in withActorSystem(TestRegistryWithCompression) {
       system =>
         val serializeExt = SerializationExtension(system)
-        val longContent  = "test" * 1024
+        val longContent  = "t" * COMPRESSION_THRESHOLD
         val bigEvent1    = Event1(longContent, 1)
         val bigEvent2    = Event2(longContent, Inner(on = true))
         val shortContent = "clearText-short"
@@ -294,7 +297,7 @@ class PlayJsonSerializerSpec extends WordSpec with Matchers {
           val serializer = serializeExt.findSerializerFor(event).asInstanceOf[SerializerWithStringManifest]
 
           val bytes = serializer.toBinary(event)
-          bytes.length should be < 1024 // this is a magic number. I know longContent will compress well under this 1024.
+          bytes.length should be < COMPRESSION_THRESHOLD
           Compression.isGZipped(bytes) should be(true)
           val manifest = serializer.manifest(event)
 


### PR DESCRIPTION
After testing the impact of GZipping JSON messages (see https://github.com/akka/akka/pull/27067) the default to run compression should be increased.