### PR TITLE
Bump scalafmt version (lib, not sbt plugin)

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -8,4 +8,4 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.0.0-RC5
+version = 2.0.0-RC8

--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/DynamicProjectAdder.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/DynamicProjectAdder.scala
@@ -72,8 +72,9 @@ package com.lightbend.lagom.sbt {
             projectWithRoot.resolve(Scope.resolveProjectRef(structure.root, structure.rootProject, _))
 
           // Some really basic config that's apparently needed for any project to do anything.
-          val defineConfig: Seq[Setting[_]] = for (c <- resolvedProject.configurations)
-            yield (configuration in (projectRef, ConfigKey(c.name))) := c
+          val defineConfig: Seq[Setting[_]] =
+            for (c <- resolvedProject.configurations)
+              yield (configuration in (projectRef, ConfigKey(c.name))) := c
           val builtin
               : Seq[Setting[_]] = (thisProject := resolvedProject) +: (thisProjectRef := projectRef) +: defineConfig
           // And put all the settings together

--- a/docs/.scalafmt.conf
+++ b/docs/.scalafmt.conf
@@ -8,4 +8,4 @@ rewrite.rules = [ AvoidInfix, ExpandImportSelectors, RedundantParens, SortModifi
 rewrite.sortModifiers.order = [ "private", "protected", "final", "sealed", "abstract", "implicit", "override", "lazy" ]
 spaces.inImportCurlyBraces = true   # more idiomatic to include whitepsace in import x.{ yyy }
 trailingCommas = preserve
-version = 2.0.0-RC5
+version = 2.0.0-RC8

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/AggregateEventTag.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/AggregateEventTag.scala
@@ -159,9 +159,9 @@ final class AggregateEventShards[Event <: AggregateEvent[Event]](
    * @return all the tags that this app will use according to the `numShards` and the `eventType`
    */
   val allTags: PSequence[AggregateEventTag[Event]] = {
-    val shardTags = for (shardNo <- 0 until numShards)
-      yield
-        AggregateEventTag.of(
+    val shardTags =
+      for (shardNo <- 0 until numShards)
+        yield AggregateEventTag.of(
           eventType,
           AggregateEventTag.shardTag(tag, shardNo)
         )

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AggregateEventTag.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AggregateEventTag.scala
@@ -162,11 +162,10 @@ final class AggregateEventShards[Event <: AggregateEvent[Event]](
    */
   val allTags: Set[AggregateEventTag[Event]] = {
     (for (shardNo <- 0 until numShards)
-      yield
-        new AggregateEventTag(
-          eventType,
-          AggregateEventTag.shardTag(tag, shardNo)
-        )).toSet
+      yield new AggregateEventTag(
+        eventType,
+        AggregateEventTag.shardTag(tag, shardNo)
+      )).toSet
   }
 
   override def toString: String = s"AggregateEventShards($eventType, $tag)"


### PR DESCRIPTION
Apparently, [`version`](https://github.com/scalameta/scalafmt/blob/master/scalafmt-core/shared/src/main/scala/org/scalafmt/config/ScalafmtConfig.scala#L14-L15) is used on the IntelliJ-sbt integration but [Travis just failed trying to download 2.0.0-RC5](https://travis-ci.com/lagom/lagom/jobs/211168033#L1839):

```
saving stty: 500:5:bf:8a3b:3:1c:7f:15:4:0:1:0:11:13:1a:0:12:f:17:16:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[error] failed to resolve Scalafmt version '2.0.0-RC5': /home/travis/build/lagom/lagom/docs/.scalafmt.conf
[error] (Test / scalafmt) failed to resolve Scalafmt version '2.0.0-RC5': /home/travis/build/lagom/lagom/docs/.scalafmt.conf
```

So probably the `sbt-scalafmt` plugin honors the value of `version` in `scalafmt.conf` too.