### PR TITLE
Only consider minor version when checking protoc version

### DIFF
--- a/persistence/javadsl/src/main/protobuf/PersistenceMessages.proto
+++ b/persistence/javadsl/src/main/protobuf/PersistenceMessages.proto
@@ -1,6 +1,9 @@
 /**
  * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
+syntax = "proto2";
+
 package com.lightbend.lagom.internal.javadsl.persistence;
 
 option java_package = "com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg";

--- a/persistence/scaladsl/src/main/protobuf/PersistenceMessages.proto
+++ b/persistence/scaladsl/src/main/protobuf/PersistenceMessages.proto
@@ -1,6 +1,9 @@
 /**
  * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
  */
+
+syntax = "proto2";
+
 package com.lightbend.lagom.internal.scaladsl.persistence;
 
 option java_package = "com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg";

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -85,8 +85,22 @@ object Protobuf {
       p !! l
     })
     val version = res.split(" ").last.trim
-    if (version != protocVersion) {
-      sys.error("Wrong protoc version! Expected %s but got %s".format(protocVersion, version))
+
+    val installedVersion = CrossVersion.partialVersion(version)
+    val expectedVersion  = CrossVersion.partialVersion(protocVersion)
+
+    (installedVersion, expectedVersion) match {
+      case (Some(installed), Some(expected)) =>
+        // Compare minor version, for example 3.7, instead of full version 3.7.1
+        if (installed != expected) {
+          sys.error(
+            s"Wrong protoc version. Expected ${expected._1}.${expected._2} but got ${installed._1}.${installed._2}"
+          )
+        }
+      case _ =>
+        sys.error(
+          s"Unable to parse partial versions for installed protoc ($version) and required protoc version ($protocVersion)"
+        )
     }
   }
 


### PR DESCRIPTION
## Purpose

There is no need to check the patch version since they are supposed to be compatible. Also explicitly set the syntax expected for proto files.