### PR TITLE
Bump Akka to 2.5.25

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,6 +1,6 @@
 val ScalaVersion = "2.12.9"
 
-val AkkaVersion: String   = sys.props.getOrElse("lagom.build.akka.version", "2.5.22")
+val AkkaVersion: String   = sys.props.getOrElse("lagom.build.akka.version", "2.5.25")
 val JUnitVersion          = "4.12"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion      = "3.0.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
     val Twirl            = "1.4.0"
     val PlayFileWatch    = "1.1.8"
 
-    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.22")
+    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.5.25")
     val AkkaHttp     = "10.1.8"
     val Aeron        = "1.15.1"
 


### PR DESCRIPTION
https://github.com/akka/akka/pull/27331 backports to Akka 2.5.x some serialisers introduced into Akka 2.6. That backport allows rolling upgrades between Akka 2.5. and Akka 2.6.

The backport was introduced in Akka 2.5.24 but Akka 2.5.25 is already out and introduces necessary fixes for Lagom (Cluster Singletons).