### PR TITLE
Tolerate multi-jvm failures when running tests on CI

### DIFF
--- a/persistence-cassandra/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
+++ b/persistence-cassandra/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
@@ -15,6 +15,7 @@ import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersis
 import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntitySpec
 import com.lightbend.lagom.javadsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.javadsl.persistence.TestEntityReadSide
+import com.lightbend.lagom.persistence.TolerateFailuresWhenRunningContinuousIntegration
 import com.typesafe.config.Config
 
 object CassandraClusteredPersistentEntityConfig extends AbstractClusteredPersistentEntityConfig {
@@ -27,7 +28,8 @@ class CassandraClusteredPersistentEntitySpecMultiJvmNode2 extends CassandraClust
 class CassandraClusteredPersistentEntitySpecMultiJvmNode3 extends CassandraClusteredPersistentEntitySpec
 
 class CassandraClusteredPersistentEntitySpec
-    extends AbstractClusteredPersistentEntitySpec(CassandraClusteredPersistentEntityConfig) {
+    extends AbstractClusteredPersistentEntitySpec(CassandraClusteredPersistentEntityConfig)
+    with TolerateFailuresWhenRunningContinuousIntegration {
 
   import CassandraClusteredPersistentEntityConfig._
 

--- a/persistence-cassandra/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
+++ b/persistence-cassandra/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
@@ -13,6 +13,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.Materializer
 import com.lightbend.lagom.internal.persistence.testkit.AwaitPersistenceInit.awaitPersistenceInit
 import com.lightbend.lagom.internal.persistence.testkit.PersistenceTestConfig.cassandraConfigOnly
+import com.lightbend.lagom.persistence.TolerateFailuresWhenRunningContinuousIntegration
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
 import com.lightbend.lagom.scaladsl.persistence.ReadSideProcessor
@@ -40,7 +41,8 @@ class CassandraClusteredPersistentEntitySpecMultiJvmNode2 extends CassandraClust
 class CassandraClusteredPersistentEntitySpecMultiJvmNode3 extends CassandraClusteredPersistentEntitySpec
 
 class CassandraClusteredPersistentEntitySpec
-    extends AbstractClusteredPersistentEntitySpec(CassandraClusteredPersistentEntityConfig) {
+    extends AbstractClusteredPersistentEntitySpec(CassandraClusteredPersistentEntityConfig)
+    with TolerateFailuresWhenRunningContinuousIntegration {
 
   import CassandraClusteredPersistentEntityConfig._
 

--- a/persistence/core/src/test/scala/com/lightbend/lagom/persistence/TolerateFailuresWhenRunningContinuousIntegration.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/persistence/TolerateFailuresWhenRunningContinuousIntegration.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.persistence
+
+import org.scalatest.Canceled
+import org.scalatest.Exceptional
+import org.scalatest.Failed
+import org.scalatest.Outcome
+import org.scalatest.TestSuiteMixin
+import org.scalatest.TestSuite
+
+import scala.util.control.NonFatal
+
+/**
+ * This can be mixed into flaky tests so that we don't care if they fail on CI, but we
+ * care if they failed when running locally.
+ */
+trait TolerateFailuresWhenRunningContinuousIntegration extends TestSuiteMixin { this: TestSuite =>
+
+  // See https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+  val isTravis: Boolean     = sys.env.get("TRAVIS").exists(_.toBoolean)
+  val isTravisCron: Boolean = sys.env.get("TRAVIS_EVENT_TYPE").exists(_.equalsIgnoreCase("cron"))
+
+  // See https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables
+  val isCircleCi: Boolean = sys.env.get("CIRCLECI").exists(_.toBoolean)
+
+  val isContinuousIntegration: Boolean = isTravis || isCircleCi
+  val isCronBuild: Boolean             = isTravisCron // TODO We don't have cron builds for CircleCI yet
+
+  protected abstract override def withFixture(test: NoArgTest): Outcome = {
+    try {
+      super.withFixture(test) match {
+        case f: Failed        => handleUnsuccessfulOutcome(f.exception)(f)
+        case Exceptional(e)   => handleUnsuccessfulOutcome(e)(Exceptional(e))
+        case outcome: Outcome => outcome
+      }
+    } catch {
+      case NonFatal(e)  => handleUnsuccessfulOutcome(e)(Exceptional(e))
+      case t: Throwable => Exceptional(t)
+    }
+  }
+
+  private def handleUnsuccessfulOutcome(t: Throwable)(outcome: => Outcome): Outcome = {
+    // Do not ignore failures for cron builds
+    if (isContinuousIntegration && !isCronBuild) Canceled(s"Ignoring ${t} since it is running on CI")
+    else outcome
+  }
+}


### PR DESCRIPTION
We still have some flaky tests for persistence-cassandra-*, as documented
in #2080. Those are the most common flaky tests so we can ignore them for
now when running on Travis or Circle. They won't be ignored locally, however.

We also won't ignore failures on cron/scheduled builds since they are a
safeguard and don't disrupt the contribution flow.


