### PR TITLE
scripted-tests: disable C* and Kafka when possible

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-remote-in-dev/build.sbt
@@ -7,6 +7,7 @@ scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 val netty = "io.netty" % "netty" % "3.10.6.Final"
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 
+// no need for Cassandra and Kafka on this test
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cassandra-overrides-default-configs/build.sbt
@@ -10,6 +10,10 @@ scalaVersion := sys.props.get("scala.version").getOrElse("2.12.9")
 
 interactionMode := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
+lagomCassandraEnabled in ThisBuild := true
+// no need for Kafka on this test
+lagomKafkaEnabled in ThisBuild := false
+
 val CassandraJournalKeyspace       = "cassandra-journal.keyspace"
 val CassandraJournalPort           = "cassandra-journal.port"
 val CassandraSnapshotStoreKeyspace = "cassandra-snapshot-store.keyspace"

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-javadsl/build.sbt
@@ -2,6 +2,7 @@ import play.sbt.PlayImport
 
 scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
+// no need for Cassandra and Kafka on this test
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/external-project-scaladsl/build.sbt
@@ -2,6 +2,7 @@ import play.sbt.PlayImport
 
 scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
+// no need for Cassandra and Kafka on this test
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/http-backend-switch/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/http-backend-switch/build.sbt
@@ -4,6 +4,10 @@ version in ThisBuild := "1.0-SNAPSHOT"
 // the Scala version that will be used for cross-compiled libraries
 scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
+// no need for Cassandra and Kafka on this test
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
 lazy val `server-backend-switch` = (project in file("."))
   .aggregate(`apis`, `netty-impl`, `akka-http-impl`)
 
@@ -24,6 +28,3 @@ lazy val `netty-impl` = (project in file("netty-impl"))
   .disablePlugins(LagomAkkaHttpServer)
   .settings(lagomForkedTestSettings: _*)
   .dependsOn(`apis`)
-
-lagomCassandraEnabled in ThisBuild := false
-lagomKafkaEnabled in ThisBuild := false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/injected-configs/build.sbt
@@ -8,6 +8,11 @@ scalaVersion := sys.props.get("scala.version").getOrElse("2.12.9")
 
 interactionMode := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
+
+lagomCassandraEnabled in ThisBuild := true
+// no need for Kafka on this test
+lagomKafkaEnabled in ThisBuild := false
+
 val CassandraJournalPort       = "cassandra-journal.port"
 val CassandraSnapshotStorePort = "cassandra-snapshot-store.port"
 val LagomCassandraReadPort     = "lagom.persistence.read-side.cassandra.port"

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/build.sbt
@@ -9,9 +9,10 @@ val lombok = "org.projectlombok" % "lombok" % "1.18.8"
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.0" % "provided"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
 
-lagomKafkaEnabled in ThisBuild := false
-lagomCassandraEnabled in ThisBuild := true
 
+lagomCassandraEnabled in ThisBuild := true
+// no need for Kafka on this test
+lagomKafkaEnabled in ThisBuild := false
 
 lazy val `projections-happpy-path` = (project in file(".")).aggregate(`hello-javadsl`, `hello-scaladsl`)
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-javadsl/build.sbt
@@ -4,6 +4,10 @@ interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMo
 
 scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
+// no need for Cassandra and Kafka on this test
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
 lazy val `a-api` = (project in file("a") / "api")
   .settings(
     libraryDependencies += lagomJavadslApi

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-all-scaladsl/build.sbt
@@ -6,6 +6,10 @@ scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 
+// no need for Cassandra and Kafka on this test
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
 lazy val `a-api` = (project in file("a") / "api")
   .settings(
     libraryDependencies += lagomScaladslApi

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-play-on-conf/build.sbt
@@ -4,6 +4,10 @@ interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMo
 
 scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
+// no need for Cassandra and Kafka on this test
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
 lazy val p = (project in file("p"))
   .enablePlugins(PlayJava && LagomPlay)
   .settings(

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-services/build.sbt
@@ -3,3 +3,6 @@ lazy val root = (project in file(".")).enablePlugins(LagomJava)
 lagomUnmanagedServices in ThisBuild := Map("externalservice" -> "http://localhost:6000")
 
 libraryDependencies += lagomJavadslPersistenceCassandra
+
+// no need for Kafka on this test
+lagomKafkaEnabled in ThisBuild := false

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-ssl/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run-ssl/build.sbt
@@ -8,6 +8,10 @@ interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMo
 
 lagomServiceEnableSsl in ThisBuild := true
 
+// no need for Cassandra and Kafka on this test
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
 InputKey[Unit]("makeRequest") := {
   val args                      = Def.spaceDelimited("<url> <status> ...").parsed
   val path :: status :: headers = args

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/run/build.sbt
@@ -6,6 +6,10 @@ scalaVersion := sys.props.get("scala.version").getOrElse("2.12.9")
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
+// no need for Cassandra and Kafka on this test
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
 InputKey[Unit]("verifyReloads") := {
   val expected = Def.spaceDelimited().parsed.head.toInt
   val actual   = IO.readLines(target.value / "reload.log").count(_.nonEmpty)

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/service-discovery/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/service-discovery/build.sbt
@@ -6,6 +6,7 @@ scalaVersion in ThisBuild := sys.props.get("scala.version").getOrElse("2.12.9")
 
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.2.5" % "provided"
 
+// no need for Cassandra and Kafka on this test
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/services-intra-communication/build.sbt
@@ -2,6 +2,10 @@ import com.lightbend.lagom.sbt.Internal.Keys.interactionMode
 
 interactionMode in ThisBuild := com.lightbend.lagom.sbt.NonBlockingInteractionMode
 
+// no need for Cassandra and Kafka on this test
+lagomCassandraEnabled in ThisBuild := false
+lagomKafkaEnabled in ThisBuild := false
+
 lazy val commonSettings = Seq(
   scalaVersion := sys.props.get("scala.version").getOrElse("2.12.9")
 )


### PR DESCRIPTION
This is a minor optimization for the scripts tests. Most of them are starting Cassandra and Kafka while they are not needed. 

This won't have a huge impact on the build time, but there is a small gain. And one or two things less that could fail.