### PR TITLE
Speed-up scripted by reusing user-wide compiler bridges

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1432,7 +1432,8 @@ def scriptedSettings: Seq[Setting[_]] =
         "-XX:MaxMetaspaceSize=512m",
         "-Dscala.version=" + sys.props
           .get("scripted.scala.version")
-          .getOrElse((scalaVersion in `reloadable-server`).value)
+          .getOrElse((scalaVersion in `reloadable-server`).value),
+        s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
       )
     )
 


### PR DESCRIPTION
Defining "sbt.boot.directory" makes the scripted test (re)use the same
user-shared compiler bridge instead of compiling one every time.