### PR TITLE
Default to only 1 max inflight request per connection

### DIFF
--- a/service/core/kafka/client/src/main/resources/play/reference-overrides.conf
+++ b/service/core/kafka/client/src/main/resources/play/reference-overrides.conf
@@ -1,3 +1,4 @@
 akka.kafka.consumer.kafka-clients {
   auto.offset.reset = "earliest"
+  max.in.flight.requests.per.connection = 1
 }

--- a/service/core/kafka/client/src/main/resources/play/reference-overrides.conf
+++ b/service/core/kafka/client/src/main/resources/play/reference-overrides.conf
@@ -1,4 +1,14 @@
+
 akka.kafka.consumer.kafka-clients {
   auto.offset.reset = "earliest"
+}
+
+akka.kafka.producer.kafka-clients {
+
+  # The maximum number of unacknowledged requests the client will send on a single connection before
+  # blocking. Note that if this setting is set to be greater than 1 and there are failed sends, there
+  # is a risk of message re-ordering due to retries (i.e., if retries are enabled).
+  # (see http://kafka.apache.org/documentation/#producerconfigs)
   max.in.flight.requests.per.connection = 1
+
 }


### PR DESCRIPTION
This would be a new default in Lagom 1.6 that users may explicitly opt-out of.

Note, [Lagom `1.5.x` already uses Kafka `2.1.x`](https://github.com/lagom/lagom/blob/1.5.x/project/Dependencies.scala#L46) but we're not overwriting the default there. 

## Background Context

https://blog.softwaremill.com/does-kafka-really-guarantee-the-order-of-messages-3ca849fd19d2
https://www.youtube.com/watch?v=BxH5ixyfzTA&t=1085

ping @ennru 