### PR TITLE
Docs: improve links to Alpakka Kafka

### DIFF
--- a/docs/manual/java/guide/broker/KafkaClient.md
+++ b/docs/manual/java/guide/broker/KafkaClient.md
@@ -1,6 +1,7 @@
 # Lagom Kafka Client
 
-Lagom provides an implementation of the Message Broker API that uses Kafka. The following sections show how to add the dependency in your build, and how to configure and tune topic publishers and subscribers. For information on running Kafka in development, see the [[Kafka Server|KafkaServer]] page. 
+Lagom provides an implementation of the Message Broker API that uses Kafka. The following sections show how to add the dependency in your build, and how to configure and tune topic publishers and subscribers.
+For information on running Kafka in development, see the [[Kafka Server|KafkaServer]] page.
 
 ## Dependency
 
@@ -25,7 +26,7 @@ When importing the Lagom Kafka Broker module keep in mind that the Lagom Kafka B
 
 ## Configuration
 
-The Lagom Kafka Client implementation is built using [Alpakka Kafka](https://github.com/akka/alpakka-kafka). The Alpakka Kafka library wraps the official [Apache Java Kafka client](https://kafka.apache.org/documentation.html) and exposes a (Akka) stream based API to publish/consume messages to/from Kafka. Therefore, we have effectively three libraries at play, with each of them exposing its own configuration. Let's explore the configuration keys exposed by each layer, starting with the one sitting at the top, i.e., the Lagom Kafka Client.
+The Lagom Kafka Client implementation is built using [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/). The Alpakka Kafka library wraps the official [Apache Java Kafka client](https://kafka.apache.org/documentation.html) and exposes a (Akka) stream based API to publish/consume messages to/from Kafka. Therefore, we have effectively three libraries at play, with each of them exposing its own configuration. Let's explore the configuration keys exposed by each layer, starting with the one sitting at the top, i.e., the Lagom Kafka Client.
 
 ### Lagom Kafka Client
 
@@ -39,7 +40,9 @@ Third, the consumer has a few more configuration keys allowing you to decide how
 
 ### Alpakka Kafka configuration
 
-See the [Alpakka Kafka reference.conf](https://github.com/akka/alpakka-kafka/blob/master/core/src/main/resources/reference.conf) to find out about the available configuration parameters.
+See the [Alpakka Kafka producer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/producer.html#settings) and [Alpakka Kafka consumer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/consumer.html#settings) to find out about the available configuration parameters.
+
+Please refer to [production considerations](https://doc.akka.io/docs/alpakka-kafka/1.0/production.html) for other things to keep in mind when using Alpakka Kafka.
 
 ### Apache Java Kafka Client
 

--- a/docs/manual/scala/guide/broker/KafkaClient.md
+++ b/docs/manual/scala/guide/broker/KafkaClient.md
@@ -1,6 +1,7 @@
 # Lagom Kafka Client
 
-Lagom provides an implementation of the Message Broker API that uses Kafka. In the remainder you will learn how to add the dependency in your build, and how to configure and tune topic's publishers and subscribers.
+Lagom provides an implementation of the Message Broker API that uses Kafka. The following sections show how to add the dependency in your build, and how to configure and tune topic publishers and subscribers.
+For information on running Kafka in development, see the [[Kafka Server|KafkaServer]] page.
 
 ## Dependency
 
@@ -15,8 +16,7 @@ When importing the Lagom Kafka Broker module keep in mind that the Lagom Kafka B
 
 After adding the dependency you also need to mix-in the `LagomKafkaComponents` trait on your `Application` to ensure it is enabled and usable at runtime.
 
-The Lagom Kafka Client implementation is built using [Alpakka Kafka](https://github.com/akka/alpakka-kafka). The Alpakka Kafka library wraps the official [Apache Java Kafka client](https://kafka.apache.org/documentation.html) and exposes a (Akka) stream based API to publish/consume messages to/from Kafka. Therefore, we have effectively three libraries at play, with each of them exposing its own configuration. Let's explore  the configuration keys exposed by each layer, starting with the one sitting at the top, i.e., the Lagom Kafka Client.
-
+The Lagom Kafka Client implementation is built using [Alpakka Kafka](https://doc.akka.io/docs/alpakka-kafka/). The Alpakka Kafka library wraps the official [Apache Java Kafka client](https://kafka.apache.org/documentation.html) and exposes a (Akka) stream based API to publish/consume messages to/from Kafka. Therefore, we have effectively three libraries at play, with each of them exposing its own configuration. Let's explore  the configuration keys exposed by each layer, starting with the one sitting at the top, i.e., the Lagom Kafka Client.
 
 ### Lagom Kafka Client
 
@@ -30,7 +30,9 @@ Third, the consumer has a few more configuration keys allowing you to decide how
 
 ### Alpakka Kafka configuration
 
-See the [Alpakka Kafka reference.conf](https://github.com/akka/alpakka-kafka/blob/master/core/src/main/resources/reference.conf) to find out about the available configuration parameters.
+See the [Alpakka Kafka producer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/producer.html#settings) and [Alpakka Kafka consumer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/consumer.html#settings) to find out about the available configuration parameters.
+
+Please refer to [production considerations](https://doc.akka.io/docs/alpakka-kafka/1.0/production.html) for other things to keep in mind when using Alpakka Kafka.
 
 ### Apache Java Kafka Client
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
     val Netty                = "4.1.39.Final"
     val NettyReactiveStreams = "2.0.3"
     val Kafka                = "2.1.1"
+    // adapt links in (java/scala)/KafkaClient.md for minor version changes
     val AlpakkaKafka         = "1.0.5"
     val Curator              = "2.12.0"
     val Immutables           = "2.7.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,11 +45,11 @@ object Dependencies {
     val NettyReactiveStreams = "2.0.3"
     val Kafka                = "2.1.1"
     // adapt links in (java/scala)/KafkaClient.md for minor version changes
-    val AlpakkaKafka         = "1.0.5"
-    val Curator              = "2.12.0"
-    val Immutables           = "2.7.5"
-    val HibernateCore        = "5.4.4.Final"
-    val PCollections         = "3.0.5"
+    val AlpakkaKafka  = "1.0.5"
+    val Curator       = "2.12.0"
+    val Immutables    = "2.7.5"
+    val HibernateCore = "5.4.4.Final"
+    val PCollections  = "3.0.5"
 
     val ScalaJava8Compat = "0.9.0"
     val ScalaXml         = "1.2.0"


### PR DESCRIPTION
## Purpose

Make it easier to discover the correct configuration of Alpakka Kafka when using Lagom.

## Background Context

I was in contact with a Lagom user who was looking for the security configuration which is described in the Alpakka Kafka docs.