### PR TITLE
Adds defaults settings for remote classic

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1202,6 +1202,7 @@ lazy val `sbt-plugin` = (project in file("dev") / "sbt-plugin")
       val () = (publishLocal in `client-scaladsl`).value
       val () = (publishLocal in `cluster-core`).value
       val () = (publishLocal in `cluster-javadsl`).value
+      val () = (publishLocal in `cluster-scaladsl`).value
       val () = (publishLocal in `immutables`).value
       val () = (publishLocal in `jackson`).value
       val () = (publishLocal in `logback`).value

--- a/dev/reloadable-server/src/main/resources/play/reference-overrides.conf
+++ b/dev/reloadable-server/src/main/resources/play/reference-overrides.conf
@@ -1,3 +1,8 @@
 # Overriding Akka's defaults so that services are assigned different tcp ports.
 akka.remote.artery.canonical.port = 0
 akka.remote.artery.canonical.hostname = "127.0.0.1"
+
+# Overriding Akka's defaults for Remote Classic so that services are assigned different tcp ports.
+# needed when users opt-out from Artery
+akka.remote.classic.netty.tcp.port = 0
+akka.remote.classic.netty.tcp.hostname = "127.0.0.1"

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/api/src/main/scala/api/FooService.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/api/src/main/scala/api/FooService.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package api
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api._
+import com.lightbend.lagom.scaladsl.api.transport.Method
+
+trait FooService extends Service {
+
+  def foo: ServiceCall[NotUsed, String]
+
+  override def descriptor = {
+    import Service._
+    named("a")
+      .withCalls(
+        restCall(Method.GET, "/foo", foo)
+      )
+      .withAutoAcl(true)
+  }
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/impl/src/main/resources/application.conf
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/impl/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.application.loader = impl.FooLoader

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/impl/src/main/scala/impl/FooLoader.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/impl/src/main/scala/impl/FooLoader.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package impl
+
+import api.FooService
+import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import com.lightbend.lagom.scaladsl.cluster.ClusterComponents
+import com.lightbend.lagom.scaladsl.playjson.EmptyJsonSerializerRegistry
+import com.lightbend.lagom.scaladsl.server._
+import com.softwaremill.macwire._
+import play.api.libs.ws.ahc.AhcWSComponents
+
+class FooLoader extends LagomApplicationLoader {
+
+  override def load(context: LagomApplicationContext): LagomApplication =
+    new FooApplication(context) {
+      override def serviceLocator = NoServiceLocator
+    }
+
+  override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+    new FooApplication(context) with LagomDevModeComponents
+}
+
+abstract class FooApplication(context: LagomApplicationContext)
+  extends LagomApplication(context)
+    with AhcWSComponents
+    with ClusterComponents {
+
+  override lazy val lagomServer = serverFor[FooService](wire[FooServiceImpl])
+
+  lazy val jsonSerializerRegistry = EmptyJsonSerializerRegistry
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/impl/src/main/scala/impl/FooServiceImpl.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/a/impl/src/main/scala/impl/FooServiceImpl.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package impl
+
+import api.FooService
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+
+import scala.concurrent.Future
+
+class FooServiceImpl extends FooService {
+  override def foo = ServiceCall { _ =>
+    Future.successful("ack foo")
+  }
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/api/src/main/scala/api/BarService.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/api/src/main/scala/api/BarService.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package api
+
+import akka.NotUsed
+import com.lightbend.lagom.scaladsl.api._
+import com.lightbend.lagom.scaladsl.api.transport.Method
+
+trait BarService extends Service {
+
+  def bar: ServiceCall[NotUsed, String]
+
+  override def descriptor = {
+    import Service._
+    named("b")
+      .withCalls(
+        restCall(Method.GET, "/bar", bar)
+      )
+      .withAutoAcl(true)
+  }
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/impl/src/main/resources/application.conf
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/impl/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+play.application.loader = impl.BarLoader

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/impl/src/main/scala/impl/BarLoader.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/impl/src/main/scala/impl/BarLoader.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package impl
+
+import api.BarService
+import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
+import com.lightbend.lagom.scaladsl.cluster.ClusterComponents
+import com.lightbend.lagom.scaladsl.playjson.EmptyJsonSerializerRegistry
+import com.lightbend.lagom.scaladsl.server._
+import com.softwaremill.macwire._
+import play.api.libs.ws.ahc.AhcWSComponents
+
+class BarLoader extends LagomApplicationLoader {
+
+  override def load(context: LagomApplicationContext): LagomApplication =
+    new BarApplication(context) {
+      override def serviceLocator = NoServiceLocator
+    }
+
+  override def loadDevMode(context: LagomApplicationContext): LagomApplication =
+    new BarApplication(context) with LagomDevModeComponents
+}
+
+abstract class BarApplication(context: LagomApplicationContext)
+  extends LagomApplication(context)
+    with AhcWSComponents
+    with ClusterComponents {
+
+  override lazy val lagomServer = serverFor[BarService](wire[BarServiceImpl])
+
+  lazy val jsonSerializerRegistry = EmptyJsonSerializerRegistry
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/impl/src/main/scala/impl/BarServiceImpl.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/b/impl/src/main/scala/impl/BarServiceImpl.scala
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package impl
+
+import api.BarService
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+
+import scala.concurrent.Future
+
+class BarServiceImpl extends BarService {
+  override def bar = ServiceCall { _ =>
+    Future.successful("ack bar")
+  }
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/build.sbt
@@ -1,0 +1,47 @@
+import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
+
+interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
+
+scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.8")
+
+val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
+
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
+lazy val `a-api` = (project in file("a") / "api")
+  .settings(
+    libraryDependencies += lagomScaladslApi
+  )
+
+lazy val `a-impl` = (project in file("a") / "impl")
+  .enablePlugins(LagomScala)
+  .settings(
+    lagomServiceHttpPort := 10000,
+    libraryDependencies ++= Seq(lagomScaladslCluster, macwire)
+  )
+  .dependsOn(`a-api`)
+
+lazy val `b-api` = (project in file("b") / "api")
+  .settings(
+    libraryDependencies += lagomScaladslApi
+  )
+
+
+lazy val `b-impl` = (project in file("b") / "impl")
+  .enablePlugins(LagomScala)
+  .settings(
+    lagomServiceHttpPort := 10001,
+    libraryDependencies ++= Seq(lagomScaladslCluster, macwire)
+  )
+  .dependsOn(`b-api`)
+
+
+InputKey[Unit]("assertRequest") := {
+  val args   = Def.spaceDelimited().parsed
+  val port   = args(0)
+  val path   = args(1)
+  val expect = args.drop(2).mkString(" ")
+
+  DevModeBuild.waitForRequestToContain(s"http://localhost:${port}${path}", expect)
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/build.sbt
@@ -4,6 +4,7 @@ interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMo
 
 scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.8")
 
+val netty = "io.netty" % "netty" % "3.10.6.Final"
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 
 lagomCassandraEnabled in ThisBuild := false
@@ -18,7 +19,7 @@ lazy val `a-impl` = (project in file("a") / "impl")
   .enablePlugins(LagomScala)
   .settings(
     lagomServiceHttpPort := 10000,
-    libraryDependencies ++= Seq(lagomScaladslCluster, macwire)
+    libraryDependencies ++= Seq(lagomScaladslCluster, macwire, netty)
   )
   .dependsOn(`a-api`)
 
@@ -32,7 +33,7 @@ lazy val `b-impl` = (project in file("b") / "impl")
   .enablePlugins(LagomScala)
   .settings(
     lagomServiceHttpPort := 10001,
-    libraryDependencies ++= Seq(lagomScaladslCluster, macwire)
+    libraryDependencies ++= Seq(lagomScaladslCluster, macwire, netty)
   )
   .dependsOn(`b-api`)
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/changes/a-application.conf
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/changes/a-application.conf
@@ -1,0 +1,2 @@
+play.application.loader = impl.FooLoader
+akka.remote.artery.enabled = false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/changes/b-application.conf
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/changes/b-application.conf
@@ -1,0 +1,2 @@
+play.application.loader = impl.BarLoader
+akka.remote.artery.enabled = false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/project/Build.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/project/Build.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import java.net.HttpURLConnection
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+import sbt.IO
+import sbt.File
+
+object DevModeBuild {
+
+  val ConnectTimeout = 10000
+  val ReadTimeout    = 10000
+
+  def waitForRequestToContain(uri: String, toContain: String): Unit = {
+    waitFor[String](
+      makeRequest(uri),
+      _.contains(toContain),
+      actual => s"'$actual' did not contain '$toContain'"
+    )
+  }
+
+  def makeRequest(uri: String): String = {
+    var conn: java.net.HttpURLConnection = null
+    try {
+      val url = new java.net.URL(uri)
+      conn = url.openConnection().asInstanceOf[HttpURLConnection]
+      conn.setConnectTimeout(ConnectTimeout)
+      conn.setReadTimeout(ReadTimeout)
+      conn.getResponseCode // we make this call just to block until a response is returned.
+      val br = new BufferedReader(new InputStreamReader((conn.getInputStream())))
+      Stream.continually(br.readLine()).takeWhile(_ != null).mkString("\n").trim()
+    } finally if (conn != null) conn.disconnect()
+  }
+
+  def waitFor[T](check: => T, assertion: T => Boolean, error: T => String): Unit = {
+    var checks = 0
+    var actual = check
+    while (!assertion(actual) && checks < 10) {
+      Thread.sleep(1000)
+      actual = check
+      checks += 1
+    }
+    if (!assertion(actual)) {
+      throw new RuntimeException(error(actual))
+    }
+  }
+
+}

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/project/build.properties
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/project/plugins.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % sys.props("project.version"))

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/test
@@ -1,0 +1,30 @@
+# Structure of this test:
+# =======================
+
+# Here we test that akka remote uses non-conflicting ports for each service (2 services more precisely).
+# Services a configured with akka-remote enabled (through Lagom Cluster).
+# We also test that the behavior is the same when using Artery or Classical remote.
+
+
+
+# First we start the services using Artery (default in 1.6.x) and
+# we call endpoints in both services to prove they are up and running.
+# `runAll` tests
+# --------------
+> runAll
+> assertRequest 10000 /foo ack foo
+> assertRequest 10001 /bar ack bar
+> stop
+
+
+# Next, we change each service configuration to use Remote Classical and we run the same test.
+
+# Change configuration files (enable remote classical)
+$ copy-file changes/a-application.conf a/impl/src/main/resources/application.conf
+$ copy-file changes/b-application.conf b/impl/src/main/resources/application.conf
+
+# re-run the same test using akka remote classical
+> runAll
+> assertRequest 10000 /foo ack foo
+> assertRequest 10001 /bar ack bar
+> stop

--- a/docs/manual/java/releases/Migration16.md
+++ b/docs/manual/java/releases/Migration16.md
@@ -70,7 +70,14 @@ When marking a serializable class with `CompressedJsonable` compression will onl
 
 Lagom 1.6.0 builds on Akka 2.6.0 that uses a new Akka Remote implementation called Artery. Artery is enabled by default in Lagom and replaces the previous Akka Remote protocol (aka. Akka Remote Classic). If you are using Lagom in a clustered setup, you will need to shutdown all nodes before updating, unless you choose to disable Artery.
 
-To disable Artery set property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options are specific to classic search for them in: [`akka-remote/reference.conf`](https://github.com/akka/akka/blob/master/akka-remote/src/main/resources/reference.conf)
+To use classic remoting instead of Artery, you need to:
+
+1. Set property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options are specific to classic search for them in: [`akka-remote/reference.conf`](https://github.com/akka/akka/blob/master/akka-remote/src/main/resources/reference.conf)
+2. Add Netty dependency as explained in [Akka Remoting docs](https://doc.akka.io/docs/akka/2.6/remoting.html#dependency):
+
+```scala
+libraryDependencies += "io.netty" % "netty" % "3.10.6.Final"
+```
 
 ### Shard Coordination
 

--- a/docs/manual/java/releases/Migration16.md
+++ b/docs/manual/java/releases/Migration16.md
@@ -52,7 +52,7 @@ akka.serialization.jackson {
   # Configuration of the ObjectMapper for external service api
   jackson-json-serviceapi {
      # Serializes dates using Jackson custom formats
-     WRITE_DATES_AS_TIMESTAMPS = on 
+     WRITE_DATES_AS_TIMESTAMPS = on
   }
 }
 ```
@@ -66,6 +66,12 @@ akka.serialization.jackson {
 
 When marking a serializable class with `CompressedJsonable` compression will only kick in when the serialized representation goes past a threshold. The default value for `akka.serialization.jackson.jackson-json-gzip.compress-larger-than` is 32 Kilobytes. As mentioned above, this setting was previously configure by `lagom.serialization.json.compress-larger-than` and defaulted to 1024 bytes. (See [#1983](https://github.com/lagom/lagom/pull/1983))
 
+### Remoting Artery
+
+Lagom 1.6.0 builds on Akka 2.6.0 that uses a new Akka Remote implementation called Artery. Artery is enabled by default in Lagom and replaces the previous Akka Remote protocol (aka. Akka Remote Classic). If you are using Lagom in a clustered setup, you will need to shutdown all nodes before updating, unless you choose to disable Artery.
+
+To disable Artery set property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options are specific to classic search for them in: [`akka-remote/reference.conf`](https://github.com/akka/akka/blob/master/akka-remote/src/main/resources/reference.conf)
+
 ### Shard Coordination
 
 In Lagom 1.4 and 1.5 users could use the `akka.cluster.sharding.store-state-mode` configuration key to switch from the default `persistence`-based shard coordination to the `ddata`-based coordination.  As of Lagom 1.6 `ddata` is the new default.
@@ -77,8 +83,13 @@ Switching from `persistence` to `ddata`, such as if your cluster relies of Lagom
 akka.cluster.sharding.state-store-mode = persistence
 ```
 
-## Cluster Shutdown changes
+## Upgrading a production system
+
+As usual, before upgrading to Lagom 1.6.0, makes sure you are using the latest version on the 1.5.x series.
+
+Lagom 1.6.0 has a few new default settings that will prevent you to run a rolling upgrade. In case you prefer to run a rolling upgrade, you will need to opt-out from each of these new defaults as explained below.
 
 This is a summary of changes in Lagom 1.6 that would require a full cluster shutdown rather than a rolling upgrade:
 
+* The change in [[Akka Remote|Migration16#Remoting-Artery] default implementation.
 * The change in default [[Shard Coordination|Migration16#Shard-Coordination] strategy.

--- a/docs/manual/scala/releases/Migration16.md
+++ b/docs/manual/scala/releases/Migration16.md
@@ -22,6 +22,12 @@ We also recommend upgrading to sbt 1.2.8 or later, by updating the `sbt.version`
 
 ## Main changes
 
+### Remoting Artery
+
+Lagom 1.6.0 builds on Akka 2.6.0 that uses a new Akka Remote implementation called Artery. Artery is enabled by default in Lagom and replaces the previous Akka Remote protocol (aka. Akka Remote Classic). If you are using Lagom in a clustered setup, you will need to shutdown all nodes before updating, unless you choose to disable Artery.
+
+To disable Artery set property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options are specific to classic search for them in: [`akka-remote/reference.conf`](https://github.com/akka/akka/blob/master/akka-remote/src/main/resources/reference.conf)
+
 ### Shard Coordination
 
 In Lagom 1.4 and 1.5 users could use the `akka.cluster.sharding.store-state-mode` configuration key to switch from the default `persistence`-based shard coordination to the `ddata`-based coordination.  As of Lagom 1.6 `ddata` is the new default.
@@ -33,14 +39,19 @@ Switching from `persistence` to `ddata`, such as if your cluster relies of Lagom
 akka.cluster.sharding.state-store-mode = persistence
 ```
 
+## Upgrading a production system
+
+As usual, before upgrading to Lagom 1.6.0, makes sure you are using the latest version on the 1.5.x series.
+
+Lagom 1.6.0 has a few new default settings that will prevent you to run a rolling upgrade. In case you prefer to run a rolling upgrade, you will need to opt-out from each of these new defaults as explained below.
+
+This is a summary of changes in Lagom 1.6 that would require a full cluster shutdown rather than a rolling upgrade:
+
+* The change in [[Akka Remote|Migration16#Remoting-Artery] default implementation.
+* The change in default [[Shard Coordination|Migration16#Shard-Coordination] strategy.
+
 ## Minor changes
 
 ### JSON Compression threshold
 
 When creating a serializer with `JsonSerializer.compressed[T]` compression will only kick in when the serialized representation is biger than a threshold. The default value for `lagom.serialization.json.compress-larger-than` has been increased from 1024 bytes to 32 Kilobytes. (See [#1983](https://github.com/lagom/lagom/pull/1983))
-
-## Cluster Shutdown changes
-
-This is a summary of changes in Lagom 1.6 that would require a full cluster shutdown rather than a rolling upgrade:
-
-* The change in default [[Shard Coordination|Migration16#Shard-Coordination] strategy.

--- a/docs/manual/scala/releases/Migration16.md
+++ b/docs/manual/scala/releases/Migration16.md
@@ -26,7 +26,14 @@ We also recommend upgrading to sbt 1.2.8 or later, by updating the `sbt.version`
 
 Lagom 1.6.0 builds on Akka 2.6.0 that uses a new Akka Remote implementation called Artery. Artery is enabled by default in Lagom and replaces the previous Akka Remote protocol (aka. Akka Remote Classic). If you are using Lagom in a clustered setup, you will need to shutdown all nodes before updating, unless you choose to disable Artery.
 
-To disable Artery set property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options are specific to classic search for them in: [`akka-remote/reference.conf`](https://github.com/akka/akka/blob/master/akka-remote/src/main/resources/reference.conf)
+To use classic remoting instead of Artery, you need to:
+
+1. Set property `akka.remote.artery.enabled` to `false`. Further, any configuration under `akka.remote` that is specific to classic remoting needs to be moved to `akka.remote.classic`. To see which configuration options are specific to classic search for them in: [`akka-remote/reference.conf`](https://github.com/akka/akka/blob/master/akka-remote/src/main/resources/reference.conf)
+2. Add Netty dependency as explained in [Akka Remoting docs](https://doc.akka.io/docs/akka/2.6/remoting.html#dependency):
+
+```scala
+libraryDependencies += "io.netty" % "netty" % "3.10.6.Final"
+```
 
 ### Shard Coordination
 

--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -73,6 +73,8 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
 
       # no jvm exit on tests
       lagom.cluster.exit-jvm-when-system-terminated = off
+
+      akka.cluster.sharding.waiting-for-state-timeout = 5s
     """
         )
         .withFallback(ConfigFactory.parseResources("play/reference-overrides.conf"))

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -68,6 +68,8 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
 
       # no jvm exit on tests
       lagom.cluster.exit-jvm-when-system-terminated = off
+
+      akka.cluster.sharding.waiting-for-state-timeout = 5s
     """
         )
         .withFallback(ConfigFactory.parseResources("play/reference-overrides.conf"))

--- a/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
+++ b/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
@@ -17,9 +17,9 @@ private[lagom] object PersistenceTestConfig {
   lazy val BasicConfig: Config = ConfigFactory.parseMap(BasicConfigMap.asJava)
 
   lazy val ClusterConfigMap: Map[String, AnyRef] = Map(
-    "akka.actor.provider"                           -> "cluster",
-    "akka.remote.artery.canonical.port"             -> "0",
-    "akka.remote.artery.canonical.hostname"         -> "127.0.0.1",
+    "akka.actor.provider"                   -> "cluster",
+    "akka.remote.artery.canonical.port"     -> "0",
+    "akka.remote.artery.canonical.hostname" -> "127.0.0.1",
     // needed when users opt-out from Artery
     "akka.remote.classic.netty.tcp.port"            -> "0",
     "akka.remote.classic.netty.tcp.hostname"        -> "127.0.0.1",

--- a/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
+++ b/persistence/testkit/src/main/scala/com/lightbend/lagom/internal/persistence/testkit/PersistenceTestConfig.scala
@@ -20,6 +20,9 @@ private[lagom] object PersistenceTestConfig {
     "akka.actor.provider"                           -> "cluster",
     "akka.remote.artery.canonical.port"             -> "0",
     "akka.remote.artery.canonical.hostname"         -> "127.0.0.1",
+    // needed when users opt-out from Artery
+    "akka.remote.classic.netty.tcp.port"            -> "0",
+    "akka.remote.classic.netty.tcp.hostname"        -> "127.0.0.1",
     "lagom.cluster.join-self"                       -> "on",
     "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
     "lagom.cluster.bootstrap.enabled"               -> "off"


### PR DESCRIPTION
This PR adds back the default settings for remote classic. Needed when opting-out from Artery.
 

- [x] `scripted` tests
- [x] docs

Fixes #1969 
Fixes #1986