### PR TITLE
Refactor ProjectionMessagesSerializer spec to correctly find the serializer

### DIFF
--- a/projection/core/src/main/resources/reference.conf
+++ b/projection/core/src/main/resources/reference.conf
@@ -7,6 +7,6 @@ akka.actor {
     "com.lightbend.lagom.projection.ProjectionSerializable" = lagom-projection
   }
   serialization-identifiers {
-    "com.lightbend.lagom.internal.projection.ProjectionMessageSerializer" = 10000007
+    "com.lightbend.lagom.internal.projection.ProjectionMessageSerializer" = 1000007
   }
 }

--- a/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionMessageSerializer.scala
+++ b/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionMessageSerializer.scala
@@ -25,6 +25,8 @@ private[lagom] object ProjectionMessageSerializer {
   val StatusManifest            = "C"
   val StateManifest             = "D"
   val WorkerCoordinatesManifest = "E"
+
+  val SerializerId = 1000007
 }
 
 private[lagom] class ProjectionMessageSerializer(val system: ExtendedActorSystem)


### PR DESCRIPTION
Follow up to #2143.

The test was initially creating an instance of `ProjectionMessagesSerializer` but this does not reveal errors such as wrong configuration or a message not extending marker traits.