### PR TITLE
rename injectable instance to 'clusterSharding'

### DIFF
--- a/cluster/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/cluster/typed/ClusterShardingTypedComponents.scala
+++ b/cluster/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/cluster/typed/ClusterShardingTypedComponents.scala
@@ -16,7 +16,7 @@ import akka.cluster.sharding.typed.scaladsl.ClusterSharding
 trait ClusterShardingTypedComponents {
   def actorSystem: ActorSystemClassic
 
-  lazy val clusterShardingTyped: ClusterSharding = {
+  lazy val clusterSharding: ClusterSharding = {
     val actorSystemTyped: ActorSystem[_] = {
       import akka.actor.typed.scaladsl.adapter._
       actorSystem.toTyped


### PR DESCRIPTION
I noticed that the name of the instance for the typed `ClusterSharding` was set to `clusterShardingTyped`. 

This is not what we want because the Play ClusterSharding components is using `clusterSharding` and one day we want to remove this component from Lagom and  use the one in Play without impacting users. 

Morefore, the adjective 'typed' is not adding much value here. As we adopt Akka Typed more and more, we don't have the need to qualify things. 

And from a user perspective, they need to understand cluster sharding, but the fact that is a typed one is irrelevant for the actual usage. The user only needs to learn they need to register (ie: `init`) on `ClusterSharding` and lookup (ie: `entityRefFor`). 