### PR TITLE
Bump Play and Akka to latest Milestones

### DIFF
--- a/cluster/core/src/main/java/com/lightbend/lagom/internal/cluster/protobuf/msg/ClusterMessages.java
+++ b/cluster/core/src/main/java/com/lightbend/lagom/internal/cluster/protobuf/msg/ClusterMessages.java
@@ -10,59 +10,62 @@ package com.lightbend.lagom.internal.cluster.protobuf.msg;
 public final class ClusterMessages {
   private ClusterMessages() {}
 
-  public static void registerAllExtensions(akka.protobuf.ExtensionRegistry registry) {}
+  public static void registerAllExtensions(
+      akka.protobufv3.internal.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(akka.protobufv3.internal.ExtensionRegistry registry) {
+    registerAllExtensions((akka.protobufv3.internal.ExtensionRegistryLite) registry);
+  }
 
   public interface ExceptionOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.cluster.Exception)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>optional string message = 1;</code> */
     boolean hasMessage();
     /** <code>optional string message = 1;</code> */
     java.lang.String getMessage();
     /** <code>optional string message = 1;</code> */
-    akka.protobuf.ByteString getMessageBytes();
+    akka.protobufv3.internal.ByteString getMessageBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.cluster.Exception} */
-  public static final class Exception extends akka.protobuf.GeneratedMessage
+  public static final class Exception extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.cluster.Exception)
       ExceptionOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use Exception.newBuilder() to construct.
-    private Exception(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Exception(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private Exception(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private Exception() {
+      message_ = "";
     }
-
-    private static final Exception defaultInstance;
-
-    public static Exception getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Exception getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new Exception();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private Exception(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -71,28 +74,26 @@ public final class ClusterMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 message_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -100,12 +101,14 @@ public final class ClusterMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
           .internal_static_com_lightbend_lagom_internal_cluster_Exception_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
           .internal_static_com_lightbend_lagom_internal_cluster_Exception_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -114,27 +117,12 @@ public final class ClusterMessages {
                   .class);
     }
 
-    public static akka.protobuf.Parser<Exception> PARSER =
-        new akka.protobuf.AbstractParser<Exception>() {
-          public Exception parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new Exception(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<Exception> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MESSAGE_FIELD_NUMBER = 1;
-    private java.lang.Object message_;
+    private volatile java.lang.Object message_;
     /** <code>optional string message = 1;</code> */
     public boolean hasMessage() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>optional string message = 1;</code> */
     public java.lang.String getMessage() {
@@ -142,7 +130,7 @@ public final class ClusterMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           message_ = s;
@@ -151,23 +139,21 @@ public final class ClusterMessages {
       }
     }
     /** <code>optional string message = 1;</code> */
-    public akka.protobuf.ByteString getMessageBytes() {
+    public akka.protobufv3.internal.ByteString getMessageBytes() {
       java.lang.Object ref = message_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         message_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      message_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -177,129 +163,186 @@ public final class ClusterMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getMessageBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, message_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getMessageBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, message_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception other =
+          (com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception) obj;
+
+      if (hasMessage() != other.hasMessage()) return false;
+      if (hasMessage()) {
+        if (!getMessage().equals(other.getMessage())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasMessage()) {
+        hash = (37 * hash) + MESSAGE_FIELD_NUMBER;
+        hash = (53 * hash) + getMessage().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() {
-      return Builder.create();
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
     }
 
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
     public Builder newBuilderForType() {
       return newBuilder();
     }
 
-    public static Builder newBuilder(
-        com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
-    public Builder toBuilder() {
-      return newBuilder(this);
+    public static Builder newBuilder(
+        com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.cluster.Exception} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.cluster.Exception)
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.ExceptionOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
             .internal_static_com_lightbend_lagom_internal_cluster_Exception_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
             .internal_static_com_lightbend_lagom_internal_cluster_Exception_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -314,19 +357,16 @@ public final class ClusterMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         message_ = "";
@@ -334,21 +374,20 @@ public final class ClusterMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
             .internal_static_com_lightbend_lagom_internal_cluster_Exception_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
           getDefaultInstanceForType() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
             .getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception build() {
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception result =
             buildPartial();
@@ -358,13 +397,14 @@ public final class ClusterMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
           buildPartial() {
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception result =
             new com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.message_ = message_;
@@ -373,7 +413,43 @@ public final class ClusterMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception) {
@@ -395,27 +471,30 @@ public final class ClusterMessages {
           message_ = other.message_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception parsedMessage =
             null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -429,13 +508,13 @@ public final class ClusterMessages {
       private java.lang.Object message_ = "";
       /** <code>optional string message = 1;</code> */
       public boolean hasMessage() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>optional string message = 1;</code> */
       public java.lang.String getMessage() {
         java.lang.Object ref = message_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             message_ = s;
@@ -446,15 +525,15 @@ public final class ClusterMessages {
         }
       }
       /** <code>optional string message = 1;</code> */
-      public akka.protobuf.ByteString getMessageBytes() {
+      public akka.protobufv3.internal.ByteString getMessageBytes() {
         java.lang.Object ref = message_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           message_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>optional string message = 1;</code> */
@@ -475,7 +554,7 @@ public final class ClusterMessages {
         return this;
       }
       /** <code>optional string message = 1;</code> */
-      public Builder setMessageBytes(akka.protobuf.ByteString value) {
+      public Builder setMessageBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -485,68 +564,112 @@ public final class ClusterMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.cluster.Exception)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.cluster.Exception)
+    private static final com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new Exception(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.cluster.Exception)
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<Exception> PARSER =
+        new akka.protobufv3.internal.AbstractParser<Exception>() {
+          @java.lang.Override
+          public Exception parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new Exception(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<Exception> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<Exception> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.Exception
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface EnsureActiveOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.cluster.EnsureActive)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string entityId = 1;</code> */
     boolean hasEntityId();
     /** <code>required string entityId = 1;</code> */
     java.lang.String getEntityId();
     /** <code>required string entityId = 1;</code> */
-    akka.protobuf.ByteString getEntityIdBytes();
+    akka.protobufv3.internal.ByteString getEntityIdBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.cluster.EnsureActive} */
-  public static final class EnsureActive extends akka.protobuf.GeneratedMessage
+  public static final class EnsureActive extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.cluster.EnsureActive)
       EnsureActiveOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use EnsureActive.newBuilder() to construct.
-    private EnsureActive(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private EnsureActive(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private EnsureActive(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private EnsureActive() {
+      entityId_ = "";
     }
-
-    private static final EnsureActive defaultInstance;
-
-    public static EnsureActive getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public EnsureActive getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new EnsureActive();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private EnsureActive(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -555,28 +678,26 @@ public final class ClusterMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 entityId_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -584,12 +705,14 @@ public final class ClusterMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
           .internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
           .internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -598,27 +721,12 @@ public final class ClusterMessages {
                   .class);
     }
 
-    public static akka.protobuf.Parser<EnsureActive> PARSER =
-        new akka.protobuf.AbstractParser<EnsureActive>() {
-          public EnsureActive parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new EnsureActive(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<EnsureActive> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ENTITYID_FIELD_NUMBER = 1;
-    private java.lang.Object entityId_;
+    private volatile java.lang.Object entityId_;
     /** <code>required string entityId = 1;</code> */
     public boolean hasEntityId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string entityId = 1;</code> */
     public java.lang.String getEntityId() {
@@ -626,7 +734,7 @@ public final class ClusterMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           entityId_ = s;
@@ -635,23 +743,21 @@ public final class ClusterMessages {
       }
     }
     /** <code>required string entityId = 1;</code> */
-    public akka.protobuf.ByteString getEntityIdBytes() {
+    public akka.protobufv3.internal.ByteString getEntityIdBytes() {
       java.lang.Object ref = entityId_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         entityId_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      entityId_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -665,129 +771,187 @@ public final class ClusterMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getEntityIdBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, entityId_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getEntityIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, entityId_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive other =
+          (com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive) obj;
+
+      if (hasEntityId() != other.hasEntityId()) return false;
+      if (hasEntityId()) {
+        if (!getEntityId().equals(other.getEntityId())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEntityId()) {
+        hash = (37 * hash) + ENTITYID_FIELD_NUMBER;
+        hash = (53 * hash) + getEntityId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() {
-      return Builder.create();
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
     }
 
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
     public Builder newBuilderForType() {
       return newBuilder();
     }
 
-    public static Builder newBuilder(
-        com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
-    public Builder toBuilder() {
-      return newBuilder(this);
+    public static Builder newBuilder(
+        com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.cluster.EnsureActive} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.cluster.EnsureActive)
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActiveOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
             .internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
             .internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -803,19 +967,16 @@ public final class ClusterMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         entityId_ = "";
@@ -823,21 +984,20 @@ public final class ClusterMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
             .internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
           getDefaultInstanceForType() {
         return com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
             .getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
           build() {
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive result =
@@ -848,6 +1008,7 @@ public final class ClusterMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
           buildPartial() {
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive result =
@@ -855,7 +1016,7 @@ public final class ClusterMessages {
                 this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.entityId_ = entityId_;
@@ -864,7 +1025,43 @@ public final class ClusterMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive) {
@@ -887,31 +1084,33 @@ public final class ClusterMessages {
           entityId_ = other.entityId_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasEntityId()) {
-
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -925,13 +1124,13 @@ public final class ClusterMessages {
       private java.lang.Object entityId_ = "";
       /** <code>required string entityId = 1;</code> */
       public boolean hasEntityId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string entityId = 1;</code> */
       public java.lang.String getEntityId() {
         java.lang.Object ref = entityId_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             entityId_ = s;
@@ -942,15 +1141,15 @@ public final class ClusterMessages {
         }
       }
       /** <code>required string entityId = 1;</code> */
-      public akka.protobuf.ByteString getEntityIdBytes() {
+      public akka.protobufv3.internal.ByteString getEntityIdBytes() {
         java.lang.Object ref = entityId_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           entityId_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string entityId = 1;</code> */
@@ -971,7 +1170,7 @@ public final class ClusterMessages {
         return this;
       }
       /** <code>required string entityId = 1;</code> */
-      public Builder setEntityIdBytes(akka.protobuf.ByteString value) {
+      public Builder setEntityIdBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -981,31 +1180,78 @@ public final class ClusterMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.cluster.EnsureActive)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.cluster.EnsureActive)
+    private static final com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages
+            .EnsureActive
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new EnsureActive(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.cluster.EnsureActive)
+    public static com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<EnsureActive> PARSER =
+        new akka.protobufv3.internal.AbstractParser<EnsureActive>() {
+          @java.lang.Override
+          public EnsureActive parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new EnsureActive(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<EnsureActive> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<EnsureActive> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.cluster.protobuf.msg.ClusterMessages.EnsureActive
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_cluster_Exception_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_cluster_Exception_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_fieldAccessorTable;
 
-  public static akka.protobuf.Descriptors.FileDescriptor getDescriptor() {
+  public static akka.protobufv3.internal.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
 
-  private static akka.protobuf.Descriptors.FileDescriptor descriptor;
+  private static akka.protobufv3.internal.Descriptors.FileDescriptor descriptor;
 
   static {
     java.lang.String[] descriptorData = {
@@ -1015,20 +1261,13 @@ public final class ClusterMessages {
           + "\001 \002(\tB5\n1com.lightbend.lagom.internal.cl"
           + "uster.protobuf.msgH\001"
     };
-    akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-          public akka.protobuf.ExtensionRegistry assignDescriptors(
-              akka.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    akka.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
-        descriptorData, new akka.protobuf.Descriptors.FileDescriptor[] {}, assigner);
+    descriptor =
+        akka.protobufv3.internal.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData, new akka.protobufv3.internal.Descriptors.FileDescriptor[] {});
     internal_static_com_lightbend_lagom_internal_cluster_Exception_descriptor =
         getDescriptor().getMessageTypes().get(0);
     internal_static_com_lightbend_lagom_internal_cluster_Exception_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_cluster_Exception_descriptor,
             new java.lang.String[] {
               "Message",
@@ -1036,7 +1275,7 @@ public final class ClusterMessages {
     internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_descriptor =
         getDescriptor().getMessageTypes().get(1);
     internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_cluster_EnsureActive_descriptor,
             new java.lang.String[] {
               "EntityId",

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -3,11 +3,11 @@ import akka.CrossJava
 
 val ScalaVersion = "2.12.9"
 
-val AkkaVersion: String   = sys.props.getOrElse("lagom.build.akka.version", "2.6.0-M5")
+val AkkaVersion: String   = sys.props.getOrElse("lagom.build.akka.version", "2.6.0-M7")
 val JUnitVersion          = "4.12"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion      = "3.0.8"
-val PlayVersion           = "2.8.0-M4"
+val PlayVersion           = "2.8.0-M5"
 val Log4jVersion          = "2.12.1"
 val MacWireVersion        = "2.3.2"
 val LombokVersion         = "1.18.8"

--- a/docs/manual/java/guide/cluster/code/docs/home/persistence/Post4Test.java
+++ b/docs/manual/java/guide/cluster/code/docs/home/persistence/Post4Test.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import akka.Done;
 import akka.actor.ActorSystem;
 import akka.testkit.javadsl.TestKit;
-import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 
 import scala.concurrent.ExecutionContext;
@@ -52,7 +51,7 @@ public class Post4Test {
       new GuiceInjectorBuilder()
           .bindings(
               bind(ActorSystem.class).toInstance(system),
-              bind(Materializer.class).toInstance(ActorMaterializer.create(system)),
+              bind(Materializer.class).toInstance(Materializer.matFromSystem(system)),
               bind(ExecutionContext.class).toInstance(system.dispatcher()))
           .bindings(new PubSubModule())
           .build();

--- a/docs/manual/scala/guide/advanced/code/IntegratingNonLagom.scala
+++ b/docs/manual/scala/guide/advanced/code/IntegratingNonLagom.scala
@@ -5,7 +5,6 @@
 package docs.scaladsl.advanced
 
 import _root_.akka.actor.ActorSystem
-import _root_.akka.stream.ActorMaterializer
 import _root_.akka.stream.Materializer
 
 package staticservicelocator {
@@ -49,7 +48,7 @@ package staticservicelocator {
     }
 
     val actorSystem   = ActorSystem("my-app")
-    val materializer  = ActorMaterializer()(actorSystem)
+    val materializer  = Materializer.matFromSystem(actorSystem)
     val clientFactory = new MyLagomClientFactory(actorSystem, materializer)
     //#static-service-locator
 
@@ -83,7 +82,8 @@ package devmode {
     //#dev-mode-url
     new StandaloneLagomClientFactory("my-client") with AhcWSComponents with LagomDevModeServiceLocatorComponents {
 
-      override lazy val devModeServiceLocatorUrl = URI.create("http://localhost:8001")
+      override lazy val devModeServiceLocatorUrl =
+        URI.create("http://localhost:8001")
     }
 
     //#dev-mode-url

--- a/persistence/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/protobuf/msg/PersistenceMessages.java
+++ b/persistence/javadsl/src/main/java/com/lightbend/lagom/internal/javadsl/persistence/protobuf/msg/PersistenceMessages.java
@@ -10,24 +10,29 @@ package com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg;
 public final class PersistenceMessages {
   private PersistenceMessages() {}
 
-  public static void registerAllExtensions(akka.protobuf.ExtensionRegistry registry) {}
+  public static void registerAllExtensions(
+      akka.protobufv3.internal.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(akka.protobufv3.internal.ExtensionRegistry registry) {
+    registerAllExtensions((akka.protobufv3.internal.ExtensionRegistryLite) registry);
+  }
 
   public interface CommandEnvelopeOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string entityId = 1;</code> */
     boolean hasEntityId();
     /** <code>required string entityId = 1;</code> */
     java.lang.String getEntityId();
     /** <code>required string entityId = 1;</code> */
-    akka.protobuf.ByteString getEntityIdBytes();
+    akka.protobufv3.internal.ByteString getEntityIdBytes();
 
     /** <code>required bytes enclosedMessage = 2;</code> */
     boolean hasEnclosedMessage();
     /** <code>required bytes enclosedMessage = 2;</code> */
-    akka.protobuf.ByteString getEnclosedMessage();
+    akka.protobufv3.internal.ByteString getEnclosedMessage();
 
     /** <code>required int32 serializerId = 3;</code> */
     boolean hasSerializerId();
@@ -37,47 +42,47 @@ public final class PersistenceMessages {
     /** <code>optional bytes messageManifest = 4;</code> */
     boolean hasMessageManifest();
     /** <code>optional bytes messageManifest = 4;</code> */
-    akka.protobuf.ByteString getMessageManifest();
+    akka.protobufv3.internal.ByteString getMessageManifest();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope} */
-  public static final class CommandEnvelope extends akka.protobuf.GeneratedMessage
+  public static final class CommandEnvelope extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope)
       CommandEnvelopeOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use CommandEnvelope.newBuilder() to construct.
-    private CommandEnvelope(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private CommandEnvelope(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private CommandEnvelope(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private CommandEnvelope() {
+      entityId_ = "";
+      enclosedMessage_ = akka.protobufv3.internal.ByteString.EMPTY;
+      messageManifest_ = akka.protobufv3.internal.ByteString.EMPTY;
     }
-
-    private static final CommandEnvelope defaultInstance;
-
-    public static CommandEnvelope getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public CommandEnvelope getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new CommandEnvelope();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private CommandEnvelope(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -86,18 +91,9 @@ public final class PersistenceMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 entityId_ = bs;
                 break;
@@ -120,12 +116,19 @@ public final class PersistenceMessages {
                 messageManifest_ = input.readBytes();
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -133,12 +136,14 @@ public final class PersistenceMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -148,27 +153,12 @@ public final class PersistenceMessages {
                   .CommandEnvelope.Builder.class);
     }
 
-    public static akka.protobuf.Parser<CommandEnvelope> PARSER =
-        new akka.protobuf.AbstractParser<CommandEnvelope>() {
-          public CommandEnvelope parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new CommandEnvelope(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<CommandEnvelope> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ENTITYID_FIELD_NUMBER = 1;
-    private java.lang.Object entityId_;
+    private volatile java.lang.Object entityId_;
     /** <code>required string entityId = 1;</code> */
     public boolean hasEntityId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string entityId = 1;</code> */
     public java.lang.String getEntityId() {
@@ -176,7 +166,7 @@ public final class PersistenceMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           entityId_ = s;
@@ -185,25 +175,26 @@ public final class PersistenceMessages {
       }
     }
     /** <code>required string entityId = 1;</code> */
-    public akka.protobuf.ByteString getEntityIdBytes() {
+    public akka.protobufv3.internal.ByteString getEntityIdBytes() {
       java.lang.Object ref = entityId_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         entityId_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
     }
 
     public static final int ENCLOSEDMESSAGE_FIELD_NUMBER = 2;
-    private akka.protobuf.ByteString enclosedMessage_;
+    private akka.protobufv3.internal.ByteString enclosedMessage_;
     /** <code>required bytes enclosedMessage = 2;</code> */
     public boolean hasEnclosedMessage() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /** <code>required bytes enclosedMessage = 2;</code> */
-    public akka.protobuf.ByteString getEnclosedMessage() {
+    public akka.protobufv3.internal.ByteString getEnclosedMessage() {
       return enclosedMessage_;
     }
 
@@ -211,7 +202,7 @@ public final class PersistenceMessages {
     private int serializerId_;
     /** <code>required int32 serializerId = 3;</code> */
     public boolean hasSerializerId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /** <code>required int32 serializerId = 3;</code> */
     public int getSerializerId() {
@@ -219,25 +210,19 @@ public final class PersistenceMessages {
     }
 
     public static final int MESSAGEMANIFEST_FIELD_NUMBER = 4;
-    private akka.protobuf.ByteString messageManifest_;
+    private akka.protobufv3.internal.ByteString messageManifest_;
     /** <code>optional bytes messageManifest = 4;</code> */
     public boolean hasMessageManifest() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /** <code>optional bytes messageManifest = 4;</code> */
-    public akka.protobuf.ByteString getMessageManifest() {
+    public akka.protobufv3.internal.ByteString getMessageManifest() {
       return messageManifest_;
-    }
-
-    private void initFields() {
-      entityId_ = "";
-      enclosedMessage_ = akka.protobuf.ByteString.EMPTY;
-      serializerId_ = 0;
-      messageManifest_ = akka.protobuf.ByteString.EMPTY;
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -259,160 +244,249 @@ public final class PersistenceMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getEntityIdBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, entityId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, enclosedMessage_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeInt32(3, serializerId_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeBytes(4, messageManifest_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getEntityIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, entityId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(2, enclosedMessage_);
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream.computeBytesSize(2, enclosedMessage_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += akka.protobuf.CodedOutputStream.computeInt32Size(3, serializerId_);
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream.computeInt32Size(3, serializerId_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(4, messageManifest_);
+      if (((bitField0_ & 0x00000008) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream.computeBytesSize(4, messageManifest_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+              .CommandEnvelope)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+              .CommandEnvelope
+          other =
+              (com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+                      .CommandEnvelope)
+                  obj;
+
+      if (hasEntityId() != other.hasEntityId()) return false;
+      if (hasEntityId()) {
+        if (!getEntityId().equals(other.getEntityId())) return false;
+      }
+      if (hasEnclosedMessage() != other.hasEnclosedMessage()) return false;
+      if (hasEnclosedMessage()) {
+        if (!getEnclosedMessage().equals(other.getEnclosedMessage())) return false;
+      }
+      if (hasSerializerId() != other.hasSerializerId()) return false;
+      if (hasSerializerId()) {
+        if (getSerializerId() != other.getSerializerId()) return false;
+      }
+      if (hasMessageManifest() != other.hasMessageManifest()) return false;
+      if (hasMessageManifest()) {
+        if (!getMessageManifest().equals(other.getMessageManifest())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEntityId()) {
+        hash = (37 * hash) + ENTITYID_FIELD_NUMBER;
+        hash = (53 * hash) + getEntityId().hashCode();
+      }
+      if (hasEnclosedMessage()) {
+        hash = (37 * hash) + ENCLOSEDMESSAGE_FIELD_NUMBER;
+        hash = (53 * hash) + getEnclosedMessage().hashCode();
+      }
+      if (hasSerializerId()) {
+        hash = (37 * hash) + SERIALIZERID_FIELD_NUMBER;
+        hash = (53 * hash) + getSerializerId();
+      }
+      if (hasMessageManifest()) {
+        hash = (37 * hash) + MESSAGEMANIFEST_FIELD_NUMBER;
+        hash = (53 * hash) + getMessageManifest().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
                 .CommandEnvelope
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope)
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelopeOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -428,41 +502,36 @@ public final class PersistenceMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         entityId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        enclosedMessage_ = akka.protobuf.ByteString.EMPTY;
+        enclosedMessage_ = akka.protobufv3.internal.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000002);
         serializerId_ = 0;
         bitField0_ = (bitField0_ & ~0x00000004);
-        messageManifest_ = akka.protobuf.ByteString.EMPTY;
+        messageManifest_ = akka.protobufv3.internal.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .CommandEnvelope
           getDefaultInstanceForType() {
@@ -470,6 +539,7 @@ public final class PersistenceMessages {
             .CommandEnvelope.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .CommandEnvelope
           build() {
@@ -482,6 +552,7 @@ public final class PersistenceMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .CommandEnvelope
           buildPartial() {
@@ -492,19 +563,19 @@ public final class PersistenceMessages {
                     .PersistenceMessages.CommandEnvelope(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.entityId_ = entityId_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.enclosedMessage_ = enclosedMessage_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.serializerId_ = serializerId_;
           to_bitField0_ |= 0x00000004;
         }
-        result.serializerId_ = serializerId_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.messageManifest_ = messageManifest_;
@@ -513,7 +584,43 @@ public final class PersistenceMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
@@ -549,41 +656,41 @@ public final class PersistenceMessages {
         if (other.hasMessageManifest()) {
           setMessageManifest(other.getMessageManifest());
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasEntityId()) {
-
           return false;
         }
         if (!hasEnclosedMessage()) {
-
           return false;
         }
         if (!hasSerializerId()) {
-
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
                 .CommandEnvelope
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
                       .CommandEnvelope)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -597,13 +704,13 @@ public final class PersistenceMessages {
       private java.lang.Object entityId_ = "";
       /** <code>required string entityId = 1;</code> */
       public boolean hasEntityId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string entityId = 1;</code> */
       public java.lang.String getEntityId() {
         java.lang.Object ref = entityId_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             entityId_ = s;
@@ -614,15 +721,15 @@ public final class PersistenceMessages {
         }
       }
       /** <code>required string entityId = 1;</code> */
-      public akka.protobuf.ByteString getEntityIdBytes() {
+      public akka.protobufv3.internal.ByteString getEntityIdBytes() {
         java.lang.Object ref = entityId_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           entityId_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string entityId = 1;</code> */
@@ -643,7 +750,7 @@ public final class PersistenceMessages {
         return this;
       }
       /** <code>required string entityId = 1;</code> */
-      public Builder setEntityIdBytes(akka.protobuf.ByteString value) {
+      public Builder setEntityIdBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -653,17 +760,18 @@ public final class PersistenceMessages {
         return this;
       }
 
-      private akka.protobuf.ByteString enclosedMessage_ = akka.protobuf.ByteString.EMPTY;
+      private akka.protobufv3.internal.ByteString enclosedMessage_ =
+          akka.protobufv3.internal.ByteString.EMPTY;
       /** <code>required bytes enclosedMessage = 2;</code> */
       public boolean hasEnclosedMessage() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /** <code>required bytes enclosedMessage = 2;</code> */
-      public akka.protobuf.ByteString getEnclosedMessage() {
+      public akka.protobufv3.internal.ByteString getEnclosedMessage() {
         return enclosedMessage_;
       }
       /** <code>required bytes enclosedMessage = 2;</code> */
-      public Builder setEnclosedMessage(akka.protobuf.ByteString value) {
+      public Builder setEnclosedMessage(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -683,7 +791,7 @@ public final class PersistenceMessages {
       private int serializerId_;
       /** <code>required int32 serializerId = 3;</code> */
       public boolean hasSerializerId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /** <code>required int32 serializerId = 3;</code> */
       public int getSerializerId() {
@@ -704,17 +812,18 @@ public final class PersistenceMessages {
         return this;
       }
 
-      private akka.protobuf.ByteString messageManifest_ = akka.protobuf.ByteString.EMPTY;
+      private akka.protobufv3.internal.ByteString messageManifest_ =
+          akka.protobufv3.internal.ByteString.EMPTY;
       /** <code>optional bytes messageManifest = 4;</code> */
       public boolean hasMessageManifest() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /** <code>optional bytes messageManifest = 4;</code> */
-      public akka.protobuf.ByteString getMessageManifest() {
+      public akka.protobufv3.internal.ByteString getMessageManifest() {
         return messageManifest_;
       }
       /** <code>optional bytes messageManifest = 4;</code> */
-      public Builder setMessageManifest(akka.protobuf.ByteString value) {
+      public Builder setMessageManifest(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -731,68 +840,116 @@ public final class PersistenceMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope)
+    private static final com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg
+            .PersistenceMessages.CommandEnvelope
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new CommandEnvelope(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+              .CommandEnvelope();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.javadsl.persistence.CommandEnvelope)
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<CommandEnvelope> PARSER =
+        new akka.protobufv3.internal.AbstractParser<CommandEnvelope>() {
+          @java.lang.Override
+          public CommandEnvelope parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new CommandEnvelope(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<CommandEnvelope> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<CommandEnvelope> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface ExceptionOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.javadsl.persistence.Exception)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>optional string message = 1;</code> */
     boolean hasMessage();
     /** <code>optional string message = 1;</code> */
     java.lang.String getMessage();
     /** <code>optional string message = 1;</code> */
-    akka.protobuf.ByteString getMessageBytes();
+    akka.protobufv3.internal.ByteString getMessageBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.javadsl.persistence.Exception} */
-  public static final class Exception extends akka.protobuf.GeneratedMessage
+  public static final class Exception extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.javadsl.persistence.Exception)
       ExceptionOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use Exception.newBuilder() to construct.
-    private Exception(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Exception(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private Exception(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private Exception() {
+      message_ = "";
     }
-
-    private static final Exception defaultInstance;
-
-    public static Exception getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Exception getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new Exception();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private Exception(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -801,28 +958,26 @@ public final class PersistenceMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 message_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -830,12 +985,14 @@ public final class PersistenceMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -845,27 +1002,12 @@ public final class PersistenceMessages {
                   .Exception.Builder.class);
     }
 
-    public static akka.protobuf.Parser<Exception> PARSER =
-        new akka.protobuf.AbstractParser<Exception>() {
-          public Exception parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new Exception(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<Exception> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MESSAGE_FIELD_NUMBER = 1;
-    private java.lang.Object message_;
+    private volatile java.lang.Object message_;
     /** <code>optional string message = 1;</code> */
     public boolean hasMessage() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>optional string message = 1;</code> */
     public java.lang.String getMessage() {
@@ -873,7 +1015,7 @@ public final class PersistenceMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           message_ = s;
@@ -882,23 +1024,21 @@ public final class PersistenceMessages {
       }
     }
     /** <code>optional string message = 1;</code> */
-    public akka.protobuf.ByteString getMessageBytes() {
+    public akka.protobufv3.internal.ByteString getMessageBytes() {
       java.lang.Object ref = message_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         message_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      message_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -908,141 +1048,205 @@ public final class PersistenceMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getMessageBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, message_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getMessageBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, message_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+              .Exception)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages.Exception
+          other =
+              (com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+                      .Exception)
+                  obj;
+
+      if (hasMessage() != other.hasMessage()) return false;
+      if (hasMessage()) {
+        if (!getMessage().equals(other.getMessage())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasMessage()) {
+        hash = (37 * hash) + MESSAGE_FIELD_NUMBER;
+        hash = (53 * hash) + getMessage().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages.Exception
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.javadsl.persistence.Exception} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.javadsl.persistence.Exception)
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .ExceptionOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1058,19 +1262,16 @@ public final class PersistenceMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         message_ = "";
@@ -1078,15 +1279,13 @@ public final class PersistenceMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .Exception
           getDefaultInstanceForType() {
@@ -1094,6 +1293,7 @@ public final class PersistenceMessages {
             .Exception.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .Exception
           build() {
@@ -1105,6 +1305,7 @@ public final class PersistenceMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .Exception
           buildPartial() {
@@ -1114,7 +1315,7 @@ public final class PersistenceMessages {
                     .PersistenceMessages.Exception(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.message_ = message_;
@@ -1123,7 +1324,43 @@ public final class PersistenceMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
@@ -1150,28 +1387,31 @@ public final class PersistenceMessages {
           message_ = other.message_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages.Exception
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
                       .Exception)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1185,13 +1425,13 @@ public final class PersistenceMessages {
       private java.lang.Object message_ = "";
       /** <code>optional string message = 1;</code> */
       public boolean hasMessage() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>optional string message = 1;</code> */
       public java.lang.String getMessage() {
         java.lang.Object ref = message_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             message_ = s;
@@ -1202,15 +1442,15 @@ public final class PersistenceMessages {
         }
       }
       /** <code>optional string message = 1;</code> */
-      public akka.protobuf.ByteString getMessageBytes() {
+      public akka.protobufv3.internal.ByteString getMessageBytes() {
         java.lang.Object ref = message_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           message_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>optional string message = 1;</code> */
@@ -1231,7 +1471,7 @@ public final class PersistenceMessages {
         return this;
       }
       /** <code>optional string message = 1;</code> */
-      public Builder setMessageBytes(akka.protobuf.ByteString value) {
+      public Builder setMessageBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -1241,68 +1481,116 @@ public final class PersistenceMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.javadsl.persistence.Exception)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.javadsl.persistence.Exception)
+    private static final com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg
+            .PersistenceMessages.Exception
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new Exception(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+              .Exception();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.javadsl.persistence.Exception)
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<Exception> PARSER =
+        new akka.protobufv3.internal.AbstractParser<Exception>() {
+          @java.lang.Override
+          public Exception parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new Exception(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<Exception> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<Exception> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface EnsureActiveOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.javadsl.persistence.EnsureActive)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string entityId = 1;</code> */
     boolean hasEntityId();
     /** <code>required string entityId = 1;</code> */
     java.lang.String getEntityId();
     /** <code>required string entityId = 1;</code> */
-    akka.protobuf.ByteString getEntityIdBytes();
+    akka.protobufv3.internal.ByteString getEntityIdBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.javadsl.persistence.EnsureActive} */
-  public static final class EnsureActive extends akka.protobuf.GeneratedMessage
+  public static final class EnsureActive extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.javadsl.persistence.EnsureActive)
       EnsureActiveOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use EnsureActive.newBuilder() to construct.
-    private EnsureActive(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private EnsureActive(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private EnsureActive(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private EnsureActive() {
+      entityId_ = "";
     }
-
-    private static final EnsureActive defaultInstance;
-
-    public static EnsureActive getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public EnsureActive getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new EnsureActive();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private EnsureActive(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -1311,28 +1599,26 @@ public final class PersistenceMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 entityId_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -1340,12 +1626,14 @@ public final class PersistenceMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1355,27 +1643,12 @@ public final class PersistenceMessages {
                   .EnsureActive.Builder.class);
     }
 
-    public static akka.protobuf.Parser<EnsureActive> PARSER =
-        new akka.protobuf.AbstractParser<EnsureActive>() {
-          public EnsureActive parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new EnsureActive(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<EnsureActive> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ENTITYID_FIELD_NUMBER = 1;
-    private java.lang.Object entityId_;
+    private volatile java.lang.Object entityId_;
     /** <code>required string entityId = 1;</code> */
     public boolean hasEntityId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string entityId = 1;</code> */
     public java.lang.String getEntityId() {
@@ -1383,7 +1656,7 @@ public final class PersistenceMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           entityId_ = s;
@@ -1392,23 +1665,21 @@ public final class PersistenceMessages {
       }
     }
     /** <code>required string entityId = 1;</code> */
-    public akka.protobuf.ByteString getEntityIdBytes() {
+    public akka.protobufv3.internal.ByteString getEntityIdBytes() {
       java.lang.Object ref = entityId_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         entityId_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      entityId_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1422,142 +1693,206 @@ public final class PersistenceMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getEntityIdBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, entityId_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getEntityIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, entityId_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+              .EnsureActive)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages.EnsureActive
+          other =
+              (com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+                      .EnsureActive)
+                  obj;
+
+      if (hasEntityId() != other.hasEntityId()) return false;
+      if (hasEntityId()) {
+        if (!getEntityId().equals(other.getEntityId())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEntityId()) {
+        hash = (37 * hash) + ENTITYID_FIELD_NUMBER;
+        hash = (53 * hash) + getEntityId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
                 .EnsureActive
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.javadsl.persistence.EnsureActive} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.javadsl.persistence.EnsureActive)
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActiveOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1573,19 +1908,16 @@ public final class PersistenceMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         entityId_ = "";
@@ -1593,15 +1925,13 @@ public final class PersistenceMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .EnsureActive
           getDefaultInstanceForType() {
@@ -1609,6 +1939,7 @@ public final class PersistenceMessages {
             .EnsureActive.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .EnsureActive
           build() {
@@ -1621,6 +1952,7 @@ public final class PersistenceMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
               .EnsureActive
           buildPartial() {
@@ -1631,7 +1963,7 @@ public final class PersistenceMessages {
                     .PersistenceMessages.EnsureActive(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.entityId_ = entityId_;
@@ -1640,7 +1972,43 @@ public final class PersistenceMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
@@ -1667,33 +2035,35 @@ public final class PersistenceMessages {
           entityId_ = other.entityId_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasEntityId()) {
-
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
                 .EnsureActive
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
                       .EnsureActive)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1707,13 +2077,13 @@ public final class PersistenceMessages {
       private java.lang.Object entityId_ = "";
       /** <code>required string entityId = 1;</code> */
       public boolean hasEntityId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string entityId = 1;</code> */
       public java.lang.String getEntityId() {
         java.lang.Object ref = entityId_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             entityId_ = s;
@@ -1724,15 +2094,15 @@ public final class PersistenceMessages {
         }
       }
       /** <code>required string entityId = 1;</code> */
-      public akka.protobuf.ByteString getEntityIdBytes() {
+      public akka.protobufv3.internal.ByteString getEntityIdBytes() {
         java.lang.Object ref = entityId_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           entityId_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string entityId = 1;</code> */
@@ -1753,7 +2123,7 @@ public final class PersistenceMessages {
         return this;
       }
       /** <code>required string entityId = 1;</code> */
-      public Builder setEntityIdBytes(akka.protobuf.ByteString value) {
+      public Builder setEntityIdBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -1763,35 +2133,85 @@ public final class PersistenceMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.javadsl.persistence.EnsureActive)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.javadsl.persistence.EnsureActive)
+    private static final com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg
+            .PersistenceMessages.EnsureActive
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new EnsureActive(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+              .EnsureActive();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.javadsl.persistence.EnsureActive)
+    public static com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<EnsureActive> PARSER =
+        new akka.protobufv3.internal.AbstractParser<EnsureActive>() {
+          @java.lang.Override
+          public EnsureActive parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new EnsureActive(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<EnsureActive> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<EnsureActive> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.javadsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_fieldAccessorTable;
 
-  public static akka.protobuf.Descriptors.FileDescriptor getDescriptor() {
+  public static akka.protobufv3.internal.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
 
-  private static akka.protobuf.Descriptors.FileDescriptor descriptor;
+  private static akka.protobufv3.internal.Descriptors.FileDescriptor descriptor;
 
   static {
     java.lang.String[] descriptorData = {
@@ -1804,20 +2224,13 @@ public final class PersistenceMessages {
           + "tyId\030\001 \002(\tBA\n=com.lightbend.lagom.intern"
           + "al.javadsl.persistence.protobuf.msgH\001"
     };
-    akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-          public akka.protobuf.ExtensionRegistry assignDescriptors(
-              akka.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    akka.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
-        descriptorData, new akka.protobuf.Descriptors.FileDescriptor[] {}, assigner);
+    descriptor =
+        akka.protobufv3.internal.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData, new akka.protobufv3.internal.Descriptors.FileDescriptor[] {});
     internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_descriptor =
         getDescriptor().getMessageTypes().get(0);
     internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_javadsl_persistence_CommandEnvelope_descriptor,
             new java.lang.String[] {
               "EntityId", "EnclosedMessage", "SerializerId", "MessageManifest",
@@ -1825,7 +2238,7 @@ public final class PersistenceMessages {
     internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_descriptor =
         getDescriptor().getMessageTypes().get(1);
     internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_javadsl_persistence_Exception_descriptor,
             new java.lang.String[] {
               "Message",
@@ -1833,7 +2246,7 @@ public final class PersistenceMessages {
     internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_descriptor =
         getDescriptor().getMessageTypes().get(2);
     internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_javadsl_persistence_EnsureActive_descriptor,
             new java.lang.String[] {
               "EntityId",

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/protobuf/PersistenceMessageSerializer.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/protobuf/PersistenceMessageSerializer.scala
@@ -5,7 +5,7 @@
 package com.lightbend.lagom.internal.javadsl.persistence.protobuf
 
 import akka.actor.ExtendedActorSystem
-import akka.protobuf.ByteString
+import akka.protobufv3.internal.ByteString
 import akka.serialization.BaseSerializer
 import akka.serialization.Serialization
 import akka.serialization.SerializationExtension

--- a/persistence/scaladsl/src/main/java/com/lightbend/lagom/internal/scaladsl/persistence/protobuf/msg/PersistenceMessages.java
+++ b/persistence/scaladsl/src/main/java/com/lightbend/lagom/internal/scaladsl/persistence/protobuf/msg/PersistenceMessages.java
@@ -10,24 +10,29 @@ package com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg;
 public final class PersistenceMessages {
   private PersistenceMessages() {}
 
-  public static void registerAllExtensions(akka.protobuf.ExtensionRegistry registry) {}
+  public static void registerAllExtensions(
+      akka.protobufv3.internal.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(akka.protobufv3.internal.ExtensionRegistry registry) {
+    registerAllExtensions((akka.protobufv3.internal.ExtensionRegistryLite) registry);
+  }
 
   public interface CommandEnvelopeOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string entityId = 1;</code> */
     boolean hasEntityId();
     /** <code>required string entityId = 1;</code> */
     java.lang.String getEntityId();
     /** <code>required string entityId = 1;</code> */
-    akka.protobuf.ByteString getEntityIdBytes();
+    akka.protobufv3.internal.ByteString getEntityIdBytes();
 
     /** <code>required bytes enclosedMessage = 2;</code> */
     boolean hasEnclosedMessage();
     /** <code>required bytes enclosedMessage = 2;</code> */
-    akka.protobuf.ByteString getEnclosedMessage();
+    akka.protobufv3.internal.ByteString getEnclosedMessage();
 
     /** <code>required int32 serializerId = 3;</code> */
     boolean hasSerializerId();
@@ -37,47 +42,47 @@ public final class PersistenceMessages {
     /** <code>optional bytes messageManifest = 4;</code> */
     boolean hasMessageManifest();
     /** <code>optional bytes messageManifest = 4;</code> */
-    akka.protobuf.ByteString getMessageManifest();
+    akka.protobufv3.internal.ByteString getMessageManifest();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope} */
-  public static final class CommandEnvelope extends akka.protobuf.GeneratedMessage
+  public static final class CommandEnvelope extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope)
       CommandEnvelopeOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use CommandEnvelope.newBuilder() to construct.
-    private CommandEnvelope(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private CommandEnvelope(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private CommandEnvelope(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private CommandEnvelope() {
+      entityId_ = "";
+      enclosedMessage_ = akka.protobufv3.internal.ByteString.EMPTY;
+      messageManifest_ = akka.protobufv3.internal.ByteString.EMPTY;
     }
-
-    private static final CommandEnvelope defaultInstance;
-
-    public static CommandEnvelope getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public CommandEnvelope getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new CommandEnvelope();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private CommandEnvelope(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -86,18 +91,9 @@ public final class PersistenceMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 entityId_ = bs;
                 break;
@@ -120,12 +116,19 @@ public final class PersistenceMessages {
                 messageManifest_ = input.readBytes();
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -133,12 +136,14 @@ public final class PersistenceMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -148,27 +153,12 @@ public final class PersistenceMessages {
                   .CommandEnvelope.Builder.class);
     }
 
-    public static akka.protobuf.Parser<CommandEnvelope> PARSER =
-        new akka.protobuf.AbstractParser<CommandEnvelope>() {
-          public CommandEnvelope parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new CommandEnvelope(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<CommandEnvelope> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ENTITYID_FIELD_NUMBER = 1;
-    private java.lang.Object entityId_;
+    private volatile java.lang.Object entityId_;
     /** <code>required string entityId = 1;</code> */
     public boolean hasEntityId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string entityId = 1;</code> */
     public java.lang.String getEntityId() {
@@ -176,7 +166,7 @@ public final class PersistenceMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           entityId_ = s;
@@ -185,25 +175,26 @@ public final class PersistenceMessages {
       }
     }
     /** <code>required string entityId = 1;</code> */
-    public akka.protobuf.ByteString getEntityIdBytes() {
+    public akka.protobufv3.internal.ByteString getEntityIdBytes() {
       java.lang.Object ref = entityId_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         entityId_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
     }
 
     public static final int ENCLOSEDMESSAGE_FIELD_NUMBER = 2;
-    private akka.protobuf.ByteString enclosedMessage_;
+    private akka.protobufv3.internal.ByteString enclosedMessage_;
     /** <code>required bytes enclosedMessage = 2;</code> */
     public boolean hasEnclosedMessage() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /** <code>required bytes enclosedMessage = 2;</code> */
-    public akka.protobuf.ByteString getEnclosedMessage() {
+    public akka.protobufv3.internal.ByteString getEnclosedMessage() {
       return enclosedMessage_;
     }
 
@@ -211,7 +202,7 @@ public final class PersistenceMessages {
     private int serializerId_;
     /** <code>required int32 serializerId = 3;</code> */
     public boolean hasSerializerId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /** <code>required int32 serializerId = 3;</code> */
     public int getSerializerId() {
@@ -219,25 +210,19 @@ public final class PersistenceMessages {
     }
 
     public static final int MESSAGEMANIFEST_FIELD_NUMBER = 4;
-    private akka.protobuf.ByteString messageManifest_;
+    private akka.protobufv3.internal.ByteString messageManifest_;
     /** <code>optional bytes messageManifest = 4;</code> */
     public boolean hasMessageManifest() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /** <code>optional bytes messageManifest = 4;</code> */
-    public akka.protobuf.ByteString getMessageManifest() {
+    public akka.protobufv3.internal.ByteString getMessageManifest() {
       return messageManifest_;
-    }
-
-    private void initFields() {
-      entityId_ = "";
-      enclosedMessage_ = akka.protobuf.ByteString.EMPTY;
-      serializerId_ = 0;
-      messageManifest_ = akka.protobuf.ByteString.EMPTY;
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -259,160 +244,249 @@ public final class PersistenceMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getEntityIdBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, entityId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000002) != 0)) {
         output.writeBytes(2, enclosedMessage_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000004) != 0)) {
         output.writeInt32(3, serializerId_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000008) != 0)) {
         output.writeBytes(4, messageManifest_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getEntityIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, entityId_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(2, enclosedMessage_);
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream.computeBytesSize(2, enclosedMessage_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += akka.protobuf.CodedOutputStream.computeInt32Size(3, serializerId_);
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream.computeInt32Size(3, serializerId_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(4, messageManifest_);
+      if (((bitField0_ & 0x00000008) != 0)) {
+        size += akka.protobufv3.internal.CodedOutputStream.computeBytesSize(4, messageManifest_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .CommandEnvelope)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .CommandEnvelope
+          other =
+              (com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+                      .CommandEnvelope)
+                  obj;
+
+      if (hasEntityId() != other.hasEntityId()) return false;
+      if (hasEntityId()) {
+        if (!getEntityId().equals(other.getEntityId())) return false;
+      }
+      if (hasEnclosedMessage() != other.hasEnclosedMessage()) return false;
+      if (hasEnclosedMessage()) {
+        if (!getEnclosedMessage().equals(other.getEnclosedMessage())) return false;
+      }
+      if (hasSerializerId() != other.hasSerializerId()) return false;
+      if (hasSerializerId()) {
+        if (getSerializerId() != other.getSerializerId()) return false;
+      }
+      if (hasMessageManifest() != other.hasMessageManifest()) return false;
+      if (hasMessageManifest()) {
+        if (!getMessageManifest().equals(other.getMessageManifest())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEntityId()) {
+        hash = (37 * hash) + ENTITYID_FIELD_NUMBER;
+        hash = (53 * hash) + getEntityId().hashCode();
+      }
+      if (hasEnclosedMessage()) {
+        hash = (37 * hash) + ENCLOSEDMESSAGE_FIELD_NUMBER;
+        hash = (53 * hash) + getEnclosedMessage().hashCode();
+      }
+      if (hasSerializerId()) {
+        hash = (37 * hash) + SERIALIZERID_FIELD_NUMBER;
+        hash = (53 * hash) + getSerializerId();
+      }
+      if (hasMessageManifest()) {
+        hash = (37 * hash) + MESSAGEMANIFEST_FIELD_NUMBER;
+        hash = (53 * hash) + getMessageManifest().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .CommandEnvelope
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelope
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
                 .CommandEnvelope
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope)
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .CommandEnvelopeOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -428,41 +502,36 @@ public final class PersistenceMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         entityId_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        enclosedMessage_ = akka.protobuf.ByteString.EMPTY;
+        enclosedMessage_ = akka.protobufv3.internal.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000002);
         serializerId_ = 0;
         bitField0_ = (bitField0_ & ~0x00000004);
-        messageManifest_ = akka.protobuf.ByteString.EMPTY;
+        messageManifest_ = akka.protobufv3.internal.ByteString.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .CommandEnvelope
           getDefaultInstanceForType() {
@@ -470,6 +539,7 @@ public final class PersistenceMessages {
             .CommandEnvelope.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .CommandEnvelope
           build() {
@@ -482,6 +552,7 @@ public final class PersistenceMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .CommandEnvelope
           buildPartial() {
@@ -492,19 +563,19 @@ public final class PersistenceMessages {
                     .PersistenceMessages.CommandEnvelope(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.entityId_ = entityId_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.enclosedMessage_ = enclosedMessage_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.serializerId_ = serializerId_;
           to_bitField0_ |= 0x00000004;
         }
-        result.serializerId_ = serializerId_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.messageManifest_ = messageManifest_;
@@ -513,7 +584,43 @@ public final class PersistenceMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
@@ -549,41 +656,41 @@ public final class PersistenceMessages {
         if (other.hasMessageManifest()) {
           setMessageManifest(other.getMessageManifest());
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasEntityId()) {
-
           return false;
         }
         if (!hasEnclosedMessage()) {
-
           return false;
         }
         if (!hasSerializerId()) {
-
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
                 .CommandEnvelope
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
                       .CommandEnvelope)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -597,13 +704,13 @@ public final class PersistenceMessages {
       private java.lang.Object entityId_ = "";
       /** <code>required string entityId = 1;</code> */
       public boolean hasEntityId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string entityId = 1;</code> */
       public java.lang.String getEntityId() {
         java.lang.Object ref = entityId_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             entityId_ = s;
@@ -614,15 +721,15 @@ public final class PersistenceMessages {
         }
       }
       /** <code>required string entityId = 1;</code> */
-      public akka.protobuf.ByteString getEntityIdBytes() {
+      public akka.protobufv3.internal.ByteString getEntityIdBytes() {
         java.lang.Object ref = entityId_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           entityId_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string entityId = 1;</code> */
@@ -643,7 +750,7 @@ public final class PersistenceMessages {
         return this;
       }
       /** <code>required string entityId = 1;</code> */
-      public Builder setEntityIdBytes(akka.protobuf.ByteString value) {
+      public Builder setEntityIdBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -653,17 +760,18 @@ public final class PersistenceMessages {
         return this;
       }
 
-      private akka.protobuf.ByteString enclosedMessage_ = akka.protobuf.ByteString.EMPTY;
+      private akka.protobufv3.internal.ByteString enclosedMessage_ =
+          akka.protobufv3.internal.ByteString.EMPTY;
       /** <code>required bytes enclosedMessage = 2;</code> */
       public boolean hasEnclosedMessage() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /** <code>required bytes enclosedMessage = 2;</code> */
-      public akka.protobuf.ByteString getEnclosedMessage() {
+      public akka.protobufv3.internal.ByteString getEnclosedMessage() {
         return enclosedMessage_;
       }
       /** <code>required bytes enclosedMessage = 2;</code> */
-      public Builder setEnclosedMessage(akka.protobuf.ByteString value) {
+      public Builder setEnclosedMessage(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -683,7 +791,7 @@ public final class PersistenceMessages {
       private int serializerId_;
       /** <code>required int32 serializerId = 3;</code> */
       public boolean hasSerializerId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /** <code>required int32 serializerId = 3;</code> */
       public int getSerializerId() {
@@ -704,17 +812,18 @@ public final class PersistenceMessages {
         return this;
       }
 
-      private akka.protobuf.ByteString messageManifest_ = akka.protobuf.ByteString.EMPTY;
+      private akka.protobufv3.internal.ByteString messageManifest_ =
+          akka.protobufv3.internal.ByteString.EMPTY;
       /** <code>optional bytes messageManifest = 4;</code> */
       public boolean hasMessageManifest() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /** <code>optional bytes messageManifest = 4;</code> */
-      public akka.protobuf.ByteString getMessageManifest() {
+      public akka.protobufv3.internal.ByteString getMessageManifest() {
         return messageManifest_;
       }
       /** <code>optional bytes messageManifest = 4;</code> */
-      public Builder setMessageManifest(akka.protobuf.ByteString value) {
+      public Builder setMessageManifest(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -731,68 +840,116 @@ public final class PersistenceMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope)
+    private static final com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg
+            .PersistenceMessages.CommandEnvelope
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new CommandEnvelope(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .CommandEnvelope();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.scaladsl.persistence.CommandEnvelope)
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<CommandEnvelope> PARSER =
+        new akka.protobufv3.internal.AbstractParser<CommandEnvelope>() {
+          @java.lang.Override
+          public CommandEnvelope parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new CommandEnvelope(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<CommandEnvelope> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<CommandEnvelope> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .CommandEnvelope
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface ExceptionOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.scaladsl.persistence.Exception)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>optional string message = 1;</code> */
     boolean hasMessage();
     /** <code>optional string message = 1;</code> */
     java.lang.String getMessage();
     /** <code>optional string message = 1;</code> */
-    akka.protobuf.ByteString getMessageBytes();
+    akka.protobufv3.internal.ByteString getMessageBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.scaladsl.persistence.Exception} */
-  public static final class Exception extends akka.protobuf.GeneratedMessage
+  public static final class Exception extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.scaladsl.persistence.Exception)
       ExceptionOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use Exception.newBuilder() to construct.
-    private Exception(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Exception(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private Exception(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private Exception() {
+      message_ = "";
     }
-
-    private static final Exception defaultInstance;
-
-    public static Exception getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Exception getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new Exception();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private Exception(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -801,28 +958,26 @@ public final class PersistenceMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 message_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -830,12 +985,14 @@ public final class PersistenceMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -845,27 +1002,12 @@ public final class PersistenceMessages {
                   .Exception.Builder.class);
     }
 
-    public static akka.protobuf.Parser<Exception> PARSER =
-        new akka.protobuf.AbstractParser<Exception>() {
-          public Exception parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new Exception(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<Exception> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int MESSAGE_FIELD_NUMBER = 1;
-    private java.lang.Object message_;
+    private volatile java.lang.Object message_;
     /** <code>optional string message = 1;</code> */
     public boolean hasMessage() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>optional string message = 1;</code> */
     public java.lang.String getMessage() {
@@ -873,7 +1015,7 @@ public final class PersistenceMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           message_ = s;
@@ -882,23 +1024,21 @@ public final class PersistenceMessages {
       }
     }
     /** <code>optional string message = 1;</code> */
-    public akka.protobuf.ByteString getMessageBytes() {
+    public akka.protobufv3.internal.ByteString getMessageBytes() {
       java.lang.Object ref = message_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         message_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      message_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -908,141 +1048,205 @@ public final class PersistenceMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getMessageBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, message_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getMessageBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, message_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .Exception)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages.Exception
+          other =
+              (com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+                      .Exception)
+                  obj;
+
+      if (hasMessage() != other.hasMessage()) return false;
+      if (hasMessage()) {
+        if (!getMessage().equals(other.getMessage())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasMessage()) {
+        hash = (37 * hash) + MESSAGE_FIELD_NUMBER;
+        hash = (53 * hash) + getMessage().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .Exception
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .Exception
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages.Exception
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.scaladsl.persistence.Exception} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.scaladsl.persistence.Exception)
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .ExceptionOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1058,19 +1262,16 @@ public final class PersistenceMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         message_ = "";
@@ -1078,15 +1279,13 @@ public final class PersistenceMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .Exception
           getDefaultInstanceForType() {
@@ -1094,6 +1293,7 @@ public final class PersistenceMessages {
             .Exception.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .Exception
           build() {
@@ -1105,6 +1305,7 @@ public final class PersistenceMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .Exception
           buildPartial() {
@@ -1114,7 +1315,7 @@ public final class PersistenceMessages {
                     .PersistenceMessages.Exception(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.message_ = message_;
@@ -1123,7 +1324,43 @@ public final class PersistenceMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
@@ -1150,28 +1387,31 @@ public final class PersistenceMessages {
           message_ = other.message_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages.Exception
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
                       .Exception)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1185,13 +1425,13 @@ public final class PersistenceMessages {
       private java.lang.Object message_ = "";
       /** <code>optional string message = 1;</code> */
       public boolean hasMessage() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>optional string message = 1;</code> */
       public java.lang.String getMessage() {
         java.lang.Object ref = message_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             message_ = s;
@@ -1202,15 +1442,15 @@ public final class PersistenceMessages {
         }
       }
       /** <code>optional string message = 1;</code> */
-      public akka.protobuf.ByteString getMessageBytes() {
+      public akka.protobufv3.internal.ByteString getMessageBytes() {
         java.lang.Object ref = message_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           message_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>optional string message = 1;</code> */
@@ -1231,7 +1471,7 @@ public final class PersistenceMessages {
         return this;
       }
       /** <code>optional string message = 1;</code> */
-      public Builder setMessageBytes(akka.protobuf.ByteString value) {
+      public Builder setMessageBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -1241,68 +1481,116 @@ public final class PersistenceMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.scaladsl.persistence.Exception)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.scaladsl.persistence.Exception)
+    private static final com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg
+            .PersistenceMessages.Exception
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new Exception(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .Exception();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.scaladsl.persistence.Exception)
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<Exception> PARSER =
+        new akka.protobufv3.internal.AbstractParser<Exception>() {
+          @java.lang.Override
+          public Exception parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new Exception(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<Exception> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<Exception> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .Exception
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface EnsureActiveOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string entityId = 1;</code> */
     boolean hasEntityId();
     /** <code>required string entityId = 1;</code> */
     java.lang.String getEntityId();
     /** <code>required string entityId = 1;</code> */
-    akka.protobuf.ByteString getEntityIdBytes();
+    akka.protobufv3.internal.ByteString getEntityIdBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive} */
-  public static final class EnsureActive extends akka.protobuf.GeneratedMessage
+  public static final class EnsureActive extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive)
       EnsureActiveOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use EnsureActive.newBuilder() to construct.
-    private EnsureActive(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private EnsureActive(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private EnsureActive(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private EnsureActive() {
+      entityId_ = "";
     }
-
-    private static final EnsureActive defaultInstance;
-
-    public static EnsureActive getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public EnsureActive getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new EnsureActive();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private EnsureActive(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -1311,28 +1599,26 @@ public final class PersistenceMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 entityId_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -1340,12 +1626,14 @@ public final class PersistenceMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
           .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1355,27 +1643,12 @@ public final class PersistenceMessages {
                   .EnsureActive.Builder.class);
     }
 
-    public static akka.protobuf.Parser<EnsureActive> PARSER =
-        new akka.protobuf.AbstractParser<EnsureActive>() {
-          public EnsureActive parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new EnsureActive(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<EnsureActive> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int ENTITYID_FIELD_NUMBER = 1;
-    private java.lang.Object entityId_;
+    private volatile java.lang.Object entityId_;
     /** <code>required string entityId = 1;</code> */
     public boolean hasEntityId() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string entityId = 1;</code> */
     public java.lang.String getEntityId() {
@@ -1383,7 +1656,7 @@ public final class PersistenceMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           entityId_ = s;
@@ -1392,23 +1665,21 @@ public final class PersistenceMessages {
       }
     }
     /** <code>required string entityId = 1;</code> */
-    public akka.protobuf.ByteString getEntityIdBytes() {
+    public akka.protobufv3.internal.ByteString getEntityIdBytes() {
       java.lang.Object ref = entityId_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         entityId_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      entityId_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1422,142 +1693,207 @@ public final class PersistenceMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getEntityIdBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, entityId_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getEntityIdBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, entityId_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .EnsureActive)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .EnsureActive
+          other =
+              (com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+                      .EnsureActive)
+                  obj;
+
+      if (hasEntityId() != other.hasEntityId()) return false;
+      if (hasEntityId()) {
+        if (!getEntityId().equals(other.getEntityId())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEntityId()) {
+        hash = (37 * hash) + ENTITYID_FIELD_NUMBER;
+        hash = (53 * hash) + getEntityId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
-            .EnsureActive
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActive
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
                 .EnsureActive
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive)
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .EnsureActiveOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1573,19 +1909,16 @@ public final class PersistenceMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         entityId_ = "";
@@ -1593,15 +1926,13 @@ public final class PersistenceMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
             .internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .EnsureActive
           getDefaultInstanceForType() {
@@ -1609,6 +1940,7 @@ public final class PersistenceMessages {
             .EnsureActive.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .EnsureActive
           build() {
@@ -1621,6 +1953,7 @@ public final class PersistenceMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
               .EnsureActive
           buildPartial() {
@@ -1631,7 +1964,7 @@ public final class PersistenceMessages {
                     .PersistenceMessages.EnsureActive(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.entityId_ = entityId_;
@@ -1640,7 +1973,43 @@ public final class PersistenceMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
@@ -1667,33 +2036,35 @@ public final class PersistenceMessages {
           entityId_ = other.entityId_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasEntityId()) {
-
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
                 .EnsureActive
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
                       .EnsureActive)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1707,13 +2078,13 @@ public final class PersistenceMessages {
       private java.lang.Object entityId_ = "";
       /** <code>required string entityId = 1;</code> */
       public boolean hasEntityId() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string entityId = 1;</code> */
       public java.lang.String getEntityId() {
         java.lang.Object ref = entityId_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             entityId_ = s;
@@ -1724,15 +2095,15 @@ public final class PersistenceMessages {
         }
       }
       /** <code>required string entityId = 1;</code> */
-      public akka.protobuf.ByteString getEntityIdBytes() {
+      public akka.protobufv3.internal.ByteString getEntityIdBytes() {
         java.lang.Object ref = entityId_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           entityId_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string entityId = 1;</code> */
@@ -1753,7 +2124,7 @@ public final class PersistenceMessages {
         return this;
       }
       /** <code>required string entityId = 1;</code> */
-      public Builder setEntityIdBytes(akka.protobuf.ByteString value) {
+      public Builder setEntityIdBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -1763,35 +2134,85 @@ public final class PersistenceMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive)
+    private static final com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg
+            .PersistenceMessages.EnsureActive
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new EnsureActive(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+              .EnsureActive();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.scaladsl.persistence.EnsureActive)
+    public static com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<EnsureActive> PARSER =
+        new akka.protobufv3.internal.AbstractParser<EnsureActive>() {
+          @java.lang.Override
+          public EnsureActive parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new EnsureActive(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<EnsureActive> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<EnsureActive> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.scaladsl.persistence.protobuf.msg.PersistenceMessages
+            .EnsureActive
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_fieldAccessorTable;
 
-  public static akka.protobuf.Descriptors.FileDescriptor getDescriptor() {
+  public static akka.protobufv3.internal.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
 
-  private static akka.protobuf.Descriptors.FileDescriptor descriptor;
+  private static akka.protobufv3.internal.Descriptors.FileDescriptor descriptor;
 
   static {
     java.lang.String[] descriptorData = {
@@ -1804,20 +2225,13 @@ public final class PersistenceMessages {
           + "ityId\030\001 \002(\tBB\n>com.lightbend.lagom.inter"
           + "nal.scaladsl.persistence.protobuf.msgH\001"
     };
-    akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-          public akka.protobuf.ExtensionRegistry assignDescriptors(
-              akka.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    akka.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
-        descriptorData, new akka.protobuf.Descriptors.FileDescriptor[] {}, assigner);
+    descriptor =
+        akka.protobufv3.internal.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData, new akka.protobufv3.internal.Descriptors.FileDescriptor[] {});
     internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_descriptor =
         getDescriptor().getMessageTypes().get(0);
     internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_scaladsl_persistence_CommandEnvelope_descriptor,
             new java.lang.String[] {
               "EntityId", "EnclosedMessage", "SerializerId", "MessageManifest",
@@ -1825,7 +2239,7 @@ public final class PersistenceMessages {
     internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_descriptor =
         getDescriptor().getMessageTypes().get(1);
     internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_scaladsl_persistence_Exception_descriptor,
             new java.lang.String[] {
               "Message",
@@ -1833,7 +2247,7 @@ public final class PersistenceMessages {
     internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_descriptor =
         getDescriptor().getMessageTypes().get(2);
     internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_scaladsl_persistence_EnsureActive_descriptor,
             new java.lang.String[] {
               "EntityId",

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/protobuf/PersistenceMessageSerializer.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/protobuf/PersistenceMessageSerializer.scala
@@ -5,7 +5,7 @@
 package com.lightbend.lagom.internal.scaladsl.persistence.protobuf
 
 import akka.actor.ExtendedActorSystem
-import akka.protobuf.ByteString
+import akka.protobufv3.internal.ByteString
 import akka.serialization.BaseSerializer
 import akka.serialization.Serialization
 import akka.serialization.SerializationExtension

--- a/project/AkkaSnapshotRepositories.scala
+++ b/project/AkkaSnapshotRepositories.scala
@@ -15,8 +15,13 @@ object AkkaSnapshotRepositories extends AutoPlugin {
     // If this is a cron job in Travis:
     // https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
     resolvers ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
-      case Some(_) => Seq("akka-snapshot-repository".at("https://repo.akka.io/snapshots"))
-      case None    => Seq.empty
+      case Some(_) =>
+        Seq(
+          "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),
+          "akka-http-snapshot-repository".at("https://dl.bintray.com/akka/snapshots/")
+        )
+      case None => Seq.empty
     })
+
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -724,6 +724,7 @@ object Dependencies {
     akkaClusterTyped,
     akkaManagementClusterBootstrap,
     akkaManagementClusterHttp,
+    akkaProtobuf_v3,
     akkaTestkit          % Test,
     akkaMultiNodeTestkit % Test,
     scalaTest            % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,7 @@ object Dependencies {
     val Logback = "1.2.3"
     val Log4j   = "2.12.1"
 
-    val jetty = "9.4.16.v20190411"
+    val jetty = "9.4.20.v20190813"
 
     val Selenium = "3.141.59"
   }
@@ -89,7 +89,7 @@ object Dependencies {
   private val javassist              = "org.javassist" % "javassist" % "3.24.0-GA"
   private val byteBuddy              = "net.bytebuddy" % "byte-buddy" % "1.10.1"
   private val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
-  private val typesafeConfig         = "com.typesafe" % "config" % "1.3.4"
+  private val typesafeConfig         = "com.typesafe" % "config" % "1.3.5-RC1"
   private val sslConfig              = "com.typesafe" %% "ssl-config-core" % "0.4.0"
   private val h2                     = "com.h2database" % "h2" % "1.4.192"
   private val cassandraDriverCore =
@@ -109,6 +109,7 @@ object Dependencies {
   private val akkaSlf4j            = ("com.typesafe.akka" %% "akka-slf4j" % Versions.Akka).excludeAll(excludeSlf4j: _*)
   private val akkaStream           = "com.typesafe.akka" %% "akka-stream" % Versions.Akka
   private val akkaProtobuf         = "com.typesafe.akka" %% "akka-protobuf" % Versions.Akka
+  private val akkaProtobuf_v3      = "com.typesafe.akka" %% "akka-protobuf-v3" % Versions.Akka
 
   private val akkaManagement                 = "com.lightbend.akka.management" %% "akka-management"                   % Versions.AkkaManagement
   private val akkaManagementClusterHttp      = "com.lightbend.akka.management" %% "akka-management-cluster-http"      % Versions.AkkaManagement
@@ -167,8 +168,8 @@ object Dependencies {
   private val okhttp3 = "com.squareup.okhttp3" % "okhttp" % "3.11.0"
   private val okio    = "com.squareup.okio"    % "okio"   % "2.4.0"
   private val kotlinDeps = Seq(
-    "org.jetbrains.kotlin" % "kotlin-stdlib"        % "1.2.60",
-    "org.jetbrains.kotlin" % "kotlin-stdlib-common" % "1.2.60",
+    "org.jetbrains.kotlin" % "kotlin-stdlib"        % "1.3.50",
+    "org.jetbrains.kotlin" % "kotlin-stdlib-common" % "1.3.50",
     "org.jetbrains"        % "annotations"          % "13.0"
   )
 
@@ -286,19 +287,20 @@ object Dependencies {
       okhttp3,
       okio,
       "org.atteo.classindex"        % "classindex"         % "3.4",
-      "org.seleniumhq.selenium"     % "htmlunit-driver"    % "2.35.1",
+      "org.seleniumhq.selenium"     % "htmlunit-driver"    % "2.36.0",
       "xalan"                       % "xalan"              % "2.7.2",
       "xalan"                       % "serializer"         % "2.7.2",
-      "org.apache.commons"          % "commons-text"       % "1.6",
-      "org.apache.httpcomponents"   % "httpmime"           % "4.5.8",
-      "org.apache.httpcomponents"   % "httpclient"         % "4.5.8",
+      "org.apache.commons"          % "commons-text"       % "1.7",
+      "org.apache.httpcomponents"   % "httpmime"           % "4.5.9",
+      "org.apache.httpcomponents"   % "httpclient"         % "4.5.9",
       "org.apache.httpcomponents"   % "httpcore"           % "4.4.11",
-      "net.sourceforge.htmlunit"    % "htmlunit"           % "2.35.0",
-      "net.sourceforge.htmlunit"    % "htmlunit-core-js"   % "2.35.0",
-      "net.sourceforge.htmlunit"    % "neko-htmlunit"      % "2.35.0",
+      "net.sourceforge.htmlunit"    % "htmlunit"           % "2.36.0",
+      "net.sourceforge.htmlunit"    % "htmlunit-core-js"   % "2.36.0",
+      "net.sourceforge.htmlunit"    % "neko-htmlunit"      % "2.36.0",
+      "org.brotli"                  % "dec"                % "0.1.2",
       "xerces"                      % "xercesImpl"         % "2.12.0",
       "xml-apis"                    % "xml-apis"           % "1.4.01",
-      "net.sourceforge.htmlunit"    % "htmlunit-cssparser" % "1.4.0",
+      "net.sourceforge.htmlunit"    % "htmlunit-cssparser" % "1.5.0",
       "commons-io"                  % "commons-io"         % "2.6",
       "commons-net"                 % "commons-net"        % "3.6",
       "org.eclipse.jetty.websocket" % "websocket-client"   % Versions.jetty,
@@ -322,7 +324,7 @@ object Dependencies {
       "javax.cache"         % "cache-api"               % "1.1.1",
       "javax.inject"        % "javax.inject"            % "1",
       "javax.transaction"   % "jta"                     % "1.1",
-      "jakarta.transaction" % "jakarta.transaction-api" % "1.3.2",
+      "jakarta.transaction" % "jakarta.transaction-api" % "1.3.3",
       "joda-time"           % "joda-time"               % "2.10.3",
       "junit"               % "junit"                   % Versions.JUnit,
       "net.jodah"           % "typetools"               % "0.5.0",
@@ -331,7 +333,7 @@ object Dependencies {
       "org.agrona"          % "agrona"                  % "1.0.1",
       commonsLang,
       kafkaClients,
-      "org.codehaus.mojo"               % "animal-sniffer-annotations" % "1.17",
+      "org.codehaus.mojo"               % "animal-sniffer-annotations" % "1.18",
       "org.hibernate"                   % "hibernate-validator"        % "5.2.4.Final",
       "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api"      % "1.0.2.Final",
       "org.immutables"                  % "value"                      % Versions.Immutables,
@@ -355,6 +357,7 @@ object Dependencies {
       scalaCollectionCompat,
       "com.google.guava"             % "failureaccess"          % "1.0.1",
       "com.google.guava"             % "listenablefuture"       % "9999.0-empty-to-avoid-conflict-with-guava",
+      "com.google.protobuf"          % "protobuf-java"          % "3.9.0",
       "javax.activation"             % "activation"             % "1.1",
       "javax.activation"             % "javax.activation-api"   % "1.2.0",
       "jakarta.activation"           % "jakarta.activation-api" % "1.2.1",
@@ -372,6 +375,7 @@ object Dependencies {
       "akka-persistence",
       "akka-persistence-query",
       "akka-protobuf",
+      "akka-protobuf-v3",
       "akka-remote",
       "akka-slf4j",
       "akka-stream",
@@ -527,7 +531,8 @@ object Dependencies {
     akkaTestkit    % Test,
     scalaTest      % Test,
     junit          % Test,
-    "com.novocode" % "junit-interface" % "0.11" % Test
+    slf4jApi       % Test,
+    "com.novocode" % "junit-interface" % "0.11" % Test,
   )
 
   val `play-json` = libraryDependencies ++= Seq(
@@ -560,6 +565,7 @@ object Dependencies {
     akkaActor,
     akkaSlf4j,
     akkaProtobuf,
+    akkaProtobuf_v3,
     guava,
     jnrFfi,
     jffi,
@@ -651,6 +657,7 @@ object Dependencies {
     playAkkaHttpServer,
     playTest       % Test,
     junit          % Test,
+    slf4jApi       % Test,
     "com.novocode" % "junit-interface" % "0.11" % Test,
     scalaTest,
     // Upgrades needed to match whitelist versions
@@ -665,6 +672,7 @@ object Dependencies {
     playAkkaHttpServer,
     playTest       % Test,
     junit          % Test,
+    slf4jApi       % Test,
     "com.novocode" % "junit-interface" % "0.11" % Test,
     scalaTest,
     okio        % Test,
@@ -694,6 +702,7 @@ object Dependencies {
     akkaStream,
     akkaActor,
     akkaProtobuf,
+    akkaProtobuf_v3,
     akkaSlf4j,
     scalaXml,
     akkaHttpCore,
@@ -719,6 +728,7 @@ object Dependencies {
     akkaMultiNodeTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
+    slf4jApi             % Test,
     "com.novocode"       % "junit-interface" % "0.11" % Test,
     // Upgrades needed to match whitelist versions
     sslConfig,
@@ -772,6 +782,7 @@ object Dependencies {
     akkaStreamTestkit    % Test,
     scalaTest            % Test,
     junit                % Test,
+    slf4jApi             % Test,
     "com.novocode"       % "junit-interface" % "0.11" % Test,
     slf4jApi             % Test,
     // Upgrades needed to match whitelist versions
@@ -788,6 +799,7 @@ object Dependencies {
     akkaMultiNodeTestkit % Test,
     akkaStreamTestkit    % Test,
     scalaTest            % Test,
+    slf4jApi             % Test,
     // Upgrades needed to match whitelist versions
     sslConfig,
     scalaXml % Test,
@@ -968,6 +980,7 @@ object Dependencies {
     akkaActor,
     akkaSlf4j,
     akkaProtobuf,
+    akkaProtobuf_v3,
     scalaXml,
     guava,
     jnrFfi,
@@ -992,6 +1005,7 @@ object Dependencies {
       akkaActor,
       akkaSlf4j,
       akkaProtobuf,
+      akkaProtobuf_v3,
       guava,
       jnrFfi,
       jffi,
@@ -1010,6 +1024,7 @@ object Dependencies {
     akkaActor,
     akkaSlf4j,
     akkaProtobuf,
+    akkaProtobuf_v3,
     jnrFfi,
     jffi,
     jnra64asm,
@@ -1073,6 +1088,7 @@ object Dependencies {
     akkaActor,
     akkaStream,
     akkaProtobuf,
+    akkaProtobuf_v3,
     akkaSlf4j,
     typesafeConfig,
     sslConfig,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,14 +18,14 @@ object Dependencies {
     val SbtScala = Seq(Scala212, Scala210)
 
     // If you update the version of Play, you probably need to update the other Play* variables.
-    val Play             = "2.8.0-M4"
-    val PlayJson         = "2.8.0-M5"
-    val PlayStandaloneWs = "2.1.0-M4"
-    val Twirl            = "1.5.0-M2"
+    val Play             = "2.8.0-M5"
+    val PlayJson         = "2.8.0-M6"
+    val PlayStandaloneWs = "2.1.0-M5"
+    val Twirl            = "1.5.0-M4"
     val PlayFileWatch    = "1.1.8"
 
-    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.6.0-M5")
-    val AkkaHttp     = "10.1.9"
+    val Akka: String = sys.props.getOrElse("lagom.build.akka.version", "2.6.0-M7")
+    val AkkaHttp     = "10.1.10"
 
     val AkkaPersistenceCassandra = "0.99"
     val AkkaPersistenceJdbc      = "3.5.2"

--- a/project/Doc.scala
+++ b/project/Doc.scala
@@ -201,7 +201,7 @@ object Unidoc extends AutoPlugin {
   // down to two assuming https://github.com/typesafehub/genjavadoc/issues/66 is possible.
   override lazy val projectSettings = inConfig(Genjavadoc)(Defaults.configSettings) ++ Seq(
     ivyConfigurations += GenjavadocCompilerPlugin,
-    libraryDependencies += ("com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.13" % "genjavadocplugin->default(compile)")
+    libraryDependencies += ("com.typesafe.genjavadoc" % "genjavadoc-plugin" % "0.14" % "genjavadocplugin->default(compile)")
       .cross(CrossVersion.full),
     scalacOptions in Genjavadoc ++= Seq(
       "-P:genjavadoc:out=" + (target.value / "java"),

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -28,7 +28,7 @@ object Protobuf {
     outputPaths := Seq((sourceDirectory in Compile).value, (sourceDirectory in Test).value).map(_ / "java"),
     importPath := None,
     protoc := "protoc",
-    protocVersion := "2.6.1",
+    protocVersion := "3.9.0",
     generate := {
       val sourceDirs = paths.value
       val targetDirs = outputPaths.value
@@ -62,7 +62,7 @@ object Protobuf {
               tmp,
               dst,
               _ => true,
-              transformFile(_.replace("com.google.protobuf", "akka.protobuf")),
+              transformFile(_.replace("com.google.protobuf", "akka.protobufv3.internal")),
               cache,
               log
             )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,5 +20,5 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 addSbtPlugin("com.lightbend"    % "sbt-whitesource"      % "0.1.17")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.0.4")
+addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.0.5")
 addSbtPlugin("com.dwijnand"      % "sbt-dynver"         % "4.0.0")

--- a/projection/core/src/main/java/com/lightbend/lagom/internal/projection/protobuf/msg/ProjectionMessages.java
+++ b/projection/core/src/main/java/com/lightbend/lagom/internal/projection/protobuf/msg/ProjectionMessages.java
@@ -10,80 +10,86 @@ package com.lightbend.lagom.internal.projection.protobuf.msg;
 public final class ProjectionMessages {
   private ProjectionMessages() {}
 
-  public static void registerAllExtensions(akka.protobuf.ExtensionRegistry registry) {}
+  public static void registerAllExtensions(
+      akka.protobufv3.internal.ExtensionRegistryLite registry) {}
+
+  public static void registerAllExtensions(akka.protobufv3.internal.ExtensionRegistry registry) {
+    registerAllExtensions((akka.protobufv3.internal.ExtensionRegistryLite) registry);
+  }
 
   public interface WorkerOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.projection.Worker)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string tagName = 1;</code> */
     boolean hasTagName();
     /** <code>required string tagName = 1;</code> */
     java.lang.String getTagName();
     /** <code>required string tagName = 1;</code> */
-    akka.protobuf.ByteString getTagNameBytes();
+    akka.protobufv3.internal.ByteString getTagNameBytes();
 
     /** <code>required string key = 2;</code> */
     boolean hasKey();
     /** <code>required string key = 2;</code> */
     java.lang.String getKey();
     /** <code>required string key = 2;</code> */
-    akka.protobuf.ByteString getKeyBytes();
+    akka.protobufv3.internal.ByteString getKeyBytes();
 
     /** <code>required string requestedStatus = 3;</code> */
     boolean hasRequestedStatus();
     /** <code>required string requestedStatus = 3;</code> */
     java.lang.String getRequestedStatus();
     /** <code>required string requestedStatus = 3;</code> */
-    akka.protobuf.ByteString getRequestedStatusBytes();
+    akka.protobufv3.internal.ByteString getRequestedStatusBytes();
 
     /** <code>required string observedStatus = 4;</code> */
     boolean hasObservedStatus();
     /** <code>required string observedStatus = 4;</code> */
     java.lang.String getObservedStatus();
     /** <code>required string observedStatus = 4;</code> */
-    akka.protobuf.ByteString getObservedStatusBytes();
+    akka.protobufv3.internal.ByteString getObservedStatusBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.projection.Worker} */
-  public static final class Worker extends akka.protobuf.GeneratedMessage
+  public static final class Worker extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.projection.Worker)
       WorkerOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use Worker.newBuilder() to construct.
-    private Worker(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Worker(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private Worker(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private Worker() {
+      tagName_ = "";
+      key_ = "";
+      requestedStatus_ = "";
+      observedStatus_ = "";
     }
-
-    private static final Worker defaultInstance;
-
-    public static Worker getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Worker getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new Worker();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private Worker(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -92,49 +98,47 @@ public final class ProjectionMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 tagName_ = bs;
                 break;
               }
             case 18:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000002;
                 key_ = bs;
                 break;
               }
             case 26:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000004;
                 requestedStatus_ = bs;
                 break;
               }
             case 34:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000008;
                 observedStatus_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -142,12 +146,14 @@ public final class ProjectionMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_Worker_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_Worker_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -156,27 +162,12 @@ public final class ProjectionMessages {
                   .class);
     }
 
-    public static akka.protobuf.Parser<Worker> PARSER =
-        new akka.protobuf.AbstractParser<Worker>() {
-          public Worker parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new Worker(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<Worker> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int TAGNAME_FIELD_NUMBER = 1;
-    private java.lang.Object tagName_;
+    private volatile java.lang.Object tagName_;
     /** <code>required string tagName = 1;</code> */
     public boolean hasTagName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string tagName = 1;</code> */
     public java.lang.String getTagName() {
@@ -184,7 +175,7 @@ public final class ProjectionMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           tagName_ = s;
@@ -193,22 +184,23 @@ public final class ProjectionMessages {
       }
     }
     /** <code>required string tagName = 1;</code> */
-    public akka.protobuf.ByteString getTagNameBytes() {
+    public akka.protobufv3.internal.ByteString getTagNameBytes() {
       java.lang.Object ref = tagName_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         tagName_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
     }
 
     public static final int KEY_FIELD_NUMBER = 2;
-    private java.lang.Object key_;
+    private volatile java.lang.Object key_;
     /** <code>required string key = 2;</code> */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /** <code>required string key = 2;</code> */
     public java.lang.String getKey() {
@@ -216,7 +208,7 @@ public final class ProjectionMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           key_ = s;
@@ -225,22 +217,23 @@ public final class ProjectionMessages {
       }
     }
     /** <code>required string key = 2;</code> */
-    public akka.protobuf.ByteString getKeyBytes() {
+    public akka.protobufv3.internal.ByteString getKeyBytes() {
       java.lang.Object ref = key_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         key_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
     }
 
     public static final int REQUESTEDSTATUS_FIELD_NUMBER = 3;
-    private java.lang.Object requestedStatus_;
+    private volatile java.lang.Object requestedStatus_;
     /** <code>required string requestedStatus = 3;</code> */
     public boolean hasRequestedStatus() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000004) != 0);
     }
     /** <code>required string requestedStatus = 3;</code> */
     public java.lang.String getRequestedStatus() {
@@ -248,7 +241,7 @@ public final class ProjectionMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           requestedStatus_ = s;
@@ -257,22 +250,23 @@ public final class ProjectionMessages {
       }
     }
     /** <code>required string requestedStatus = 3;</code> */
-    public akka.protobuf.ByteString getRequestedStatusBytes() {
+    public akka.protobufv3.internal.ByteString getRequestedStatusBytes() {
       java.lang.Object ref = requestedStatus_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         requestedStatus_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
     }
 
     public static final int OBSERVEDSTATUS_FIELD_NUMBER = 4;
-    private java.lang.Object observedStatus_;
+    private volatile java.lang.Object observedStatus_;
     /** <code>required string observedStatus = 4;</code> */
     public boolean hasObservedStatus() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000008) != 0);
     }
     /** <code>required string observedStatus = 4;</code> */
     public java.lang.String getObservedStatus() {
@@ -280,7 +274,7 @@ public final class ProjectionMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           observedStatus_ = s;
@@ -289,26 +283,21 @@ public final class ProjectionMessages {
       }
     }
     /** <code>required string observedStatus = 4;</code> */
-    public akka.protobuf.ByteString getObservedStatusBytes() {
+    public akka.protobufv3.internal.ByteString getObservedStatusBytes() {
       java.lang.Object ref = observedStatus_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         observedStatus_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      tagName_ = "";
-      key_ = "";
-      requestedStatus_ = "";
-      observedStatus_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -334,147 +323,229 @@ public final class ProjectionMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getTagNameBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, tagName_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getKeyBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeBytes(3, getRequestedStatusBytes());
+      if (((bitField0_ & 0x00000004) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 3, requestedStatus_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        output.writeBytes(4, getObservedStatusBytes());
+      if (((bitField0_ & 0x00000008) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 4, observedStatus_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getTagNameBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, tagName_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(2, getKeyBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(3, getRequestedStatusBytes());
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(3, requestedStatus_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(4, getObservedStatusBytes());
+      if (((bitField0_ & 0x00000008) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(4, observedStatus_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker other =
+          (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker) obj;
+
+      if (hasTagName() != other.hasTagName()) return false;
+      if (hasTagName()) {
+        if (!getTagName().equals(other.getTagName())) return false;
+      }
+      if (hasKey() != other.hasKey()) return false;
+      if (hasKey()) {
+        if (!getKey().equals(other.getKey())) return false;
+      }
+      if (hasRequestedStatus() != other.hasRequestedStatus()) return false;
+      if (hasRequestedStatus()) {
+        if (!getRequestedStatus().equals(other.getRequestedStatus())) return false;
+      }
+      if (hasObservedStatus() != other.hasObservedStatus()) return false;
+      if (hasObservedStatus()) {
+        if (!getObservedStatus().equals(other.getObservedStatus())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasTagName()) {
+        hash = (37 * hash) + TAGNAME_FIELD_NUMBER;
+        hash = (53 * hash) + getTagName().hashCode();
+      }
+      if (hasKey()) {
+        hash = (37 * hash) + KEY_FIELD_NUMBER;
+        hash = (53 * hash) + getKey().hashCode();
+      }
+      if (hasRequestedStatus()) {
+        hash = (37 * hash) + REQUESTEDSTATUS_FIELD_NUMBER;
+        hash = (53 * hash) + getRequestedStatus().hashCode();
+      }
+      if (hasObservedStatus()) {
+        hash = (37 * hash) + OBSERVEDSTATUS_FIELD_NUMBER;
+        hash = (53 * hash) + getObservedStatus().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() {
-      return Builder.create();
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
     }
 
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
     public Builder newBuilderForType() {
       return newBuilder();
     }
 
-    public static Builder newBuilder(
-        com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
-    public Builder toBuilder() {
-      return newBuilder(this);
+    public static Builder newBuilder(
+        com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.projection.Worker} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.projection.Worker)
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.WorkerOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_Worker_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_Worker_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -490,19 +561,16 @@ public final class ProjectionMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         tagName_ = "";
@@ -516,21 +584,20 @@ public final class ProjectionMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_Worker_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
           getDefaultInstanceForType() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
             .getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
           build() {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker result =
@@ -541,6 +608,7 @@ public final class ProjectionMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
           buildPartial() {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker result =
@@ -548,19 +616,19 @@ public final class ProjectionMessages {
                 this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.tagName_ = tagName_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.key_ = key_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+        if (((from_bitField0_ & 0x00000004) != 0)) {
           to_bitField0_ |= 0x00000004;
         }
         result.requestedStatus_ = requestedStatus_;
-        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+        if (((from_bitField0_ & 0x00000008) != 0)) {
           to_bitField0_ |= 0x00000008;
         }
         result.observedStatus_ = observedStatus_;
@@ -569,7 +637,43 @@ public final class ProjectionMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker) {
@@ -607,43 +711,42 @@ public final class ProjectionMessages {
           observedStatus_ = other.observedStatus_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasTagName()) {
-
           return false;
         }
         if (!hasKey()) {
-
           return false;
         }
         if (!hasRequestedStatus()) {
-
           return false;
         }
         if (!hasObservedStatus()) {
-
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -657,13 +760,13 @@ public final class ProjectionMessages {
       private java.lang.Object tagName_ = "";
       /** <code>required string tagName = 1;</code> */
       public boolean hasTagName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string tagName = 1;</code> */
       public java.lang.String getTagName() {
         java.lang.Object ref = tagName_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             tagName_ = s;
@@ -674,15 +777,15 @@ public final class ProjectionMessages {
         }
       }
       /** <code>required string tagName = 1;</code> */
-      public akka.protobuf.ByteString getTagNameBytes() {
+      public akka.protobufv3.internal.ByteString getTagNameBytes() {
         java.lang.Object ref = tagName_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           tagName_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string tagName = 1;</code> */
@@ -703,7 +806,7 @@ public final class ProjectionMessages {
         return this;
       }
       /** <code>required string tagName = 1;</code> */
-      public Builder setTagNameBytes(akka.protobuf.ByteString value) {
+      public Builder setTagNameBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -716,13 +819,13 @@ public final class ProjectionMessages {
       private java.lang.Object key_ = "";
       /** <code>required string key = 2;</code> */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /** <code>required string key = 2;</code> */
       public java.lang.String getKey() {
         java.lang.Object ref = key_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             key_ = s;
@@ -733,15 +836,15 @@ public final class ProjectionMessages {
         }
       }
       /** <code>required string key = 2;</code> */
-      public akka.protobuf.ByteString getKeyBytes() {
+      public akka.protobufv3.internal.ByteString getKeyBytes() {
         java.lang.Object ref = key_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           key_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string key = 2;</code> */
@@ -762,7 +865,7 @@ public final class ProjectionMessages {
         return this;
       }
       /** <code>required string key = 2;</code> */
-      public Builder setKeyBytes(akka.protobuf.ByteString value) {
+      public Builder setKeyBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -775,13 +878,13 @@ public final class ProjectionMessages {
       private java.lang.Object requestedStatus_ = "";
       /** <code>required string requestedStatus = 3;</code> */
       public boolean hasRequestedStatus() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000004) != 0);
       }
       /** <code>required string requestedStatus = 3;</code> */
       public java.lang.String getRequestedStatus() {
         java.lang.Object ref = requestedStatus_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             requestedStatus_ = s;
@@ -792,15 +895,15 @@ public final class ProjectionMessages {
         }
       }
       /** <code>required string requestedStatus = 3;</code> */
-      public akka.protobuf.ByteString getRequestedStatusBytes() {
+      public akka.protobufv3.internal.ByteString getRequestedStatusBytes() {
         java.lang.Object ref = requestedStatus_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           requestedStatus_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string requestedStatus = 3;</code> */
@@ -821,7 +924,7 @@ public final class ProjectionMessages {
         return this;
       }
       /** <code>required string requestedStatus = 3;</code> */
-      public Builder setRequestedStatusBytes(akka.protobuf.ByteString value) {
+      public Builder setRequestedStatusBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -834,13 +937,13 @@ public final class ProjectionMessages {
       private java.lang.Object observedStatus_ = "";
       /** <code>required string observedStatus = 4;</code> */
       public boolean hasObservedStatus() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000008) != 0);
       }
       /** <code>required string observedStatus = 4;</code> */
       public java.lang.String getObservedStatus() {
         java.lang.Object ref = observedStatus_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             observedStatus_ = s;
@@ -851,15 +954,15 @@ public final class ProjectionMessages {
         }
       }
       /** <code>required string observedStatus = 4;</code> */
-      public akka.protobuf.ByteString getObservedStatusBytes() {
+      public akka.protobufv3.internal.ByteString getObservedStatusBytes() {
         java.lang.Object ref = observedStatus_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           observedStatus_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string observedStatus = 4;</code> */
@@ -880,7 +983,7 @@ public final class ProjectionMessages {
         return this;
       }
       /** <code>required string observedStatus = 4;</code> */
-      public Builder setObservedStatusBytes(akka.protobuf.ByteString value) {
+      public Builder setObservedStatusBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -890,28 +993,75 @@ public final class ProjectionMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.projection.Worker)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.Worker)
+    private static final com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .Worker
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new Worker(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.Worker)
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<Worker> PARSER =
+        new akka.protobufv3.internal.AbstractParser<Worker>() {
+          @java.lang.Override
+          public Worker parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new Worker(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<Worker> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<Worker> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface ProjectionOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.projection.Projection)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string name = 1;</code> */
     boolean hasName();
     /** <code>required string name = 1;</code> */
     java.lang.String getName();
     /** <code>required string name = 1;</code> */
-    akka.protobuf.ByteString getNameBytes();
+    akka.protobufv3.internal.ByteString getNameBytes();
 
     /** <code>repeated .com.lightbend.lagom.internal.projection.Worker workers = 2;</code> */
     java.util.List<com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker>
@@ -932,44 +1082,43 @@ public final class ProjectionMessages {
         getWorkersOrBuilder(int index);
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.projection.Projection} */
-  public static final class Projection extends akka.protobuf.GeneratedMessage
+  public static final class Projection extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.projection.Projection)
       ProjectionOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use Projection.newBuilder() to construct.
-    private Projection(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private Projection(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private Projection(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private Projection() {
+      name_ = "";
+      workers_ = java.util.Collections.emptyList();
     }
-
-    private static final Projection defaultInstance;
-
-    public static Projection getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public Projection getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new Projection();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private Projection(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -978,25 +1127,16 @@ public final class ProjectionMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 name_ = bs;
                 break;
               }
             case 18:
               {
-                if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                if (!((mutable_bitField0_ & 0x00000002) != 0)) {
                   workers_ =
                       new java.util.ArrayList<
                           com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
@@ -1010,15 +1150,22 @@ public final class ProjectionMessages {
                         extensionRegistry));
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((mutable_bitField0_ & 0x00000002) != 0)) {
           workers_ = java.util.Collections.unmodifiableList(workers_);
         }
         this.unknownFields = unknownFields.build();
@@ -1026,12 +1173,14 @@ public final class ProjectionMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_Projection_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_Projection_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -1041,27 +1190,12 @@ public final class ProjectionMessages {
                   .Builder.class);
     }
 
-    public static akka.protobuf.Parser<Projection> PARSER =
-        new akka.protobuf.AbstractParser<Projection>() {
-          public Projection parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new Projection(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<Projection> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int NAME_FIELD_NUMBER = 1;
-    private java.lang.Object name_;
+    private volatile java.lang.Object name_;
     /** <code>required string name = 1;</code> */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string name = 1;</code> */
     public java.lang.String getName() {
@@ -1069,7 +1203,7 @@ public final class ProjectionMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           name_ = s;
@@ -1078,14 +1212,15 @@ public final class ProjectionMessages {
       }
     }
     /** <code>required string name = 1;</code> */
-    public akka.protobuf.ByteString getNameBytes() {
+    public akka.protobufv3.internal.ByteString getNameBytes() {
       java.lang.Object ref = name_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         name_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
     }
 
@@ -1122,13 +1257,9 @@ public final class ProjectionMessages {
       return workers_.get(index);
     }
 
-    private void initFields() {
-      name_ = "";
-      workers_ = java.util.Collections.emptyList();
-    }
-
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1148,137 +1279,200 @@ public final class ProjectionMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getNameBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, name_);
       }
       for (int i = 0; i < workers_.size(); i++) {
         output.writeMessage(2, workers_.get(i));
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getNameBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, name_);
       }
       for (int i = 0; i < workers_.size(); i++) {
-        size += akka.protobuf.CodedOutputStream.computeMessageSize(2, workers_.get(i));
+        size += akka.protobufv3.internal.CodedOutputStream.computeMessageSize(2, workers_.get(i));
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection other =
+          (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection) obj;
+
+      if (hasName() != other.hasName()) return false;
+      if (hasName()) {
+        if (!getName().equals(other.getName())) return false;
+      }
+      if (!getWorkersList().equals(other.getWorkersList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasName()) {
+        hash = (37 * hash) + NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getName().hashCode();
+      }
+      if (getWorkersCount() > 0) {
+        hash = (37 * hash) + WORKERS_FIELD_NUMBER;
+        hash = (53 * hash) + getWorkersList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.projection.Projection} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.projection.Projection)
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .ProjectionOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_Projection_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_Projection_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -1294,21 +1488,18 @@ public final class ProjectionMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {
           getWorkersFieldBuilder();
         }
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         name_ = "";
@@ -1322,21 +1513,20 @@ public final class ProjectionMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_Projection_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
           getDefaultInstanceForType() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
             .getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
           build() {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection result =
@@ -1347,6 +1537,7 @@ public final class ProjectionMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
           buildPartial() {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection result =
@@ -1354,12 +1545,12 @@ public final class ProjectionMessages {
                 this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.name_ = name_;
         if (workersBuilder_ == null) {
-          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          if (((bitField0_ & 0x00000002) != 0)) {
             workers_ = java.util.Collections.unmodifiableList(workers_);
             bitField0_ = (bitField0_ & ~0x00000002);
           }
@@ -1372,7 +1563,43 @@ public final class ProjectionMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection) {
@@ -1415,7 +1642,7 @@ public final class ProjectionMessages {
               workers_ = other.workers_;
               bitField0_ = (bitField0_ & ~0x00000002);
               workersBuilder_ =
-                  akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders
+                  akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders
                       ? getWorkersFieldBuilder()
                       : null;
             } else {
@@ -1423,37 +1650,38 @@ public final class ProjectionMessages {
             }
           }
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasName()) {
-
           return false;
         }
         for (int i = 0; i < getWorkersCount(); i++) {
           if (!getWorkers(i).isInitialized()) {
-
             return false;
           }
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -1467,13 +1695,13 @@ public final class ProjectionMessages {
       private java.lang.Object name_ = "";
       /** <code>required string name = 1;</code> */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string name = 1;</code> */
       public java.lang.String getName() {
         java.lang.Object ref = name_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             name_ = s;
@@ -1484,15 +1712,15 @@ public final class ProjectionMessages {
         }
       }
       /** <code>required string name = 1;</code> */
-      public akka.protobuf.ByteString getNameBytes() {
+      public akka.protobufv3.internal.ByteString getNameBytes() {
         java.lang.Object ref = name_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           name_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string name = 1;</code> */
@@ -1513,7 +1741,7 @@ public final class ProjectionMessages {
         return this;
       }
       /** <code>required string name = 1;</code> */
-      public Builder setNameBytes(akka.protobuf.ByteString value) {
+      public Builder setNameBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -1528,7 +1756,7 @@ public final class ProjectionMessages {
           workers_ = java.util.Collections.emptyList();
 
       private void ensureWorkersIsMutable() {
-        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+        if (!((bitField0_ & 0x00000002) != 0)) {
           workers_ =
               new java.util.ArrayList<
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker>(
@@ -1537,7 +1765,7 @@ public final class ProjectionMessages {
         }
       }
 
-      private akka.protobuf.RepeatedFieldBuilder<
+      private akka.protobufv3.internal.RepeatedFieldBuilderV3<
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker,
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
                   .Builder,
@@ -1669,7 +1897,7 @@ public final class ProjectionMessages {
               values) {
         if (workersBuilder_ == null) {
           ensureWorkersIsMutable();
-          akka.protobuf.AbstractMessageLite.Builder.addAll(values, workers_);
+          akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(values, workers_);
           onChanged();
         } else {
           workersBuilder_.addAllMessages(values);
@@ -1749,7 +1977,7 @@ public final class ProjectionMessages {
         return getWorkersFieldBuilder().getBuilderList();
       }
 
-      private akka.protobuf.RepeatedFieldBuilder<
+      private akka.protobufv3.internal.RepeatedFieldBuilderV3<
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker,
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
                   .Builder,
@@ -1758,36 +1986,80 @@ public final class ProjectionMessages {
           getWorkersFieldBuilder() {
         if (workersBuilder_ == null) {
           workersBuilder_ =
-              new akka.protobuf.RepeatedFieldBuilder<
+              new akka.protobufv3.internal.RepeatedFieldBuilderV3<
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker,
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Worker
                       .Builder,
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
                       .WorkerOrBuilder>(
-                  workers_,
-                  ((bitField0_ & 0x00000002) == 0x00000002),
-                  getParentForChildren(),
-                  isClean());
+                  workers_, ((bitField0_ & 0x00000002) != 0), getParentForChildren(), isClean());
           workers_ = null;
         }
         return workersBuilder_;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.projection.Projection)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.Projection)
+    private static final com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .Projection
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new Projection(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.Projection)
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<Projection> PARSER =
+        new akka.protobufv3.internal.AbstractParser<Projection>() {
+          @java.lang.Override
+          public Projection parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new Projection(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<Projection> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<Projection> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface StateOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.projection.State)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /**
      * <code>repeated .com.lightbend.lagom.internal.projection.Projection projections = 1;</code>
@@ -1819,44 +2091,42 @@ public final class ProjectionMessages {
         getProjectionsOrBuilder(int index);
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.projection.State} */
-  public static final class State extends akka.protobuf.GeneratedMessage
+  public static final class State extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.projection.State)
       StateOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use State.newBuilder() to construct.
-    private State(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private State(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private State(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private State() {
+      projections_ = java.util.Collections.emptyList();
     }
-
-    private static final State defaultInstance;
-
-    public static State getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public State getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new State();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private State(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -1865,18 +2135,9 @@ public final class ProjectionMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                if (!((mutable_bitField0_ & 0x00000001) != 0)) {
                   projections_ =
                       new java.util.ArrayList<
                           com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
@@ -1890,15 +2151,22 @@ public final class ProjectionMessages {
                         extensionRegistry));
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
-        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((mutable_bitField0_ & 0x00000001) != 0)) {
           projections_ = java.util.Collections.unmodifiableList(projections_);
         }
         this.unknownFields = unknownFields.build();
@@ -1906,33 +2174,20 @@ public final class ProjectionMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_State_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_State_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State.class,
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State.Builder
                   .class);
-    }
-
-    public static akka.protobuf.Parser<State> PARSER =
-        new akka.protobuf.AbstractParser<State>() {
-          public State parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new State(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<State> getParserForType() {
-      return PARSER;
     }
 
     public static final int PROJECTIONS_FIELD_NUMBER = 1;
@@ -1979,12 +2234,9 @@ public final class ProjectionMessages {
       return projections_.get(index);
     }
 
-    private void initFields() {
-      projections_ = java.util.Collections.emptyList();
-    }
-
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2000,129 +2252,185 @@ public final class ProjectionMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
       for (int i = 0; i < projections_.size(); i++) {
         output.writeMessage(1, projections_.get(i));
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
       for (int i = 0; i < projections_.size(); i++) {
-        size += akka.protobuf.CodedOutputStream.computeMessageSize(1, projections_.get(i));
+        size +=
+            akka.protobufv3.internal.CodedOutputStream.computeMessageSize(1, projections_.get(i));
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State other =
+          (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State) obj;
+
+      if (!getProjectionsList().equals(other.getProjectionsList())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getProjectionsCount() > 0) {
+        hash = (37 * hash) + PROJECTIONS_FIELD_NUMBER;
+        hash = (53 * hash) + getProjectionsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
     }
 
-    public static Builder newBuilder() {
-      return Builder.create();
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
     }
 
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
     public Builder newBuilderForType() {
       return newBuilder();
     }
 
-    public static Builder newBuilder(
-        com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State prototype) {
-      return newBuilder().mergeFrom(prototype);
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
-    public Builder toBuilder() {
-      return newBuilder(this);
+    public static Builder newBuilder(
+        com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.projection.State} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.projection.State)
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.StateOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_State_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_State_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2137,21 +2445,18 @@ public final class ProjectionMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {
           getProjectionsFieldBuilder();
         }
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (projectionsBuilder_ == null) {
@@ -2163,21 +2468,20 @@ public final class ProjectionMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_State_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
           getDefaultInstanceForType() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
             .getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State build() {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State result =
             buildPartial();
@@ -2187,13 +2491,14 @@ public final class ProjectionMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
           buildPartial() {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State result =
             new com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State(this);
         int from_bitField0_ = bitField0_;
         if (projectionsBuilder_ == null) {
-          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          if (((bitField0_ & 0x00000001) != 0)) {
             projections_ = java.util.Collections.unmodifiableList(projections_);
             bitField0_ = (bitField0_ & ~0x00000001);
           }
@@ -2205,7 +2510,43 @@ public final class ProjectionMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State) {
@@ -2242,7 +2583,7 @@ public final class ProjectionMessages {
               projections_ = other.projections_;
               bitField0_ = (bitField0_ & ~0x00000001);
               projectionsBuilder_ =
-                  akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders
+                  akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders
                       ? getProjectionsFieldBuilder()
                       : null;
             } else {
@@ -2250,33 +2591,35 @@ public final class ProjectionMessages {
             }
           }
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         for (int i = 0; i < getProjectionsCount(); i++) {
           if (!getProjections(i).isInitialized()) {
-
             return false;
           }
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -2292,7 +2635,7 @@ public final class ProjectionMessages {
           projections_ = java.util.Collections.emptyList();
 
       private void ensureProjectionsIsMutable() {
-        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+        if (!((bitField0_ & 0x00000001) != 0)) {
           projections_ =
               new java.util.ArrayList<
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
@@ -2301,7 +2644,7 @@ public final class ProjectionMessages {
         }
       }
 
-      private akka.protobuf.RepeatedFieldBuilder<
+      private akka.protobufv3.internal.RepeatedFieldBuilderV3<
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection,
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
                   .Builder,
@@ -2456,7 +2799,7 @@ public final class ProjectionMessages {
               values) {
         if (projectionsBuilder_ == null) {
           ensureProjectionsIsMutable();
-          akka.protobuf.AbstractMessageLite.Builder.addAll(values, projections_);
+          akka.protobufv3.internal.AbstractMessageLite.Builder.addAll(values, projections_);
           onChanged();
         } else {
           projectionsBuilder_.addAllMessages(values);
@@ -2556,7 +2899,7 @@ public final class ProjectionMessages {
         return getProjectionsFieldBuilder().getBuilderList();
       }
 
-      private akka.protobuf.RepeatedFieldBuilder<
+      private akka.protobufv3.internal.RepeatedFieldBuilderV3<
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection,
               com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
                   .Builder,
@@ -2565,7 +2908,7 @@ public final class ProjectionMessages {
           getProjectionsFieldBuilder() {
         if (projectionsBuilder_ == null) {
           projectionsBuilder_ =
-              new akka.protobuf.RepeatedFieldBuilder<
+              new akka.protobufv3.internal.RepeatedFieldBuilderV3<
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
                       .Projection,
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.Projection
@@ -2573,7 +2916,7 @@ public final class ProjectionMessages {
                   com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
                       .ProjectionOrBuilder>(
                   projections_,
-                  ((bitField0_ & 0x00000001) == 0x00000001),
+                  ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
                   isClean());
           projections_ = null;
@@ -2581,75 +2924,121 @@ public final class ProjectionMessages {
         return projectionsBuilder_;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.projection.State)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.State)
+    private static final com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .State
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new State(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.State)
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<State> PARSER =
+        new akka.protobufv3.internal.AbstractParser<State>() {
+          @java.lang.Override
+          public State parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new State(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<State> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<State> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.State
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
   public interface WorkerCoordinatesOrBuilder
       extends
       // @@protoc_insertion_point(interface_extends:com.lightbend.lagom.internal.projection.WorkerCoordinates)
-      akka.protobuf.MessageOrBuilder {
+      akka.protobufv3.internal.MessageOrBuilder {
 
     /** <code>required string projectionName = 1;</code> */
     boolean hasProjectionName();
     /** <code>required string projectionName = 1;</code> */
     java.lang.String getProjectionName();
     /** <code>required string projectionName = 1;</code> */
-    akka.protobuf.ByteString getProjectionNameBytes();
+    akka.protobufv3.internal.ByteString getProjectionNameBytes();
 
     /** <code>required string tagName = 2;</code> */
     boolean hasTagName();
     /** <code>required string tagName = 2;</code> */
     java.lang.String getTagName();
     /** <code>required string tagName = 2;</code> */
-    akka.protobuf.ByteString getTagNameBytes();
+    akka.protobufv3.internal.ByteString getTagNameBytes();
   }
   /** Protobuf type {@code com.lightbend.lagom.internal.projection.WorkerCoordinates} */
-  public static final class WorkerCoordinates extends akka.protobuf.GeneratedMessage
+  public static final class WorkerCoordinates extends akka.protobufv3.internal.GeneratedMessageV3
       implements
       // @@protoc_insertion_point(message_implements:com.lightbend.lagom.internal.projection.WorkerCoordinates)
       WorkerCoordinatesOrBuilder {
+    private static final long serialVersionUID = 0L;
     // Use WorkerCoordinates.newBuilder() to construct.
-    private WorkerCoordinates(akka.protobuf.GeneratedMessage.Builder<?> builder) {
+    private WorkerCoordinates(akka.protobufv3.internal.GeneratedMessageV3.Builder<?> builder) {
       super(builder);
-      this.unknownFields = builder.getUnknownFields();
     }
 
-    private WorkerCoordinates(boolean noInit) {
-      this.unknownFields = akka.protobuf.UnknownFieldSet.getDefaultInstance();
+    private WorkerCoordinates() {
+      projectionName_ = "";
+      tagName_ = "";
     }
-
-    private static final WorkerCoordinates defaultInstance;
-
-    public static WorkerCoordinates getDefaultInstance() {
-      return defaultInstance;
-    }
-
-    public WorkerCoordinates getDefaultInstanceForType() {
-      return defaultInstance;
-    }
-
-    private final akka.protobuf.UnknownFieldSet unknownFields;
 
     @java.lang.Override
-    public final akka.protobuf.UnknownFieldSet getUnknownFields() {
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(UnusedPrivateParameter unused) {
+      return new WorkerCoordinates();
+    }
+
+    @java.lang.Override
+    public final akka.protobufv3.internal.UnknownFieldSet getUnknownFields() {
       return this.unknownFields;
     }
 
     private WorkerCoordinates(
-        akka.protobuf.CodedInputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws akka.protobuf.InvalidProtocolBufferException {
-      initFields();
+        akka.protobufv3.internal.CodedInputStream input,
+        akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+        throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       int mutable_bitField0_ = 0;
-      akka.protobuf.UnknownFieldSet.Builder unknownFields =
-          akka.protobuf.UnknownFieldSet.newBuilder();
+      akka.protobufv3.internal.UnknownFieldSet.Builder unknownFields =
+          akka.protobufv3.internal.UnknownFieldSet.newBuilder();
       try {
         boolean done = false;
         while (!done) {
@@ -2658,35 +3047,33 @@ public final class ProjectionMessages {
             case 0:
               done = true;
               break;
-            default:
-              {
-                if (!parseUnknownField(
-                    input, unknownFields,
-                    extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
             case 10:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000001;
                 projectionName_ = bs;
                 break;
               }
             case 18:
               {
-                akka.protobuf.ByteString bs = input.readBytes();
+                akka.protobufv3.internal.ByteString bs = input.readBytes();
                 bitField0_ |= 0x00000002;
                 tagName_ = bs;
                 break;
               }
+            default:
+              {
+                if (!parseUnknownField(input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
           }
         }
-      } catch (akka.protobuf.InvalidProtocolBufferException e) {
+      } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
         throw e.setUnfinishedMessage(this);
       } catch (java.io.IOException e) {
-        throw new akka.protobuf.InvalidProtocolBufferException(e.getMessage())
+        throw new akka.protobufv3.internal.InvalidProtocolBufferException(e)
             .setUnfinishedMessage(this);
       } finally {
         this.unknownFields = unknownFields.build();
@@ -2694,12 +3081,14 @@ public final class ProjectionMessages {
       }
     }
 
-    public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+    public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_descriptor;
     }
 
-    protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+    @java.lang.Override
+    protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
       return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
           .internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
@@ -2709,27 +3098,12 @@ public final class ProjectionMessages {
                   .WorkerCoordinates.Builder.class);
     }
 
-    public static akka.protobuf.Parser<WorkerCoordinates> PARSER =
-        new akka.protobuf.AbstractParser<WorkerCoordinates>() {
-          public WorkerCoordinates parsePartialFrom(
-              akka.protobuf.CodedInputStream input,
-              akka.protobuf.ExtensionRegistryLite extensionRegistry)
-              throws akka.protobuf.InvalidProtocolBufferException {
-            return new WorkerCoordinates(input, extensionRegistry);
-          }
-        };
-
-    @java.lang.Override
-    public akka.protobuf.Parser<WorkerCoordinates> getParserForType() {
-      return PARSER;
-    }
-
     private int bitField0_;
     public static final int PROJECTIONNAME_FIELD_NUMBER = 1;
-    private java.lang.Object projectionName_;
+    private volatile java.lang.Object projectionName_;
     /** <code>required string projectionName = 1;</code> */
     public boolean hasProjectionName() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /** <code>required string projectionName = 1;</code> */
     public java.lang.String getProjectionName() {
@@ -2737,7 +3111,7 @@ public final class ProjectionMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           projectionName_ = s;
@@ -2746,22 +3120,23 @@ public final class ProjectionMessages {
       }
     }
     /** <code>required string projectionName = 1;</code> */
-    public akka.protobuf.ByteString getProjectionNameBytes() {
+    public akka.protobufv3.internal.ByteString getProjectionNameBytes() {
       java.lang.Object ref = projectionName_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         projectionName_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
     }
 
     public static final int TAGNAME_FIELD_NUMBER = 2;
-    private java.lang.Object tagName_;
+    private volatile java.lang.Object tagName_;
     /** <code>required string tagName = 2;</code> */
     public boolean hasTagName() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000002) != 0);
     }
     /** <code>required string tagName = 2;</code> */
     public java.lang.String getTagName() {
@@ -2769,7 +3144,7 @@ public final class ProjectionMessages {
       if (ref instanceof java.lang.String) {
         return (java.lang.String) ref;
       } else {
-        akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+        akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
         java.lang.String s = bs.toStringUtf8();
         if (bs.isValidUtf8()) {
           tagName_ = s;
@@ -2778,24 +3153,21 @@ public final class ProjectionMessages {
       }
     }
     /** <code>required string tagName = 2;</code> */
-    public akka.protobuf.ByteString getTagNameBytes() {
+    public akka.protobufv3.internal.ByteString getTagNameBytes() {
       java.lang.Object ref = tagName_;
       if (ref instanceof java.lang.String) {
-        akka.protobuf.ByteString b = akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+        akka.protobufv3.internal.ByteString b =
+            akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
         tagName_ = b;
         return b;
       } else {
-        return (akka.protobuf.ByteString) ref;
+        return (akka.protobufv3.internal.ByteString) ref;
       }
-    }
-
-    private void initFields() {
-      projectionName_ = "";
-      tagName_ = "";
     }
 
     private byte memoizedIsInitialized = -1;
 
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2813,147 +3185,219 @@ public final class ProjectionMessages {
       return true;
     }
 
-    public void writeTo(akka.protobuf.CodedOutputStream output) throws java.io.IOException {
-      getSerializedSize();
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeBytes(1, getProjectionNameBytes());
+    @java.lang.Override
+    public void writeTo(akka.protobufv3.internal.CodedOutputStream output)
+        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 1, projectionName_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeBytes(2, getTagNameBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        akka.protobufv3.internal.GeneratedMessageV3.writeString(output, 2, tagName_);
       }
-      getUnknownFields().writeTo(output);
+      unknownFields.writeTo(output);
     }
 
-    private int memoizedSerializedSize = -1;
-
+    @java.lang.Override
     public int getSerializedSize() {
-      int size = memoizedSerializedSize;
+      int size = memoizedSize;
       if (size != -1) return size;
 
       size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(1, getProjectionNameBytes());
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(1, projectionName_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += akka.protobuf.CodedOutputStream.computeBytesSize(2, getTagNameBytes());
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += akka.protobufv3.internal.GeneratedMessageV3.computeStringSize(2, tagName_);
       }
-      size += getUnknownFields().getSerializedSize();
-      memoizedSerializedSize = size;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
       return size;
     }
 
-    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj
+          instanceof
+          com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+              .WorkerCoordinates)) {
+        return super.equals(obj);
+      }
+      com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.WorkerCoordinates
+          other =
+              (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+                      .WorkerCoordinates)
+                  obj;
+
+      if (hasProjectionName() != other.hasProjectionName()) return false;
+      if (hasProjectionName()) {
+        if (!getProjectionName().equals(other.getProjectionName())) return false;
+      }
+      if (hasTagName() != other.hasTagName()) return false;
+      if (hasTagName()) {
+        if (!getTagName().equals(other.getTagName())) return false;
+      }
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
 
     @java.lang.Override
-    protected java.lang.Object writeReplace() throws java.io.ObjectStreamException {
-      return super.writeReplace();
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasProjectionName()) {
+        hash = (37 * hash) + PROJECTIONNAME_FIELD_NUMBER;
+        hash = (53 * hash) + getProjectionName().hashCode();
+      }
+      if (hasTagName()) {
+        hash = (37 * hash) + TAGNAME_FIELD_NUMBER;
+        hash = (53 * hash) + getTagName().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .WorkerCoordinates
-        parseFrom(akka.protobuf.ByteString data)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(java.nio.ByteBuffer data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .WorkerCoordinates
         parseFrom(
-            akka.protobuf.ByteString data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+            java.nio.ByteBuffer data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .WorkerCoordinates
-        parseFrom(byte[] data) throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(akka.protobufv3.internal.ByteString data)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .WorkerCoordinates
-        parseFrom(byte[] data, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws akka.protobuf.InvalidProtocolBufferException {
+        parseFrom(
+            akka.protobufv3.internal.ByteString data,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        parseFrom(byte[] data) throws akka.protobufv3.internal.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        parseFrom(byte[] data, akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws akka.protobufv3.internal.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .WorkerCoordinates
         parseFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
-            .WorkerCoordinates
-        parseFrom(java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
-            .WorkerCoordinates
-        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
-            .WorkerCoordinates
-        parseDelimitedFrom(
-            java.io.InputStream input, akka.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-      return PARSER.parseDelimitedFrom(input, extensionRegistry);
-    }
-
-    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
-            .WorkerCoordinates
-        parseFrom(akka.protobuf.CodedInputStream input) throws java.io.IOException {
-      return PARSER.parseFrom(input);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
     }
 
     public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .WorkerCoordinates
         parseFrom(
-            akka.protobuf.CodedInputStream input,
-            akka.protobuf.ExtensionRegistryLite extensionRegistry)
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
             throws java.io.IOException {
-      return PARSER.parseFrom(input, extensionRegistry);
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        parseDelimitedFrom(
+            java.io.InputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseDelimitedWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        parseFrom(akka.protobufv3.internal.CodedInputStream input) throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(PARSER, input);
+    }
+
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        parseFrom(
+            akka.protobufv3.internal.CodedInputStream input,
+            akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+      return akka.protobufv3.internal.GeneratedMessageV3.parseWithIOException(
+          PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() {
+      return newBuilder();
     }
 
     public static Builder newBuilder() {
-      return Builder.create();
-    }
-
-    public Builder newBuilderForType() {
-      return newBuilder();
+      return DEFAULT_INSTANCE.toBuilder();
     }
 
     public static Builder newBuilder(
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.WorkerCoordinates
             prototype) {
-      return newBuilder().mergeFrom(prototype);
-    }
-
-    public Builder toBuilder() {
-      return newBuilder(this);
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
 
     @java.lang.Override
-    protected Builder newBuilderForType(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
     /** Protobuf type {@code com.lightbend.lagom.internal.projection.WorkerCoordinates} */
-    public static final class Builder extends akka.protobuf.GeneratedMessage.Builder<Builder>
+    public static final class Builder
+        extends akka.protobufv3.internal.GeneratedMessageV3.Builder<Builder>
         implements
         // @@protoc_insertion_point(builder_implements:com.lightbend.lagom.internal.projection.WorkerCoordinates)
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .WorkerCoordinatesOrBuilder {
-      public static final akka.protobuf.Descriptors.Descriptor getDescriptor() {
+      public static final akka.protobufv3.internal.Descriptors.Descriptor getDescriptor() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_descriptor;
       }
 
-      protected akka.protobuf.GeneratedMessage.FieldAccessorTable internalGetFieldAccessorTable() {
+      @java.lang.Override
+      protected akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
@@ -2969,19 +3413,16 @@ public final class ProjectionMessages {
         maybeForceBuilderInitialization();
       }
 
-      private Builder(akka.protobuf.GeneratedMessage.BuilderParent parent) {
+      private Builder(akka.protobufv3.internal.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
 
       private void maybeForceBuilderInitialization() {
-        if (akka.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {}
+        if (akka.protobufv3.internal.GeneratedMessageV3.alwaysUseFieldBuilders) {}
       }
 
-      private static Builder create() {
-        return new Builder();
-      }
-
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         projectionName_ = "";
@@ -2991,15 +3432,13 @@ public final class ProjectionMessages {
         return this;
       }
 
-      public Builder clone() {
-        return create().mergeFrom(buildPartial());
-      }
-
-      public akka.protobuf.Descriptors.Descriptor getDescriptorForType() {
+      @java.lang.Override
+      public akka.protobufv3.internal.Descriptors.Descriptor getDescriptorForType() {
         return com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
             .internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_descriptor;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
               .WorkerCoordinates
           getDefaultInstanceForType() {
@@ -3007,6 +3446,7 @@ public final class ProjectionMessages {
             .WorkerCoordinates.getDefaultInstance();
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
               .WorkerCoordinates
           build() {
@@ -3018,6 +3458,7 @@ public final class ProjectionMessages {
         return result;
       }
 
+      @java.lang.Override
       public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
               .WorkerCoordinates
           buildPartial() {
@@ -3027,11 +3468,11 @@ public final class ProjectionMessages {
                     .WorkerCoordinates(this);
         int from_bitField0_ = bitField0_;
         int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+        if (((from_bitField0_ & 0x00000001) != 0)) {
           to_bitField0_ |= 0x00000001;
         }
         result.projectionName_ = projectionName_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+        if (((from_bitField0_ & 0x00000002) != 0)) {
           to_bitField0_ |= 0x00000002;
         }
         result.tagName_ = tagName_;
@@ -3040,7 +3481,43 @@ public final class ProjectionMessages {
         return result;
       }
 
-      public Builder mergeFrom(akka.protobuf.Message other) {
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+
+      @java.lang.Override
+      public Builder setField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.setField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder clearField(akka.protobufv3.internal.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+
+      @java.lang.Override
+      public Builder clearOneof(akka.protobufv3.internal.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+
+      @java.lang.Override
+      public Builder setRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field,
+          int index,
+          java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+
+      @java.lang.Override
+      public Builder addRepeatedField(
+          akka.protobufv3.internal.Descriptors.FieldDescriptor field, java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(akka.protobufv3.internal.Message other) {
         if (other
             instanceof
             com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
@@ -3071,36 +3548,37 @@ public final class ProjectionMessages {
           tagName_ = other.tagName_;
           onChanged();
         }
-        this.mergeUnknownFields(other.getUnknownFields());
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
         return this;
       }
 
+      @java.lang.Override
       public final boolean isInitialized() {
         if (!hasProjectionName()) {
-
           return false;
         }
         if (!hasTagName()) {
-
           return false;
         }
         return true;
       }
 
+      @java.lang.Override
       public Builder mergeFrom(
-          akka.protobuf.CodedInputStream input,
-          akka.protobuf.ExtensionRegistryLite extensionRegistry)
+          akka.protobufv3.internal.CodedInputStream input,
+          akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
         com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.WorkerCoordinates
             parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (akka.protobuf.InvalidProtocolBufferException e) {
+        } catch (akka.protobufv3.internal.InvalidProtocolBufferException e) {
           parsedMessage =
               (com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
                       .WorkerCoordinates)
                   e.getUnfinishedMessage();
-          throw e;
+          throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
             mergeFrom(parsedMessage);
@@ -3114,13 +3592,13 @@ public final class ProjectionMessages {
       private java.lang.Object projectionName_ = "";
       /** <code>required string projectionName = 1;</code> */
       public boolean hasProjectionName() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
+        return ((bitField0_ & 0x00000001) != 0);
       }
       /** <code>required string projectionName = 1;</code> */
       public java.lang.String getProjectionName() {
         java.lang.Object ref = projectionName_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             projectionName_ = s;
@@ -3131,15 +3609,15 @@ public final class ProjectionMessages {
         }
       }
       /** <code>required string projectionName = 1;</code> */
-      public akka.protobuf.ByteString getProjectionNameBytes() {
+      public akka.protobufv3.internal.ByteString getProjectionNameBytes() {
         java.lang.Object ref = projectionName_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           projectionName_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string projectionName = 1;</code> */
@@ -3160,7 +3638,7 @@ public final class ProjectionMessages {
         return this;
       }
       /** <code>required string projectionName = 1;</code> */
-      public Builder setProjectionNameBytes(akka.protobuf.ByteString value) {
+      public Builder setProjectionNameBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -3173,13 +3651,13 @@ public final class ProjectionMessages {
       private java.lang.Object tagName_ = "";
       /** <code>required string tagName = 2;</code> */
       public boolean hasTagName() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000002) != 0);
       }
       /** <code>required string tagName = 2;</code> */
       public java.lang.String getTagName() {
         java.lang.Object ref = tagName_;
         if (!(ref instanceof java.lang.String)) {
-          akka.protobuf.ByteString bs = (akka.protobuf.ByteString) ref;
+          akka.protobufv3.internal.ByteString bs = (akka.protobufv3.internal.ByteString) ref;
           java.lang.String s = bs.toStringUtf8();
           if (bs.isValidUtf8()) {
             tagName_ = s;
@@ -3190,15 +3668,15 @@ public final class ProjectionMessages {
         }
       }
       /** <code>required string tagName = 2;</code> */
-      public akka.protobuf.ByteString getTagNameBytes() {
+      public akka.protobufv3.internal.ByteString getTagNameBytes() {
         java.lang.Object ref = tagName_;
         if (ref instanceof String) {
-          akka.protobuf.ByteString b =
-              akka.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+          akka.protobufv3.internal.ByteString b =
+              akka.protobufv3.internal.ByteString.copyFromUtf8((java.lang.String) ref);
           tagName_ = b;
           return b;
         } else {
-          return (akka.protobuf.ByteString) ref;
+          return (akka.protobufv3.internal.ByteString) ref;
         }
       }
       /** <code>required string tagName = 2;</code> */
@@ -3219,7 +3697,7 @@ public final class ProjectionMessages {
         return this;
       }
       /** <code>required string tagName = 2;</code> */
-      public Builder setTagNameBytes(akka.protobuf.ByteString value) {
+      public Builder setTagNameBytes(akka.protobufv3.internal.ByteString value) {
         if (value == null) {
           throw new NullPointerException();
         }
@@ -3229,39 +3707,88 @@ public final class ProjectionMessages {
         return this;
       }
 
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final akka.protobufv3.internal.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
       // @@protoc_insertion_point(builder_scope:com.lightbend.lagom.internal.projection.WorkerCoordinates)
     }
 
+    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.WorkerCoordinates)
+    private static final com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        DEFAULT_INSTANCE;
+
     static {
-      defaultInstance = new WorkerCoordinates(true);
-      defaultInstance.initFields();
+      DEFAULT_INSTANCE =
+          new com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+              .WorkerCoordinates();
     }
 
-    // @@protoc_insertion_point(class_scope:com.lightbend.lagom.internal.projection.WorkerCoordinates)
+    public static com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages
+            .WorkerCoordinates
+        getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated
+    public static final akka.protobufv3.internal.Parser<WorkerCoordinates> PARSER =
+        new akka.protobufv3.internal.AbstractParser<WorkerCoordinates>() {
+          @java.lang.Override
+          public WorkerCoordinates parsePartialFrom(
+              akka.protobufv3.internal.CodedInputStream input,
+              akka.protobufv3.internal.ExtensionRegistryLite extensionRegistry)
+              throws akka.protobufv3.internal.InvalidProtocolBufferException {
+            return new WorkerCoordinates(input, extensionRegistry);
+          }
+        };
+
+    public static akka.protobufv3.internal.Parser<WorkerCoordinates> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public akka.protobufv3.internal.Parser<WorkerCoordinates> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.lightbend.lagom.internal.projection.protobuf.msg.ProjectionMessages.WorkerCoordinates
+        getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
   }
 
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_projection_Worker_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_projection_Worker_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_projection_Projection_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_projection_Projection_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_projection_State_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_projection_State_fieldAccessorTable;
-  private static final akka.protobuf.Descriptors.Descriptor
+  private static final akka.protobufv3.internal.Descriptors.Descriptor
       internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_descriptor;
-  private static akka.protobuf.GeneratedMessage.FieldAccessorTable
+  private static final akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable
       internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_fieldAccessorTable;
 
-  public static akka.protobuf.Descriptors.FileDescriptor getDescriptor() {
+  public static akka.protobufv3.internal.Descriptors.FileDescriptor getDescriptor() {
     return descriptor;
   }
 
-  private static akka.protobuf.Descriptors.FileDescriptor descriptor;
+  private static akka.protobufv3.internal.Descriptors.FileDescriptor descriptor;
 
   static {
     java.lang.String[] descriptorData = {
@@ -3274,23 +3801,17 @@ public final class ProjectionMessages {
           + "ion.Worker\"Q\n\005State\022H\n\013projections\030\001 \003(\013"
           + "23.com.lightbend.lagom.internal.projecti"
           + "on.Projection\"<\n\021WorkerCoordinates\022\026\n\016pr"
-          + "ojectionName\030\001 \002(\t\022\017\n\007tagName\030\002 \002(\tB8\n4c",
-      "om.lightbend.lagom.internal.projection.p" + "rotobuf.msgH\001"
+          + "ojectionName\030\001 \002(\t\022\017\n\007tagName\030\002 \002(\tB8\n4c"
+          + "om.lightbend.lagom.internal.projection.p"
+          + "rotobuf.msgH\001"
     };
-    akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
-        new akka.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
-          public akka.protobuf.ExtensionRegistry assignDescriptors(
-              akka.protobuf.Descriptors.FileDescriptor root) {
-            descriptor = root;
-            return null;
-          }
-        };
-    akka.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
-        descriptorData, new akka.protobuf.Descriptors.FileDescriptor[] {}, assigner);
+    descriptor =
+        akka.protobufv3.internal.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+            descriptorData, new akka.protobufv3.internal.Descriptors.FileDescriptor[] {});
     internal_static_com_lightbend_lagom_internal_projection_Worker_descriptor =
         getDescriptor().getMessageTypes().get(0);
     internal_static_com_lightbend_lagom_internal_projection_Worker_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_projection_Worker_descriptor,
             new java.lang.String[] {
               "TagName", "Key", "RequestedStatus", "ObservedStatus",
@@ -3298,7 +3819,7 @@ public final class ProjectionMessages {
     internal_static_com_lightbend_lagom_internal_projection_Projection_descriptor =
         getDescriptor().getMessageTypes().get(1);
     internal_static_com_lightbend_lagom_internal_projection_Projection_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_projection_Projection_descriptor,
             new java.lang.String[] {
               "Name", "Workers",
@@ -3306,7 +3827,7 @@ public final class ProjectionMessages {
     internal_static_com_lightbend_lagom_internal_projection_State_descriptor =
         getDescriptor().getMessageTypes().get(2);
     internal_static_com_lightbend_lagom_internal_projection_State_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_projection_State_descriptor,
             new java.lang.String[] {
               "Projections",
@@ -3314,7 +3835,7 @@ public final class ProjectionMessages {
     internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_descriptor =
         getDescriptor().getMessageTypes().get(3);
     internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_fieldAccessorTable =
-        new akka.protobuf.GeneratedMessage.FieldAccessorTable(
+        new akka.protobufv3.internal.GeneratedMessageV3.FieldAccessorTable(
             internal_static_com_lightbend_lagom_internal_projection_WorkerCoordinates_descriptor,
             new java.lang.String[] {
               "ProjectionName", "TagName",


### PR DESCRIPTION
Along with other scalasteward version bumps.

- `genjavadoc` was https://github.com/lagom/lagom/pull/2265
- `sbt-scalafmt` was #2264 
- play `2.8.0-M5` was #2262 
- play-json `2.8.0-M6` was #2257  
- akka `2.6.0-M7` was #2249 