### PR TITLE
release to bintray before changing version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,9 +100,9 @@ def releaseSettings: Seq[Setting[_]] = Seq(
       tagRelease,
       releaseStepCommandAndRemaining("+publishSigned"),
       releaseStepCommand("sonatypeRelease"),
+      releaseStepTask(bintrayRelease in thisProjectRef.value),
       setNextVersion,
       commitNextVersion,
-      releaseStepTask(bintrayRelease in thisProjectRef.value),
       pushChanges
     )
   }


### PR DESCRIPTION
In `master` we changed the order in which we publish to bintray. We now only publish it after we successfully publish in Maven. 

However, when I cherry picked that change from `master`, I made a mistake. I let the bintray release happen after we change the version. Hence the error I got...

```
[error] java.lang.RuntimeException: failed to release lagom/lagom-sbt-plugin@1.5.4-SNAPSHOT: {"message":"Version '1.5.4-SNAPSHOT' was not found"}
[error]         at scala.sys.package$.error(package.scala:26)
```

This PR fix this.

In the meantime I was able to only publish the 1.5.3 plugin to bintray (manually). 

FYI, in master we don't set the next version because we are using dynver.