### PR TITLE
Prefer sonatypeBundleRelease

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,7 @@ def releaseSettings: Seq[Setting[_]] = Seq(
     Seq[ReleaseStep](
       checkSnapshotDependencies,
       releaseStepCommandAndRemaining("+publishSigned"),
-      releaseStepCommand("sonatypeRelease"),
+      releaseStepCommand("sonatypeBundleRelease"),
       releaseStepTask(bintrayRelease in thisProjectRef.value),
       pushChanges
     )


### PR DESCRIPTION
Following recommendations on https://github.com/xerial/sbt-sonatype/issues/89#issuecomment-529203859, this PR opts into using `sonatypeBundleRelease`.

I'm unsure of how the `releaseSettings` will impact the actual release process since, `releaseSettings` (where `sonatypeBundleRelease` is used) are actuall part of `common`:

https://github.com/lagom/lagom/blob/c5973de0713541d8befc1e7832e1d1e83e92dcfe/build.sbt#L36-L39

Then `common` are used in `runtimeLib`:

https://github.com/lagom/lagom/blob/c5973de0713541d8befc1e7832e1d1e83e92dcfe/build.sbt#L179-L180

which, in turn, also adds `sonatypeSettings`:

https://github.com/lagom/lagom/blob/c5973de0713541d8befc1e7832e1d1e83e92dcfe/build.sbt#L155-L157

Then, `runtimeLib` is added in generic projects on the build. While `common` is used by the `sbt-plugin` and other dev libraries.


This PR is only meant to test out this change. 
