### PR TITLE
Workaround extraProjects bug by declaring the root

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/build.sbt
@@ -5,6 +5,10 @@ scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
+// WORKAROUND https://github.com/sbt/sbt/issues/4947
+val distributionRoot = project in file(".")
+aggregateProjects(lagomProj, playProj)
+
 lazy val lagomProj = (project in file("lagomProj"))
   .enablePlugins(LagomJava)
   .settings(

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/distribution/test
@@ -1,5 +1,5 @@
 # Build the distribution and ensure that the files we expect are indeed there
-> lagomProj/stage
+> stage
 $ exists lagomProj/target/universal/stage/README
 $ exists lagomProj/target/universal/stage/SomeFile.txt
 $ exists lagomProj/target/universal/stage/SomeFolder/SomeOtherFile.txt
@@ -12,7 +12,6 @@ $ exists lagomProj/target/universal/stage/lib/lagom-dist-proj.lagom-dist-proj-1.
 > checkDevRuntimeClasspath lagomProj reloadable-server
 > absence lagomProj/target/universal/stage/lib/*reloadable-server*.jar
 
-> playProj/stage
 $ exists playProj/target/universal/stage/README
 $ exists playProj/target/universal/stage/SomeFile.txt
 $ exists playProj/target/universal/stage/SomeFolder/SomeOtherFile.txt


### PR DESCRIPTION
By declaring the root and its aggregates we workaround sbt's
extraProjects bug, which means we can revert the previous workaround of
using lagomProj/stage and playProj/stage.

See https://github.com/sbt/sbt/issues/4947