### PR TITLE
Removes (invalid) overwrite

### DIFF
--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistenceComponents.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistenceComponents.scala
@@ -6,12 +6,10 @@ package com.lightbend.lagom.scaladsl.persistence
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import com.lightbend.lagom.internal.projection.ProjectionRegistry
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.scaladsl.persistence.ReadSideImpl
 import com.lightbend.lagom.scaladsl.cluster.ClusterComponents
 import com.lightbend.lagom.scaladsl.projection.ProjectionComponents
-import com.lightbend.lagom.scaladsl.projection.Projections
 import play.api.Configuration
 
 import scala.concurrent.ExecutionContext
@@ -35,7 +33,6 @@ trait ReadSidePersistenceComponents extends WriteSidePersistenceComponents with 
   def actorSystem: ActorSystem
   def executionContext: ExecutionContext
   def materializer: Materializer
-  private[lagom] def projectionRegistry: ProjectionRegistry
 
   def configuration: Configuration
 


### PR DESCRIPTION
Fixes #2192 

A leftover from a previous implementation caused the overwrite to invalidate the `val` so the field in the DI cake was abstract.
