### PR TITLE
Scope TestKit dependency to Test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -781,7 +781,7 @@ lazy val `akka-discovery-service-locator-scaladsl` = (project in file("akka-serv
     name := "lagom-scaladsl-akka-discovery-service-locator",
     Dependencies.`lagom-akka-discovery-service-locator-scaladsl`
   )
-  .dependsOn(`testkit-scaladsl`)
+  .dependsOn(`testkit-scaladsl` % Test)
 
 lazy val `akka-management-core` = (project in file("akka-management/core"))
   .settings(runtimeLibCommon: _*)


### PR DESCRIPTION
This prevents the library from pulling in extra dependencies, including cluster.

Fixes #2148 (the follow-up issue described in the comments).