### PR TITLE
Delete previous CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Code of Conduct
-
-Please visit https://www.lagomframework.com/conduct.html


### PR DESCRIPTION
This will cause this repo to use the default (new) version at https://github.com/lagom/.github/blob/master/CODE_OF_CONDUCT.md