### PR TITLE
Makes scripted test less verbose more resilient

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-javadsl/src/main/java/com/example/hello/api/HelloService.java
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-javadsl/src/main/java/com/example/hello/api/HelloService.java
@@ -26,7 +26,7 @@ public interface HelloService extends Service {
 
     @Override
     default Descriptor descriptor() {
-        return named("hello")
+        return named("hello-java")
             .withCalls(
                 pathCall("/api-java/hello/:id", this::hello),
                 pathCall("/api-java/set/:id/:message", this::useGreeting)

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-javadsl/src/test/resources/logback.xml
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-javadsl/src/test/resources/logback.xml
@@ -11,8 +11,12 @@
 
     <logger name="org.apache.cassandra" level="ERROR" />
     <logger name="com.datastax.driver" level="WARN" />
-
     <logger name="akka" level="WARN" />
+
+    <!-- don't use the following in actual code. These are only to keep scripted tests' output cleaner-->
+    <logger name="com.datastax.driver.core.ControlConnection" level="OFF" />
+    <logger name="akka.stream.scaladsl.RestartWithBackoffSource" level="ERROR" />
+
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-scaladsl/src/main/scala/com/example/helloworld/api/HelloWorldService.scala
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-scaladsl/src/main/scala/com/example/helloworld/api/HelloWorldService.scala
@@ -26,7 +26,7 @@ trait HelloWorldService extends Service {
 
   override final def descriptor: Descriptor = {
     // @formatter:off
-    named("hello-world")
+    named("hello-scala")
       .withCalls(
         pathCall("/api-scala/hello/:id", hello _),
         pathCall("/api-scala/set/:id/:message", useGreeting _)

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-scaladsl/src/test/resources/logback.xml
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/hello-scaladsl/src/test/resources/logback.xml
@@ -11,8 +11,12 @@
 
     <logger name="org.apache.cassandra" level="ERROR" />
     <logger name="com.datastax.driver" level="WARN" />
-
     <logger name="akka" level="WARN" />
+
+    <!-- don't use the following in actual code. These are only to keep scripted tests' output cleaner-->
+    <logger name="com.datastax.driver.core.ControlConnection" level="OFF" />
+    <logger name="akka.stream.scaladsl.RestartWithBackoffSource" level="ERROR" />
+
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/project/plugins.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/project/plugins.sbt
@@ -1,1 +1,2 @@
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-scripted-tools" % sys.props("project.version"))
 addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % sys.props("project.version"))

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/test
@@ -18,6 +18,14 @@
 
 > runAll
 
+# Locator and gateway should be up
+> validateRequest retry-until-success http://localhost:9008
+> validateRequest retry-until-success http://localhost:9000
+
+# Ensure the foo service is reachable
+> validateRequest retry-until-success http://localhost:9008/services/hello-scala status 200
+> validateRequest retry-until-success http://localhost:9000/api-java/hello/Alice status 200
+
 ##
 ## Test the java impl in dev mode
 ##


### PR DESCRIPTION
Supersedes #2286 

Removes useless logs with false negatives and includes awaiting ops so the tests doesn't progress until the database is available.