### PR TITLE
Comment on each UpdateSuccess/UpdateFailure case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ commands:
     steps:
       - run:
           name: Run scripted tests
-          command: sbt ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ; ++<< parameters.scalaVersion >> scripted"
+          command: sbt ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ;++<< parameters.scalaVersion >> publishScriptedDependencies;++<< parameters.scalaVersion >> scripted"
           no_output_timeout: 20m
 
   run-docs-validation:


### PR DESCRIPTION
After reviewing https://github.com/lagom/lagom/issues/2124#issuecomment-521659228 and https://github.com/lagom/lagom/issues/2130#issuecomment-521657624 I think both 

```scala
   case UpdateSuccess => 
   case UpdateFailure =>
```

are noop. 

In this PR I add comments on the sources and implement small cleanups. 

Fixes #2124 