### PR TITLE
Fix typo in bash code

### DIFF
--- a/bin/changelog.sh
+++ b/bin/changelog.sh
@@ -14,11 +14,11 @@
 
 
 FROM=$1
-if [ $2 ]; then
-  TO=$2
+if [ "$2" ]; then
+  TO="$2"
 else
   TO=HEAD
 fi
 
 echo "Changelog from $FROM to $TO"
-  git log --pretty=format:"%s %an" $FROM..$TO | sed 's/\(.*\)(#\([0-9]*\)) \(.*\)/\* [\2](https:\/\/github.com\/lagom\/lagom\/issues\/\2) \1(\3)/'
+  git log --pretty=format:"%s %an" "$FROM".."$TO" | sed 's/\(.*\)(#\([0-9]*\)) \(.*\)/\* [\2](https:\/\/github.com\/lagom\/lagom\/issues\/\2) \1(\3)/'

--- a/bin/local-pr-validation.sh
+++ b/bin/local-pr-validation.sh
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 printMessage "VALIDATE FRAMEWORK CODE"

--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -11,7 +11,7 @@ set -o pipefail
 # CURRENT_BRANCH is used when updating Whitesource to determine the correct project name
 export CURRENT_BRANCH=${TRAVIS_BRANCH}
 
-EXTRA_OPTS="-Dakka.test.timefactor=10"
+EXTRA_OPTS=("-Dakka.test.timefactor=10")
 
 # Check if it is a scheduled build
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
@@ -20,15 +20,15 @@ if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
 
     echo "Using Akka SNAPSHOT ${AKKA_VERSION}"
 
-    EXTRA_OPTS="${EXTRA_OPTS} -Dlagom.build.akka.version=${AKKA_VERSION}"
+    EXTRA_OPTS+=("-Dlagom.build.akka.version=${AKKA_VERSION}")
 fi
 
 runSbt() {
-  sbt ${EXTRA_OPTS} --warn 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
+  sbt "${EXTRA_OPTS[@]}" --warn 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
 }
 
 runSbtNoisy() {
-  sbt ${EXTRA_OPTS} 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
+  sbt "${EXTRA_OPTS[@]}" 'set concurrentRestrictions in Global += Tags.limitAll(1)' "$@"
 }
 
 

--- a/bin/test-2.1x
+++ b/bin/test-2.1x
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 runSbtNoisy "++${SCALA_VERSION} test"

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -2,8 +2,8 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
-
 
 ## The following are three separate `sbt` invocations because in some versions of sbt (0.13)
 ## trying to run all tasks in a single session caused "GC overhead limit exceeded" (both in
@@ -21,7 +21,7 @@ if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
     EXTRA_TASKS+=("validateDependencies")
 fi
 
-runSbt  ${EXTRA_TASKS[@]} \
+runSbt  "${EXTRA_TASKS[@]}" \
         +mimaReportBinaryIssues
 
 printMessage "VALIDATE SCALA CODE FORMATTING"

--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -21,7 +21,7 @@ if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
     EXTRA_TASKS+=("validateDependencies")
 fi
 
-runSbt  ${EXTRA_TASK[@]} \
+runSbt  ${EXTRA_TASKS[@]} \
         +mimaReportBinaryIssues
 
 printMessage "VALIDATE SCALA CODE FORMATTING"

--- a/bin/test-docs-code-only
+++ b/bin/test-docs-code-only
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 ## This is a simplified version of ./bin/test-documentation to only run `sbt test`

--- a/bin/test-documentation
+++ b/bin/test-documentation
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 runSbt unidoc

--- a/bin/test-maven
+++ b/bin/test-maven
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 runSbt publishM2
@@ -14,7 +15,8 @@ validate_pom_files() {
   # Downloads maven schema file which will be used to validate the generated pom file
   wget -c http://maven.apache.org/xsd/maven-4.0.0.xsd
 
-  for f in $(find . -name *.pom); do
+  shopt -s globstar nullglob
+  for f in **/*.pom; do
     echo "Validating file $f"
     xmllint --noout -schema maven-4.0.0.xsd "${f}"
 

--- a/bin/test-multi-jvm-2.1x
+++ b/bin/test-multi-jvm-2.1x
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 runSbtNoisy "++${SCALA_VERSION} multi-jvm:test"

--- a/bin/test-sbt
+++ b/bin/test-sbt
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
 
+# shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
 SCALA_VERSION="${SCALA_VERSION:-2.12.9}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -201,7 +201,10 @@ object Dependencies {
     ) ++ libraryFamily("com.fasterxml.jackson.module", Versions.JacksonDatatype)(
       "jackson-module-parameter-names",
       "jackson-module-paranamer"
-    ) ++ libraryFamily("com.fasterxml.jackson.dataformat", Versions.JacksonDatatype)(
+    ) ++ Seq("com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.JacksonDatatype) ++ libraryFamily(
+      "com.fasterxml.jackson.dataformat",
+      Versions.JacksonDatatype
+    )(
       "jackson-dataformat-cbor",
     )
 
@@ -489,12 +492,13 @@ object Dependencies {
     guava,
     // Upgrades needed to match whitelist versions
     sslConfig,
+    pcollections,
     playJson,
     jnrFfi,
     jffi,
     jnra64asm,
     jnrConstants,
-  ) ++ ow2asmDeps // to match whitelist versions
+  ) ++ jacksonFamily ++ ow2asmDeps // to match whitelist versions
 
   val `api-javadsl` = libraryDependencies ++= Seq(
     playJava,
@@ -569,7 +573,8 @@ object Dependencies {
     jffi,
     jnra64asm,
     jnrConstants,
-  ) ++ ow2asmDeps // to match whitelist versions
+    pcollections,
+  ) ++ jacksonFamily ++ ow2asmDeps // to match whitelist versions
 
   val client = libraryDependencies ++= Seq(
     slf4jApi,
@@ -598,7 +603,9 @@ object Dependencies {
     // we need to explicitly add akka-remote in test scope
     // because the test for LagomClientFactory needs it
     akkaRemote % Test,
-    scalaTest  % Test
+    scalaTest  % Test,
+    // Upgrades needed to match whitelist versions
+    scalaCollectionCompat,
   )
 
   val server = libraryDependencies ++= Nil
@@ -626,6 +633,7 @@ object Dependencies {
     playJson,
     akkaSlf4j,
     scalaXml,
+    jffi,
     jnrConstants,
     jnrPosix
   )
@@ -711,7 +719,8 @@ object Dependencies {
     jffi,
     jnra64asm,
     jnrConstants,
-  ) ++ ow2asmDeps // to match whitelist versions
+    pcollections,
+  ) ++ jacksonFamily ++ ow2asmDeps // to match whitelist versions
 
   val `akka-management-javadsl`  = libraryDependencies ++= Seq.empty[ModuleID]
   val `akka-management-scaladsl` = libraryDependencies ++= Seq.empty[ModuleID]
@@ -754,7 +763,9 @@ object Dependencies {
     akkaMultiNodeTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
-    "com.novocode"       % "junit-interface" % "0.11" % Test
+    "com.novocode"       % "junit-interface" % "0.11" % Test,
+    // Upgrades needed to match whitelist versions
+    slf4jApi,
   )
 
   val `cluster-scaladsl` = libraryDependencies ++= Seq(
@@ -770,7 +781,9 @@ object Dependencies {
     // explicitly depend on particular versions of jackson
   ) ++ jacksonFamily ++ Seq(
     // explicitly depend on particular versions of guava
-    guava
+    guava,
+    // Upgrades needed to match whitelist versions
+    slf4jApi,
   )
 
   val `pubsub-javadsl` = libraryDependencies ++= Seq(
@@ -893,7 +906,8 @@ object Dependencies {
     // Upgrades needed to match whitelist versions
     scalaCollectionCompat,
     scalaXml,
-    jnrConstants
+    jnrConstants,
+    pcollections,
   )
 
   val `persistence-jdbc-javadsl` = libraryDependencies ++= Seq(
@@ -924,7 +938,8 @@ object Dependencies {
     scalaTest % Test,
     // Upgrades needed to match whitelist versions
     sslConfig,
-    kafkaClients
+    kafkaClients,
+    scalaCollectionCompat,
   )
 
   val `kafka-client-javadsl` = libraryDependencies ++= Seq(
@@ -946,7 +961,9 @@ object Dependencies {
   val `kafka-broker` = libraryDependencies ++= Seq(
     kafkaClients,
     // Upgrades needed to match whitelist versions
-    jnrConstants
+    jnrConstants,
+    pcollections,
+    scalaCollectionCompat,
   )
 
   val `kafka-broker-javadsl` = libraryDependencies ++= Seq(
@@ -984,11 +1001,15 @@ object Dependencies {
     jffi,
     jnra64asm,
     jnrConstants,
-  ) ++ ow2asmDeps ++ Seq("logback-core", "logback-classic").map("ch.qos.logback" % _ % Versions.Logback)
+    pcollections,
+  ) ++ jacksonFamily ++ ow2asmDeps ++ Seq("logback-core", "logback-classic").map(
+    "ch.qos.logback" % _ % Versions.Logback
+  )
 
   val log4j2 = libraryDependencies ++= Seq(slf4jApi) ++
     log4jModules ++
     ow2asmDeps ++ // to match whitelist versions
+    jacksonFamily ++
     Seq(
       "com.lmax" % "disruptor" % Versions.Disruptor,
       play,
@@ -1007,6 +1028,7 @@ object Dependencies {
       jffi,
       jnra64asm,
       jnrConstants,
+      pcollections,
     )
 
   val `reloadable-server` = libraryDependencies ++= Seq(
@@ -1084,11 +1106,12 @@ object Dependencies {
     akkaStream,
     akkaProtobuf_v3,
     akkaSlf4j,
+    pcollections,
     typesafeConfig,
     sslConfig,
     scalaXml,
     playJson,
-  )
+  ) ++ jacksonFamily
 
   val `service-registry-client-core` =
     libraryDependencies ++= Seq(


### PR DESCRIPTION
This typo caused `validateDependencies` and `versionSyncCheck` to not run. We've been on the blind for a while.

This Pr will fail on unrelated issues as those two tasks are rerun for a first time after a while.