### PR TITLE
Support requestedStatus before projections register

### DIFF
--- a/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/AbstractReadSideSpec.scala
@@ -202,7 +202,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
 
     "register on the projection registry" in {
       withReadSideProcessor("123") { _ =>
-        projectionRegistryProbe.get.expectMsgType[ProjectionRegistryActor.RegisterProjectionWorker]
+        projectionRegistryProbe.get.expectMsgType[ProjectionRegistryActor.ReportForDuty]
       }
     }
 

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AbstractReadSideSpec.scala
@@ -200,7 +200,7 @@ trait AbstractReadSideSpec extends ImplicitSender with ScalaFutures with Eventua
 
     "register on the projection registry" in {
       withReadSideProcessor("123") { _ =>
-        projectionRegistryProbe.get.expectMsgType[ProjectionRegistryActor.RegisterProjectionWorker]
+        projectionRegistryProbe.get.expectMsgType[ProjectionRegistryActor.ReportForDuty]
       }
     }
 

--- a/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistry.scala
+++ b/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistry.scala
@@ -76,5 +76,4 @@ private[lagom] class ProjectionRegistry(system: ActorSystem) {
     (projectionRegistryRef ? GetState).mapTo[State]
   }
 
-
 }

--- a/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistry.scala
+++ b/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistry.scala
@@ -8,19 +8,16 @@ import akka.actor.ActorRef
 import akka.actor.ActorSystem
 import akka.actor.Props
 import akka.annotation.ApiMayChange
+import akka.annotation.InternalApi
 import akka.pattern.ask
 import akka.cluster.sharding.ClusterShardingSettings
 import akka.util.Timeout
 import com.lightbend.lagom.internal.cluster.ClusterDistribution
 import com.lightbend.lagom.internal.cluster.ClusterDistributionSettings
-import com.lightbend.lagom.internal.projection.ProjectionRegistry.StateRequestCommand
 import com.lightbend.lagom.internal.projection.ProjectionRegistryActor.GetState
 import com.lightbend.lagom.internal.projection.ProjectionRegistryActor.WorkerCoordinates
-import com.lightbend.lagom.projection.Projection
-import com.lightbend.lagom.projection.ProjectionNotFound
 import com.lightbend.lagom.projection.Started
 import com.lightbend.lagom.projection.State
-import com.lightbend.lagom.projection.Status
 import com.lightbend.lagom.projection.Stopped
 
 import scala.concurrent.ExecutionContext
@@ -28,12 +25,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 @ApiMayChange
-object ProjectionRegistry {
-
-  case class StateRequestCommand(coordinates: WorkerCoordinates, requestedStatus: Status)
-}
-
-@ApiMayChange
+@InternalApi
 private[lagom] class ProjectionRegistry(system: ActorSystem) {
 
   private val projectionRegistryRef: ActorRef = system.actorOf(ProjectionRegistryActor.props, "projection-registry")
@@ -54,6 +46,8 @@ private[lagom] class ProjectionRegistry(system: ActorSystem) {
       runInRole: Option[String] = None
   ): Unit = {
 
+    projectionRegistryRef ! ProjectionRegistryActor.RegisterProjection(projectionName, shardNames)
+
     clusterShardingSettings.withRole(runInRole)
 
     clusterDistribution.start(
@@ -68,31 +62,19 @@ private[lagom] class ProjectionRegistry(system: ActorSystem) {
   implicit val exCtx: ExecutionContext = system.dispatcher
   implicit val timeout: Timeout        = Timeout(1.seconds)
 
-  def startWorker(coordinates: WorkerCoordinates): Unit =
-    projectionRegistryRef ! StateRequestCommand(coordinates, Started)
-
   def stopWorker(coordinates: WorkerCoordinates): Unit =
-    projectionRegistryRef ! StateRequestCommand(coordinates, Stopped)
+    projectionRegistryRef ! ProjectionRegistryActor.WorkerRequestCommand(coordinates, Stopped)
+  def startWorker(coordinates: WorkerCoordinates): Unit =
+    projectionRegistryRef ! ProjectionRegistryActor.WorkerRequestCommand(coordinates, Started)
 
-  def stopAllWorkers(projectionName: String): Unit = bulk(projectionName, stopWorker)
-
-  def startAllWorkers(projectionName: String): Unit = bulk(projectionName, startWorker)
+  def stopAllWorkers(projectionName: String): Unit =
+    projectionRegistryRef ! ProjectionRegistryActor.ProjectionRequestCommand(projectionName, Stopped)
+  def startAllWorkers(projectionName: String): Unit =
+    projectionRegistryRef ! ProjectionRegistryActor.ProjectionRequestCommand(projectionName, Started)
 
   private[lagom] def getState(): Future[State] = {
     (projectionRegistryRef ? GetState).mapTo[State]
   }
 
-  private def bulk(projectionName: String, op: WorkerCoordinates => Unit): Unit = {
-    val eventualProjection: Future[Projection] = getState()
-      .map { state =>
-        state.findProjection(projectionName) match {
-          case None             => throw new ProjectionNotFound(projectionName)
-          case Some(projection) => projection
-        }
-      }
-    eventualProjection.map { projection =>
-      projection.workers.map(_.tagName).foreach(tagName => op(WorkerCoordinates(projectionName, tagName)))
-    }
-  }
 
 }

--- a/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/WorkerCoordinator.scala
+++ b/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/WorkerCoordinator.scala
@@ -72,7 +72,7 @@ class WorkerCoordinator(
     case EnsureActive(tagName) =>
       val coordinates = WorkerCoordinates(projectionName, tagName)
       log.debug(s"Requesting registry of $coordinates [${self.path.toString}].")
-      projectionRegistryActorRef ! ProjectionRegistryActor.RegisterProjectionWorker(coordinates)
+      projectionRegistryActorRef ! ProjectionRegistryActor.ReportForDuty(coordinates)
       // become stopped and await for instructions from the Registry
       becomeStopped(coordinates)
   }

--- a/projection/core/src/multi-jvm/resources/logback.xml
+++ b/projection/core/src/multi-jvm/resources/logback.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} [%-5level] %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.cassandra" level="DEBUG" />
+    <logger name="com.datastax.driver" level="DEBUG" />
+
+    <logger name="akka.cluster" level="DEBUG" />
+    <logger name="akka.persistence" level="DEBUG" />
+    <logger name="com.lightbend.lagom.internal.projection" level="DEBUG" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/projection/core/src/multi-jvm/scala/com/lightbend/lagom/internal/projection/ProjectionRegistrySpec.scala
+++ b/projection/core/src/multi-jvm/scala/com/lightbend/lagom/internal/projection/ProjectionRegistrySpec.scala
@@ -255,9 +255,7 @@ class ProjectionRegistrySpec extends ClusteredMultiNodeUtils(numOfNodes = 3) wit
       expectWorkerStatus(projectionName, tagName001, Started)
       expectWorkerStatus(projectionName, tagName002, Stopped)
 
-
     }
-
 
   }
 

--- a/projection/core/src/multi-jvm/scala/com/lightbend/lagom/internal/projection/ProjectionRegistrySpec.scala
+++ b/projection/core/src/multi-jvm/scala/com/lightbend/lagom/internal/projection/ProjectionRegistrySpec.scala
@@ -82,6 +82,23 @@ class ProjectionRegistrySpec extends ClusteredMultiNodeUtils(numOfNodes = 3) wit
       expectWorkerStatus(projectionName, tagName001, Stopped)
     }
 
+    "request the pause of a projection worker (before projection is registered)" in {
+      enterBarrier("request-pause-worker-before-registering-test")
+      val projectionName = "test-pause-worker-before-registering"
+      val tagNamePrefix  = projectionName
+      val tagNames       = (1 to 5).map(id => s"$tagNamePrefix-$id")
+      val tagName001     = tagNames.head
+      val coordinates001 = WorkerCoordinates(projectionName, tagNames.head)
+
+      runOn(RoleName("node2")) {
+        projectionRegistry.stopWorker(coordinates001)
+      }
+
+      registerProjection(projectionName, tagNames.toSet)
+
+      expectWorkerStatus(projectionName, tagName001, Stopped)
+    }
+
     "request the pause of a complete projection" in {
       enterBarrier("request-pause-projection-test")
       val projectionName = "test-pause-projection"
@@ -98,6 +115,22 @@ class ProjectionRegistrySpec extends ClusteredMultiNodeUtils(numOfNodes = 3) wit
       runOn(RoleName("node2")) {
         projectionRegistry.stopAllWorkers(projectionName)
       }
+      expectProjectionStatus(projectionName, 5, Stopped)
+    }
+
+    "request the pause of a complete projection (before projection is registered)" in {
+      enterBarrier("request-pause-projection-test-before-registering")
+      val projectionName = "test-pause-projection-before-registering"
+      val tagNamePrefix  = projectionName
+      val tagNames       = (1 to 5).map(id => s"$tagNamePrefix-$id")
+
+      runOn(RoleName("node2")) {
+        projectionRegistry.stopAllWorkers(projectionName)
+      }
+
+      registerProjection(projectionName, tagNames.toSet)
+      enterBarrier("sync-request-pause-projection-test-before-registering")
+
       expectProjectionStatus(projectionName, 5, Stopped)
     }
 
@@ -172,8 +205,8 @@ class ProjectionRegistrySpec extends ClusteredMultiNodeUtils(numOfNodes = 3) wit
 
   private def expectWorkerStatus(projectionName: String, tagName: String, expectedStatus: Status) = {
     eventually(Timeout(pc.timeout), Interval(pc.interval)) {
-      whenReady(projectionRegistry.getState()) { x =>
-        val maybeWorker = x.findWorker(WorkerCoordinates(projectionName, tagName).asKey)
+      whenReady(projectionRegistry.getState()) { state =>
+        val maybeWorker = state.findWorker(WorkerCoordinates(projectionName, tagName).asKey)
         maybeWorker.map(_.observedStatus) should be(Some(expectedStatus))
         maybeWorker.map(_.requestedStatus) should be(Some(expectedStatus))
       }
@@ -189,7 +222,6 @@ class ProjectionRegistrySpec extends ClusteredMultiNodeUtils(numOfNodes = 3) wit
         projection.workers.forall(_.observedStatus == expectedStatus) should be(true)
       }
     }
-
   }
 
   private def registerProjection(
@@ -206,10 +238,6 @@ class ProjectionRegistrySpec extends ClusteredMultiNodeUtils(numOfNodes = 3) wit
       )
 
     projectionRegistry.registerProjection(projectionName, tagNames, workerProps, runInRole)
-
-    tagNames.foreach { tagName =>
-      projectionRegistry.startWorker(WorkerCoordinates(projectionName, tagName))
-    }
 
     testProbe
   }

--- a/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
+++ b/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
@@ -4,10 +4,10 @@
 
 package com.lightbend.lagom.internal.cluster.projections
 
+import com.lightbend.lagom.internal.projection.ProjectionRegistryActor.ProjectionName
 import com.lightbend.lagom.internal.projection.ProjectionRegistryActor.WorkerCoordinates
 import com.lightbend.lagom.projection.Started
 import com.lightbend.lagom.projection.State
-import com.lightbend.lagom.projection.State.WorkerKey
 import com.lightbend.lagom.projection.Status
 import com.lightbend.lagom.projection.Stopped
 import com.lightbend.lagom.projection.Worker
@@ -20,33 +20,32 @@ import org.scalatest.WordSpec
 class ProjectionStateSpec extends WordSpec with Matchers {
 
   private val prj001   = "prj001"
+  private val prj002   = "prj002"
   val p1w1             = prj001 + "-workers-1"
   val p1w2             = prj001 + "-workers-2"
   val p1w3             = prj001 + "-workers-3"
-  val p2w1             = "prj002-workers-1"
+  val p2w1             = s"$prj002-workers-1"
   val coordinates001_1 = WorkerCoordinates(prj001, p1w1)
   val coordinates001_2 = WorkerCoordinates(prj001, p1w2)
   val coordinates001_3 = WorkerCoordinates(prj001, p1w3)
-  val coordinates002_1 = WorkerCoordinates("prj002", p2w1)
+  val coordinates002_1 = WorkerCoordinates(prj002, p2w1)
 
-  val nameIndex: Map[WorkerKey, WorkerCoordinates] = Map(
-    coordinates001_1.asKey -> coordinates001_1,
-    coordinates001_2.asKey -> coordinates001_2,
-    coordinates001_3.asKey -> coordinates001_3,
-    coordinates002_1.asKey -> coordinates002_1
+  val nameIndex: Map[ProjectionName, Set[WorkerCoordinates]] = Map(
+    prj001 -> Set(coordinates001_1, coordinates001_2, coordinates001_3),
+    prj002 -> Set(coordinates002_1)
   )
 
-  val desiredStatus: Map[WorkerKey, Status] = Map(
-    coordinates001_1.asKey -> Stopped,
-    coordinates001_2.asKey -> Started,
-    coordinates001_3.asKey -> Stopped,
-    coordinates002_1.asKey -> Started
+  val desiredStatus: Map[WorkerCoordinates, Status] = Map(
+    coordinates001_1 -> Stopped,
+    coordinates001_2 -> Started,
+    coordinates001_3 -> Stopped,
+    coordinates002_1 -> Started
   )
-  val observedStatus: Map[WorkerKey, Status] = Map(
-    coordinates001_1.asKey -> Stopped,
-    coordinates001_2.asKey -> Stopped,
-    coordinates001_3.asKey -> Started,
-    coordinates002_1.asKey -> Started
+  val observedStatus: Map[WorkerCoordinates, Status] = Map(
+    coordinates001_1 -> Stopped,
+    coordinates001_2 -> Stopped,
+    coordinates001_3 -> Started,
+    coordinates002_1 -> Started
   )
 
   "ProjectionStateSpec" should {
@@ -78,7 +77,7 @@ class ProjectionStateSpec extends WordSpec with Matchers {
       val newWorkerName     = "new-worker-001"
       val newCoordinates    = WorkerCoordinates(newProjectionName, newWorkerName)
       val richIndex = nameIndex ++ Map(
-        newCoordinates.asKey -> newCoordinates
+        newProjectionName -> Set(newCoordinates)
       )
 
       val defaultRequested = Stopped

--- a/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
+++ b/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
@@ -83,7 +83,8 @@ class ProjectionStateSpec extends WordSpec with Matchers {
       val defaultRequested = Stopped
       val defaultObserved  = Started
 
-      val state       = State.fromReplicatedData(richIndex, requestedStatus, observedStatus, defaultRequested, defaultObserved)
+      val state =
+        State.fromReplicatedData(richIndex, requestedStatus, observedStatus, defaultRequested, defaultObserved)
       val maybeWorker = state.findWorker(newCoordinates.asKey)
       maybeWorker shouldBe Some(
         Worker(newWorkerName, newCoordinates.asKey, defaultRequested, defaultObserved)

--- a/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
+++ b/projection/core/src/test/scala/com/lightbend/lagom/internal/cluster/projections/ProjectionStateSpec.scala
@@ -35,7 +35,7 @@ class ProjectionStateSpec extends WordSpec with Matchers {
     prj002 -> Set(coordinates002_1)
   )
 
-  val desiredStatus: Map[WorkerCoordinates, Status] = Map(
+  val requestedStatus: Map[WorkerCoordinates, Status] = Map(
     coordinates001_1 -> Stopped,
     coordinates001_2 -> Started,
     coordinates001_3 -> Stopped,
@@ -51,7 +51,7 @@ class ProjectionStateSpec extends WordSpec with Matchers {
   "ProjectionStateSpec" should {
 
     "be build from a replicatedData" in {
-      val state = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Stopped)
+      val state = State.fromReplicatedData(nameIndex, requestedStatus, observedStatus, Started, Stopped)
       state.projections.size should equal(2)
       state.projections.flatMap(_.workers).size should equal(4)
       state.projections.flatMap(_.workers).find(_.key == coordinates001_3.asKey) shouldBe Some(
@@ -60,12 +60,12 @@ class ProjectionStateSpec extends WordSpec with Matchers {
     }
 
     "find projection by name" in {
-      val state = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Stopped)
+      val state = State.fromReplicatedData(nameIndex, requestedStatus, observedStatus, Started, Stopped)
       state.findProjection(prj001) should not be None
     }
 
     "find worker by key" in {
-      val state       = State.fromReplicatedData(nameIndex, desiredStatus, observedStatus, Started, Stopped)
+      val state       = State.fromReplicatedData(nameIndex, requestedStatus, observedStatus, Started, Stopped)
       val maybeWorker = state.findWorker("prj001-prj001-workers-3")
       maybeWorker shouldBe Some(
         Worker(p1w3, coordinates001_3.asKey, Stopped, Started)
@@ -83,7 +83,7 @@ class ProjectionStateSpec extends WordSpec with Matchers {
       val defaultRequested = Stopped
       val defaultObserved  = Started
 
-      val state       = State.fromReplicatedData(richIndex, desiredStatus, observedStatus, defaultRequested, defaultObserved)
+      val state       = State.fromReplicatedData(richIndex, requestedStatus, observedStatus, defaultRequested, defaultObserved)
       val maybeWorker = state.findWorker(newCoordinates.asKey)
       maybeWorker shouldBe Some(
         Worker(newWorkerName, newCoordinates.asKey, defaultRequested, defaultObserved)


### PR DESCRIPTION
Fixes #2213 

This PR supersedes https://github.com/lagom/lagom/pull/2219 following a solution that's a lot simpler and more robust: eagerly tracking the projection names and it's tagNames. It also uses a poor man's stashing for early-requests (main purpose of this fix).