### PR TITLE
Compression configuration with Akka 2.6.0-RC1

### DIFF
--- a/docs/manual/java/guide/cluster/Serialization.md
+++ b/docs/manual/java/guide/cluster/Serialization.md
@@ -34,7 +34,7 @@ JSON can be rather verbose and for large messages it can be beneficial to enable
 
 @[compressed-jsonable](code/docs/home/serialization/AbstractAuthor.java)
 
-The serializer will by default only compress messages that are larger than 32 Kb. This threshold can be changed with configuration property `akka.serialization.jackson.jackson-json-gzip.compress-larger-than`.
+The serializer will by default only compress messages that are larger than 32 KiB. This threshold can be changed with configuration property `akka.serialization.jackson.jackson-json-compressed.compression.compress-larger-than`.
 
 ## Schema Evolution
 

--- a/docs/manual/java/releases/Migration16.md
+++ b/docs/manual/java/releases/Migration16.md
@@ -61,12 +61,12 @@ akka.serialization.jackson {
 
 #### Configuration changes
 
-* `lagom.serialization.json.compress-larger-than` is now configured with `akka.serialization.jackson.jackson-json-gzip.compress-larger-than`
+* `lagom.serialization.json.compress-larger-than` is now configured with `akka.serialization.jackson.jackson-json-compressed.compression.compress-larger-than`
 * `lagom.serialization.json.jackson-modules` is now configured in `akka.serialization.jackson.jackson-modules`
 
 #### JSON Compression threshold
 
-When marking a serializable class with `CompressedJsonable` compression will only kick in when the serialized representation goes past a threshold. The default value for `akka.serialization.jackson.jackson-json-gzip.compress-larger-than` is 32 Kilobytes. As mentioned above, this setting was previously configure by `lagom.serialization.json.compress-larger-than` and defaulted to 1024 bytes. (See [#1983](https://github.com/lagom/lagom/pull/1983))
+When marking a serializable class with `CompressedJsonable` compression will only kick in when the serialized representation goes past a threshold. The default value for `akka.serialization.jackson.jackson-json-compressed.compression.compress-larger-than` is 32 Kilobytes. As mentioned above, this setting was previously configure by `lagom.serialization.json.compress-larger-than` and defaulted to 1024 bytes. (See [#1983](https://github.com/lagom/lagom/pull/1983))
 
 ### Remoting Artery
 

--- a/jackson/src/main/resources/play/reference-overrides.conf
+++ b/jackson/src/main/resources/play/reference-overrides.conf
@@ -1,0 +1,7 @@
+akka.serialization.jackson {
+  jackson-json {
+    # No compression for message class that implements the Jsonable marker interface.
+    # Compression is enabled for jackson-json-compressed binding (CompressedJsonable) in reference.conf.
+    compression.algorithm = off
+  }
+}

--- a/jackson/src/main/resources/reference.conf
+++ b/jackson/src/main/resources/reference.conf
@@ -10,21 +10,21 @@ akka.actor {
     old-lagom-json = "akka.serialization.jackson.JacksonJsonSerializer"
 
     # For CompressedJsonable
-    jackson-json-gzip = "akka.serialization.jackson.JacksonJsonSerializer"
+    jackson-json-compressed = "akka.serialization.jackson.JacksonJsonSerializer"
   }
   serialization-bindings {
     # Bind Jsonable to Akka JacksonJsonSerializer
     "com.lightbend.lagom.serialization.Jsonable" = jackson-json
 
     # Bind Jsonable to Akka JacksonJsonSerializer with compression settings
-    "com.lightbend.lagom.serialization.CompressedJsonable" = jackson-json-gzip
+    "com.lightbend.lagom.serialization.CompressedJsonable" = jackson-json-compressed
   }
   serialization-identifiers {
     # For Lagom 1.5.x JacksonSerializer.
     "old-lagom-json" = 1000002
 
     # For CompressedJsonable
-    "jackson-json-gzip" = 1000005
+    "jackson-json-compressed" = 1000005
   }
 }
 
@@ -38,18 +38,18 @@ akka.serialization.jackson {
 #//#jackson-modules
 
 akka.serialization.jackson {
-  jackson-json {
-    # No compression for message class that implements the Jsonable marker interface.
-    # FIXME this config will probably change in Akka 2.6.0-M4
-    compress-larger-than = off
-  }
+  # compression is disabled for jackson-json binding in play/reference-overrides.conf
 
-  jackson-json-gzip {
-    # The serializer will compress the payload if the message class
-    # implements the CompressedJsonable marker interface and the payload
-    # is larger than this value. Only used for remote messages and persistent data
-    # within the cluster of the service.
-    compress-larger-than = 32 KiB
+  jackson-json-compressed {
+    compression {
+      algorithm = gzip
+
+      # The serializer will compress the payload if the message class
+      # implements the CompressedJsonable marker interface and the payload
+      # is larger than this value. Only used for remote messages and persistent data
+      # within the cluster of the service.
+      compress-larger-than = 32 KiB
+    }
   }
 
   # Configuration of the ObjectMapper for external service api can be defined here

--- a/jackson/src/test/java/com/lightbend/lagom/serialization/JacksonJsonSerializerTest.java
+++ b/jackson/src/test/java/com/lightbend/lagom/serialization/JacksonJsonSerializerTest.java
@@ -47,9 +47,13 @@ public class JacksonJsonSerializerTest {
             "akka.serialization.jackson.migrations {\n"
                 + "  \"com.lightbend.lagom.serialization.Event1\" = \"com.lightbend.lagom.serialization.TestEventMigration\" \n"
                 + "  \"com.lightbend.lagom.serialization.Event2\" = \"com.lightbend.lagom.serialization.TestEventMigration\" \n"
-                + "}\n");
+                + "}\n"
+                // the following is defined in pla/reference-overrides.conf, but this test is not
+                // running with
+                // Play/Lagom config loading
+                + "akka.serialization.jackson.jackson-json.compression.algorithm = off \n");
     // @formatter:on
-    system = ActorSystem.create("HelloWorldTest", conf);
+    system = ActorSystem.create("JacksonJsonSerializerTest", conf);
   }
 
   @AfterClass


### PR DESCRIPTION
## Purpose

Change compression configuration from `akka.serialization.jackson.jackson-json-gzip.compress-larger-than` to `akka.serialization.jackson.jackson-json-gzip.compression.compress-larger-than`.

## Background Context

Configuration changed in Akka to prepare for other compression algorithms than gzip, for example lz4.

## References

Change in Akka https://github.com/akka/akka/pull/27889
