### PR TITLE
Header normalization util method

### DIFF
--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
@@ -5,7 +5,6 @@
 package com.lightbend.lagom.gateway
 
 import java.net.InetSocketAddress
-import java.util.Locale
 
 import akka.Done
 import akka.actor.ActorRef
@@ -23,6 +22,7 @@ import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
+import com.lightbend.lagom.internal.api.HeaderUtils
 import com.lightbend.lagom.internal.javadsl.registry.ServiceRegistryService
 import com.lightbend.lagom.registry.impl.ServiceRegistryActor.Found
 import com.lightbend.lagom.registry.impl.ServiceRegistryActor.NotFound
@@ -32,18 +32,18 @@ import javax.inject.Inject
 import javax.inject.Named
 import org.slf4j.LoggerFactory
 import play.api.libs.typedmap.TypedMap
+import play.api.mvc.Headers
+import play.api.mvc.RequestHeader
 import play.api.mvc.request.RemoteConnection
 import play.api.mvc.request.RequestAttrKey
 import play.api.mvc.request.RequestTarget
-import play.api.mvc.Headers
-import play.api.mvc.RequestHeader
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
 
 import scala.collection.immutable
-import scala.concurrent.duration._
 import scala.concurrent.Await
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 class AkkaHttpServiceGatewayFactory @Inject()(coordinatedShutdown: CoordinatedShutdown, config: ServiceGatewayConfig)(
     @Named("serviceRegistryActor") registry: ActorRef
@@ -189,7 +189,7 @@ class AkkaHttpServiceGateway(
     "Upgrade",
     "Connection",
     "Host"
-  ).map(_.toLowerCase(Locale.ENGLISH))
+  ).map(HeaderUtils.normalize)
 
   private def filterHeaders(headers: immutable.Seq[HttpHeader]) = {
     headers.filterNot(header => HeadersToFilter(header.lowercaseName()))

--- a/service/core/api/src/main/scala/com/lightbend/lagom/internal/api/HeaderUtils.scala
+++ b/service/core/api/src/main/scala/com/lightbend/lagom/internal/api/HeaderUtils.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.api
+
+import java.util.Locale
+
+object HeaderUtils {
+
+  /**
+   * Normalize an HTTP header name.
+   *
+   * @param name the header name
+   * @return the normalized header name
+   */
+  @inline
+  def normalize(name: String): String = name.toLowerCase(Locale.ENGLISH)
+
+}

--- a/service/core/client/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
+++ b/service/core/client/src/main/scala/com/lightbend/lagom/internal/client/ClientServiceCallInvoker.scala
@@ -6,20 +6,19 @@ package com.lightbend.lagom.internal.client
 
 import java.net.URI
 import java.net.URLEncoder
-import java.util.Locale
 
 import akka.NotUsed
 import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.lightbend.lagom.internal.api.HeaderUtils
 import com.lightbend.lagom.internal.api.transport.LagomServiceApiBridge
 import play.api.http.HeaderNames
 import play.api.libs.streams.AkkaStreams
 import play.api.libs.ws.InMemoryBody
 import play.api.libs.ws.WSClient
 
-import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -274,7 +273,7 @@ private[lagom] abstract class ClientServiceCallInvoker[Request, Response](
       // Create the message header
       val protocol = messageProtocolFromContentTypeHeader(response.header(HeaderNames.CONTENT_TYPE))
       val headers = response.headers.map {
-        case (key, values) => key.toLowerCase(Locale.ENGLISH) -> values.map(key -> _).toIndexedSeq
+        case (key, values) => HeaderUtils.normalize(key) -> values.map(key -> _).toIndexedSeq
       }
       val transportResponseHeader = newResponseHeader(response.status, protocol, headers)
       val responseHeader          = headerFilterTransformClientResponse(headerFilter, transportResponseHeader, requestHeader)

--- a/service/core/client/src/main/scala/com/lightbend/lagom/internal/client/WebSocketClient.scala
+++ b/service/core/client/src/main/scala/com/lightbend/lagom/internal/client/WebSocketClient.scala
@@ -6,35 +6,6 @@ package com.lightbend.lagom.internal.client
 
 import java.net.URI
 import java.util.concurrent.TimeUnit
-import java.util.Locale
-
-import akka.stream.scaladsl._
-import akka.stream.stage._
-import akka.util.ByteString
-import com.typesafe.config.Config
-import com.typesafe.netty.HandlerPublisher
-import com.typesafe.netty.HandlerSubscriber
-import com.lightbend.lagom.internal.NettyFutureConverters._
-import io.netty.bootstrap.Bootstrap
-import io.netty.buffer.ByteBufHolder
-import io.netty.buffer.Unpooled
-import io.netty.channel.nio.NioEventLoopGroup
-import io.netty.channel.socket.SocketChannel
-import io.netty.channel.socket.nio.NioSocketChannel
-import io.netty.channel._
-import io.netty.handler.codec.http.websocketx._
-import io.netty.handler.codec.http._
-import io.netty.util.ReferenceCountUtil
-import play.api.Configuration
-import play.api.Environment
-import play.api.http.HeaderNames
-import play.api.inject.ApplicationLifecycle
-
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.Promise
-import scala.util.control.NonFatal
-import scala.collection.JavaConverters._
 import java.util.concurrent.atomic.AtomicReference
 
 import akka.NotUsed
@@ -42,11 +13,36 @@ import akka.stream.Attributes
 import akka.stream.FlowShape
 import akka.stream.Inlet
 import akka.stream.Outlet
+import akka.stream.scaladsl._
+import akka.stream.stage._
+import akka.util.ByteString
+import com.lightbend.lagom.internal.NettyFutureConverters._
+import com.lightbend.lagom.internal.api.HeaderUtils
 import com.lightbend.lagom.internal.api.transport.LagomServiceApiBridge
+import com.typesafe.config.Config
+import com.typesafe.netty.HandlerPublisher
+import com.typesafe.netty.HandlerSubscriber
+import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.ByteBufHolder
+import io.netty.buffer.Unpooled
+import io.netty.channel._
 import io.netty.channel.group.DefaultChannelGroup
+import io.netty.channel.nio.NioEventLoopGroup
+import io.netty.channel.socket.SocketChannel
+import io.netty.channel.socket.nio.NioSocketChannel
+import io.netty.handler.codec.http._
+import io.netty.handler.codec.http.websocketx._
+import io.netty.util.ReferenceCountUtil
 import io.netty.util.concurrent.GlobalEventExecutor
+import play.api.Environment
+import play.api.http.HeaderNames
+import play.api.inject.ApplicationLifecycle
 
-import scala.collection.immutable
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.util.control.NonFatal
 
 /**
  * A WebSocket client
@@ -177,7 +173,7 @@ private[lagom] abstract class WebSocketClient(
               .map { header =>
                 header.getKey -> header.getValue
               }
-              .groupBy(_._1.toLowerCase(Locale.ENGLISH))
+              .groupBy(header => HeaderUtils.normalize(header._1))
               .map {
                 case (key, values) => key -> values.toIndexedSeq
               }

--- a/service/core/server/src/main/scala/com/lightbend/lagom/internal/server/ServiceRouter.scala
+++ b/service/core/server/src/main/scala/com/lightbend/lagom/internal/server/ServiceRouter.scala
@@ -6,7 +6,6 @@ package com.lightbend.lagom.internal.server
 
 import java.net.URI
 import java.util.Base64
-import java.util.Locale
 import java.util.concurrent.CompletionException
 
 import akka.NotUsed
@@ -20,16 +19,17 @@ import akka.stream.stage.GraphStageLogic
 import akka.stream.stage.InHandler
 import akka.stream.stage.OutHandler
 import akka.util.ByteString
+import com.lightbend.lagom.internal.api.HeaderUtils
 import com.lightbend.lagom.internal.api.Path
 import com.lightbend.lagom.internal.api.transport.LagomServiceApiBridge
 import play.api.Logger
+import play.api.http.HeaderNames
+import play.api.http.HttpConfiguration
 import play.api.http.HttpEntity.Strict
 import play.api.http.websocket.BinaryMessage
 import play.api.http.websocket.CloseMessage
 import play.api.http.websocket.Message
 import play.api.http.websocket.TextMessage
-import play.api.http.HeaderNames
-import play.api.http.HttpConfiguration
 import play.api.libs.streams.Accumulator
 import play.api.libs.streams.AkkaStreams
 import play.api.mvc.BodyParser
@@ -298,7 +298,7 @@ private[lagom] abstract class ServiceRouter(httpConfiguration: HttpConfiguration
    */
   private def toLagomRequestHeader(rh: PlayRequestHeader): RequestHeader = {
     val stringToTuples: Map[String, immutable.Seq[(String, String)]] = rh.headers.toMap.map {
-      case (key, values) => key.toLowerCase(Locale.ENGLISH) -> values.map(key -> _).toIndexedSeq
+      case (key, values) => HeaderUtils.normalize(key) -> values.map(key -> _).toIndexedSeq
     }
     newRequestHeader(
       newMethod(rh.method),

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/MessageHeader.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/MessageHeader.java
@@ -4,10 +4,10 @@
 
 package com.lightbend.lagom.javadsl.api.transport;
 
+import com.lightbend.lagom.internal.api.HeaderUtils;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
 import org.pcollections.PSequence;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,7 +32,7 @@ public abstract class MessageHeader {
     PMap<String, PSequence<String>> lowercaseHeaders = HashTreePMap.empty();
     for (Map.Entry<String, PSequence<String>> header : headers.entrySet()) {
       lowercaseHeaders =
-          lowercaseHeaders.plus(header.getKey().toLowerCase(Locale.ENGLISH), header.getValue());
+          lowercaseHeaders.plus(HeaderUtils.normalize(header.getKey()), header.getValue());
     }
     this.lowercaseHeaders = lowercaseHeaders;
   }
@@ -67,7 +67,7 @@ public abstract class MessageHeader {
    * @return The header value.
    */
   public Optional<String> getHeader(String name) {
-    PSequence<String> values = lowercaseHeaders.get(name.toLowerCase(Locale.ENGLISH));
+    PSequence<String> values = lowercaseHeaders.get(HeaderUtils.normalize(name));
     if (values == null || values.isEmpty()) {
       return Optional.empty();
     } else {

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/RequestHeader.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/RequestHeader.java
@@ -4,6 +4,7 @@
 
 package com.lightbend.lagom.javadsl.api.transport;
 
+import com.lightbend.lagom.internal.api.HeaderUtils;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
 import org.pcollections.PSequence;
@@ -11,7 +12,6 @@ import org.pcollections.TreePVector;
 
 import java.net.URI;
 import java.security.Principal;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -185,7 +185,7 @@ public final class RequestHeader extends MessageHeader {
         acceptedResponseProtocols,
         principal,
         headers.plus(name, TreePVector.singleton(value)),
-        lowercaseHeaders.plus(name.toLowerCase(Locale.ENGLISH), TreePVector.singleton(value)));
+        lowercaseHeaders.plus(HeaderUtils.normalize(name), TreePVector.singleton(value)));
   }
 
   @Override

--- a/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/ResponseHeader.java
+++ b/service/javadsl/api/src/main/java/com/lightbend/lagom/javadsl/api/transport/ResponseHeader.java
@@ -4,12 +4,11 @@
 
 package com.lightbend.lagom.javadsl.api.transport;
 
+import com.lightbend.lagom.internal.api.HeaderUtils;
 import org.pcollections.HashTreePMap;
 import org.pcollections.PMap;
 import org.pcollections.PSequence;
 import org.pcollections.TreePVector;
-
-import java.util.Locale;
 
 /**
  * This header may or may not be mapped down onto HTTP. In order to remain agnostic to the
@@ -74,7 +73,7 @@ public final class ResponseHeader extends MessageHeader {
         status,
         protocol,
         headers.plus(name, TreePVector.singleton(value)),
-        lowercaseHeaders.plus(name.toLowerCase(Locale.ENGLISH), TreePVector.singleton(value)));
+        lowercaseHeaders.plus(HeaderUtils.normalize(name), TreePVector.singleton(value)));
   }
 
   public static final ResponseHeader OK =

--- a/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/javadsl/client/JavadslServiceApiBridge.scala
+++ b/service/javadsl/client/src/main/scala/com/lightbend/lagom/internal/javadsl/client/JavadslServiceApiBridge.scala
@@ -6,28 +6,27 @@ package com.lightbend.lagom.internal.javadsl.client
 
 import java.net.URI
 import java.security.Principal
-import java.util.Locale
 import java.util.concurrent.CompletionStage
 
 import akka.stream.javadsl.{ Source => JSource }
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.lightbend.lagom.internal.api.HeaderUtils
 import com.lightbend.lagom.internal.api.transport.LagomServiceApiBridge
-import com.lightbend.lagom.javadsl.api.deser
-import com.lightbend.lagom.javadsl.api.transport
 import com.lightbend.lagom.javadsl.api
 import com.lightbend.lagom.javadsl.api.Descriptor.RestCallId
 import com.lightbend.lagom.javadsl.api.deser.ExceptionMessage
 import com.lightbend.lagom.javadsl.api.security.ServicePrincipal
-import com.lightbend.lagom.javadsl.api.transport.BadRequest
+import com.lightbend.lagom.javadsl.api.deser
+import com.lightbend.lagom.javadsl.api.transport
 import org.pcollections.HashTreePMap
 import org.pcollections.PSequence
 import org.pcollections.TreePVector
 
-import scala.compat.java8.OptionConverters._
-import scala.compat.java8.FutureConverters._
 import scala.collection.JavaConverters._
 import scala.collection.immutable
+import scala.compat.java8.FutureConverters._
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
@@ -58,7 +57,7 @@ trait JavadslServiceApiBridge extends LagomServiceApiBridge {
       .flatMap {
         case (key, values) => values.asScala.map(key -> _)
       }
-      .groupBy(_._1.toLowerCase(Locale.ENGLISH))
+      .groupBy(header => HeaderUtils.normalize(header._1))
       .map {
         case (key, values) => key -> values.toIndexedSeq
       }

--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/MessageHeader.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/transport/MessageHeader.scala
@@ -6,9 +6,8 @@ package com.lightbend.lagom.scaladsl.api.transport
 
 import java.net.URI
 import java.security.Principal
-import java.util.Locale
 
-import com.lightbend.lagom.scaladsl.api.transport.RequestHeader.RequestHeaderImpl
+import com.lightbend.lagom.internal.api.HeaderUtils
 
 import scala.collection.immutable
 import scala.collection.immutable.Seq
@@ -42,7 +41,7 @@ sealed trait MessageHeader {
    * @return The header value.
    */
   def getHeader(name: String): Option[String] = {
-    headerMap.get(name.toLowerCase(Locale.ENGLISH)).flatMap(_.headOption).map(_._2)
+    headerMap.get(HeaderUtils.normalize(name)).flatMap(_.headOption).map(_._2)
   }
 
   /**
@@ -54,7 +53,7 @@ sealed trait MessageHeader {
    * @return The header values.
    */
   def getHeaders(name: String): immutable.Seq[String] = {
-    headerMap.get(name.toLowerCase(Locale.ENGLISH)).fold(immutable.Seq.empty[String])(_.map(_._2))
+    headerMap.get(HeaderUtils.normalize(name)).fold(immutable.Seq.empty[String])(_.map(_._2))
   }
 
   /**
@@ -198,7 +197,7 @@ object RequestHeader {
       protocol,
       acceptedResponseProtocols,
       principal,
-      headers.groupBy(_._1.toLowerCase(Locale.ENGLISH))
+      headers.groupBy(header => HeaderUtils.normalize(header._1))
     )
 
   val Default = RequestHeader(Method.GET, URI.create("/"), MessageProtocol.empty, Nil, None, Nil)
@@ -228,18 +227,18 @@ object RequestHeader {
     override def clearPrincipal: RequestHeaderImpl                          = copy(principal = None)
     override def withProtocol(protocol: MessageProtocol): RequestHeaderImpl = copy(protocol = protocol)
     override def withHeaders(headers: immutable.Seq[(String, String)]): RequestHeaderImpl =
-      copy(headerMap = headers.groupBy(_._1.toLowerCase(Locale.ENGLISH)))
+      copy(headerMap = headers.groupBy(header => HeaderUtils.normalize(header._1)))
     override def withHeader(name: String, value: String): RequestHeaderImpl =
-      copy(headerMap = headerMap + (name.toLowerCase(Locale.ENGLISH) -> immutable.Seq(name -> value)))
+      copy(headerMap = headerMap + (HeaderUtils.normalize(name) -> immutable.Seq(name -> value)))
     override def addHeader(name: String, value: String): RequestHeaderImpl = {
-      val lcName = name.toLowerCase(Locale.ENGLISH)
+      val lcName = HeaderUtils.normalize(name)
       headerMap.get(lcName) match {
         case None         => copy(headerMap = headerMap + (lcName -> immutable.Seq(name -> value)))
         case Some(values) => copy(headerMap = headerMap + (lcName -> (values :+ (name -> value))))
       }
     }
     override def removeHeader(name: String): RequestHeaderImpl =
-      copy(headerMap = headerMap - name.toLowerCase(Locale.ENGLISH))
+      copy(headerMap = headerMap - HeaderUtils.normalize(name))
   }
 }
 
@@ -275,7 +274,7 @@ object ResponseHeader {
       status: Int,
       protocol: MessageProtocol,
       headers: immutable.Seq[(String, String)]
-  ): ResponseHeader = ResponseHeaderImpl(status, protocol, headers.groupBy(_._1.toLowerCase(Locale.ENGLISH)))
+  ): ResponseHeader = ResponseHeaderImpl(status, protocol, headers.groupBy(header => HeaderUtils.normalize(header._1)))
 
   private[lagom] def apply(
       status: Int,
@@ -293,17 +292,17 @@ object ResponseHeader {
     override def withStatus(status: Int): ResponseHeader                 = copy(status = status)
     override def withProtocol(protocol: MessageProtocol): ResponseHeader = copy(protocol = protocol)
     override def withHeaders(headers: immutable.Seq[(String, String)]): ResponseHeaderImpl =
-      copy(headerMap = headers.groupBy(_._1.toLowerCase(Locale.ENGLISH)))
+      copy(headerMap = headers.groupBy(header => HeaderUtils.normalize(header._1)))
     override def withHeader(name: String, value: String): ResponseHeaderImpl =
-      copy(headerMap = headerMap + (name.toLowerCase(Locale.ENGLISH) -> immutable.Seq(name -> value)))
+      copy(headerMap = headerMap + (HeaderUtils.normalize(name) -> immutable.Seq(name -> value)))
     override def addHeader(name: String, value: String): ResponseHeaderImpl = {
-      val lcName = name.toLowerCase(Locale.ENGLISH)
+      val lcName = HeaderUtils.normalize(name)
       headerMap.get(lcName) match {
         case None         => copy(headerMap = headerMap + (lcName -> immutable.Seq(name -> value)))
         case Some(values) => copy(headerMap = headerMap + (lcName -> (values :+ (name -> value))))
       }
     }
     override def removeHeader(name: String): ResponseHeaderImpl =
-      copy(headerMap = headerMap - name.toLowerCase(Locale.ENGLISH))
+      copy(headerMap = headerMap - HeaderUtils.normalize(name))
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [X] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you added copyright headers to new files?
* [X] Have you updated the documentation?
* [X] Have you added tests for any changed functionality?

## Fixes

This PR doesn't fix any bugs.

## Purpose

This PR moves all instances of header name normalization into a reusable util method. Basically, all calls like:

```scala
name.toLowerCase(Locale.ENGLISH)
```

are replaced with:

```scala
HeaderUtils.normalize(name)
```

The primary purpose of this PR is to isolate header name normalization into a common method so that it can be easily replaced in [lagom.js](https://github.com/mliarakos/lagom-js). In Scala.js header normalization must happen differently because the `Locale` class isn't available. Using a util method makes it easier to replace this behavior and reduces the amount of Lagom code that needs to be duplicated and modified in the Scala.js implementation.

The secondary purpose is to refactor this common operation into a standard implementation with a descriptive name.

## Background Context

I took this approach to make it easy to replace the header name normalization operation in lagom.js. I put the `HeaderUtils` object in the core api because there is a similar `UriUtils` object already there.

## References

This PR does not have any relevant references.
