### PR TITLE
Override default discovery method

### DIFF
--- a/akka-service-locator/core/src/main/resources/play/reference-overrides.conf
+++ b/akka-service-locator/core/src/main/resources/play/reference-overrides.conf
@@ -1,0 +1,8 @@
+akka {
+  discovery {
+    method = aggregate
+    aggregate {
+      discovery-methods = ["config", "akka-dns"]
+    }
+  }
+}

--- a/akka-service-locator/core/src/main/resources/reference.conf
+++ b/akka-service-locator/core/src/main/resources/reference.conf
@@ -38,12 +38,3 @@ lagom.akka.discovery {
   lookup-timeout = 5 seconds
 }
 #//#lagom-akka-discovery-reference-conf
-
-akka {
-  discovery {
-    method = aggregate
-    aggregate {
-      discovery-methods = ["config", "akka-dns"]
-    }
-  }
-}


### PR DESCRIPTION
When set in reference.conf, it may or may not override the defaults set in akka-discovery, depending on classpath ordering.

Fixes #2239.