### PR TITLE
Initial status default values differ for request and observed status

### DIFF
--- a/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistryActor.scala
+++ b/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistryActor.scala
@@ -91,7 +91,7 @@ class ProjectionRegistryActor extends Actor with ActorLogging {
   // required to handle Terminate(deadActor)
   var reversedActorIndex: Map[ActorRef, WorkerKey] = Map.empty[ActorRef, WorkerKey]
 
-  val DefaultInitialStatus: Status = {
+  val DefaultRequestedStatus: Status = {
     val autoStartEnabled = context.system.settings.config.getBoolean("lagom.projection.auto-start.enabled")
     if (autoStartEnabled) Started
     else Stopped
@@ -107,7 +107,7 @@ class ProjectionRegistryActor extends Actor with ActorLogging {
       actorIndex = actorIndex.updated(workerKey, sender())
       reversedActorIndex = reversedActorIndex.updated(sender, workerKey)
       // when worker registers, we must reply with the requested status (if it's been set already, or DefaultInitialStatus if not).
-      val initialStatus = requestedStatusLocalCopy.getOrElse(workerKey, DefaultInitialStatus)
+      val initialStatus = requestedStatusLocalCopy.getOrElse(workerKey, DefaultRequestedStatus)
       log.debug(s"Setting initial status [$initialStatus] on worker $workerKey [${sender().path.toString}]")
       sender ! initialStatus
 
@@ -119,8 +119,8 @@ class ProjectionRegistryActor extends Actor with ActorLogging {
         nameIndexLocalCopy,
         requestedStatusLocalCopy,
         observedStatusLocalCopy,
-        DefaultInitialStatus,
-        DefaultInitialStatus
+        DefaultRequestedStatus,
+        Stopped // unless observed somewhere (and replicated), we consider a worker stopped.
       )
 
     // StateRequestCommand come from `ProjectionRegistry` and contain a requested Status

--- a/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
+++ b/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
@@ -52,7 +52,7 @@ class ProjectionStateSpec extends WordSpec with Matchers {
   "ProjectionStateSpec" should {
 
     "be build from a replicatedData" in {
-      val state = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Started)
+      val state = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Stopped)
       state.projections.size should equal(2)
       state.projections.flatMap(_.workers).size should equal(4)
       state.projections.flatMap(_.workers).find(_.key == coordinates001_3.asKey) shouldBe Some(
@@ -61,12 +61,12 @@ class ProjectionStateSpec extends WordSpec with Matchers {
     }
 
     "find projection by name" in {
-      val state = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Started)
+      val state = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Stopped)
       state.findProjection(prj001) should not be None
     }
 
     "find worker by key" in {
-      val state       = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Started)
+      val state       = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Stopped)
       val maybeWorker = state.findWorker("prj001-prj001-workers-3")
       maybeWorker shouldBe Some(
         Worker(p1w3, coordinates001_3.asKey, Stopped, Started)


### PR DESCRIPTION
Followup to https://github.com/lagom/lagom/pull/2144

I think the `observedStatus` reported for workers we've never heard of should be `Stopped` (since we've never heard from them, probably meaning they never existed).