### PR TITLE
Isolate multi-jvm tests in their own jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,13 @@ jobs:
       name: "Run tests for Scala 2.12 and Java 11"
     - script: SCALA_VERSION=2.13.0 bin/test-2.1x
       name: "Run tests for Scala 2.13"
+    - script: SCALA_VERSION=2.12.9 bin/test-multi-jvm-2.1x
+      name: "Run multi-jvm tests for Scala 2.12"
+    - script: SCALA_VERSION=2.12.9 bin/test-multi-jvm-2.1x
+      env: TRAVIS_JDK=adopt@1.11.0-2
+      name: "Run multi-jvm tests for Scala 2.12 and Java 11"
+    - script: SCALA_VERSION=2.13.0 bin/test-multi-jvm-2.1x
+      name: "Run multi-jvm tests for Scala 2.13"
     - script: bin/test-documentation
       name: "Documentation validations and tests"
     - script: bin/test-docs-code-only

--- a/bin/test-multi-jvm-2.1x
+++ b/bin/test-multi-jvm-2.1x
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
+
+runSbtNoisy "++${SCALA_VERSION} multi-jvm:test"


### PR DESCRIPTION
Since multi-jvm tests are where most of the flakiness lives, we can
isolate them from regular tests, which will also make it easier to
re-run jobs when they fail without the need to run everything again.