### PR TITLE
Remove additional serialization bindings

### DIFF
--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -24,14 +24,6 @@ lagom.defaults.cluster.join-self = off
 # useful in production environments to let the deployment orchestration solutions restart the service
 akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 60s
 
-akka.actor.serialization-bindings {
-  "akka.Done"                 = akka-misc
-  "akka.NotUsed"              = akka-misc
-  "akka.actor.Address"        = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}
-
-
 # Cluster distribution settings
 lagom.persistence.cluster.distribution {
 


### PR DESCRIPTION
These are now defined in Akka by default since 2.6.0-M5.

## Purpose

Removes redundant configuration.

## References

- https://github.com/akka/akka/pull/27256
- https://github.com/akka/akka/issues/26684