### PR TITLE
Hide private binding (ProjectionRegistry) from DI

### DIFF
--- a/projection/javadsl/src/main/scala/com/lightbend/lagom/javadsl/projection/ProjectionRegistryModule.scala
+++ b/projection/javadsl/src/main/scala/com/lightbend/lagom/javadsl/projection/ProjectionRegistryModule.scala
@@ -30,27 +30,17 @@ import scala.concurrent.ExecutionContext
 class ProjectionRegistryModule extends Module {
 
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
-    bind[ProjectionRegistry].toProvider[ProjectionRegistryProvider], // for internal use
     bind[Projections].to(classOf[ProjectionsImpl])                   // for end users
   )
 }
 
 @Singleton
 @InternalApi
-// This provider is trivial but required to keep ProjectionRegistry in `-core` and free of any Guice dependency
 /** INTERNAL API */
-private[lagom] class ProjectionRegistryProvider @Inject()(actorSystem: ActorSystem)
-    extends Provider[ProjectionRegistry] {
-  override def get(): ProjectionRegistry = instance
-  private val instance                   = new ProjectionRegistry(actorSystem)
-}
-
-@Singleton
-@InternalApi
-/** INTERNAL API */
-private class ProjectionsImpl @Inject()(registry: ProjectionRegistry)(
-    implicit executionContext: ExecutionContext
+private class ProjectionsImpl @Inject()(actorSystem: ActorSystem)(
+implicit executionContext: ExecutionContext
 ) extends Projections {
+  private val registry:  ProjectionRegistry = new ProjectionRegistry(actorSystem)
 
   import FutureConverters._
 

--- a/projection/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/projection/ProjectionComponents.scala
+++ b/projection/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/projection/ProjectionComponents.scala
@@ -16,7 +16,8 @@ import com.lightbend.lagom.scaladsl.cluster.ClusterComponents
 trait ProjectionComponents extends ClusterComponents {
   def actorSystem: ActorSystem
 
-  private[lagom] lazy val projectionRegistry: ProjectionRegistry = new ProjectionRegistry(actorSystem)
-  lazy val projections: Projections                              = new Projections(projectionRegistry)
-
+  lazy val projections: Projections = {
+    val projectionRegistry: ProjectionRegistry = new ProjectionRegistry(actorSystem)
+    new Projections(projectionRegistry)
+  }
 }


### PR DESCRIPTION
when first implemented projections I didn't realized `ProjectionsRegistry` can be kept from user's access by not even creating a binding. 

While doing some other stuff I realised we can completely take it away from the DI -exposed bindings in both Guice and thin cake.