### PR TITLE
Logback and slf4j no longer use HTTPS

### DIFF
--- a/docs/manual/common/concepts/ComponentTechnologies.md
+++ b/docs/manual/common/concepts/ComponentTechnologies.md
@@ -22,7 +22,7 @@ As a complete microservices platform, Lagom assembles a collection of technologi
 
 * Guice --- Like Play, Lagom uses [Guice](https://github.com/google/guice) for dependency injection.
 
-* SLF4J & Logback --- Lagom uses [SLF4J](https://www.slf4j.org/) for logging, backed by [Logback](https://logback.qos.ch/) as its default logging engine. See [[Logging]] for more information.
+* SLF4J & Logback --- Lagom uses [SLF4J](http://www.slf4j.org/) for logging, backed by [Logback](http://logback.qos.ch/) as its default logging engine. See [[Logging]] for more information.
 
 * Typesafe Config Library --- Lagom and many of its component technologies are configured using the [Typesafe Config](https://github.com/typesafehub/config) library.  The configuration file format is [HOCON](https://github.com/typesafehub/config/blob/master/HOCON.md), a powerful and expressive superset of JSON.
 

--- a/docs/manual/common/guide/logging/SettingsLogger.md
+++ b/docs/manual/common/guide/logging/SettingsLogger.md
@@ -1,6 +1,6 @@
 # Configuring Logging
 
-Lagom uses SLF4J for logging, backed by [Logback](https://logback.qos.ch/) as its default logging engine.  See the [Logback documentation](https://logback.qos.ch/manual/configuration.html) for details on configuration.
+Lagom uses SLF4J for logging, backed by [Logback](http://logback.qos.ch/) as its default logging engine.  See the [Logback documentation](http://logback.qos.ch/manual/configuration.html) for details on configuration.
 
 ## Default configuration
 
@@ -16,7 +16,7 @@ A few things to note:
 
 * The logger logs full exception stack traces and full-qualified logger names.
 * Lagom uses ANSI color codes by default in level messages.
-* In production, Lagom puts the logger behind the logback [AsyncAppender](https://logback.qos.ch/manual/appenders.html#AsyncAppender).  For details on the performance implications on this, see this [blog post](https://blog.takipi.com/how-to-instantly-improve-your-java-logging-with-7-logback-tweaks/).
+* In production, Lagom puts the logger behind the logback [AsyncAppender](http://logback.qos.ch/manual/appenders.html#AsyncAppender).  For details on the performance implications on this, see this [blog post](https://blog.takipi.com/how-to-instantly-improve-your-java-logging-with-7-logback-tweaks/).
 
 ## Custom configuration
 

--- a/docs/manual/java/guide/logging/Logging.md
+++ b/docs/manual/java/guide/logging/Logging.md
@@ -1,10 +1,10 @@
 # Logging
 
-Lagom uses SLF4J for logging, backed by [Logback](https://logback.qos.ch/) as its default logging engine. Here is a short example showcasing how you can access the logger:
+Lagom uses SLF4J for logging, backed by [Logback](http://logback.qos.ch/) as its default logging engine. Here is a short example showcasing how you can access the logger:
 
 @[](code/docs/javadsl/logging/LoggingExample.java)
 
-And you can read of more advanced usages on the [SLF4J user manual](https://www.slf4j.org/manual.html).
+And you can read of more advanced usages on the [SLF4J user manual](http://www.slf4j.org/manual.html).
 
 If you're using maven, you'll need to add the Lagom logback dependency to your classpath to get Logback support:
 

--- a/docs/manual/scala/guide/logging/Logging.md
+++ b/docs/manual/scala/guide/logging/Logging.md
@@ -1,10 +1,10 @@
 # Logging
 
-Lagom uses SLF4J for logging, backed by [Logback](https://logback.qos.ch/) as its default logging engine. Here is a short example showcasing how you can access the logger:
+Lagom uses SLF4J for logging, backed by [Logback](http://logback.qos.ch/) as its default logging engine. Here is a short example showcasing how you can access the logger:
 
 @[](code/docs/scaladsl/logging/LoggingExample.scala)
 
-And you can read of more advanced usages on the [SLF4J user manual](https://www.slf4j.org/manual.html).
+And you can read of more advanced usages on the [SLF4J user manual](http://www.slf4j.org/manual.html).
 
 If you're using maven, you'll need to add the Lagom logback dependency to your classpath to get Logback support:
 


### PR DESCRIPTION
This caused a `CRON` job failure: https://travis-ci.com/lagom/lagom/jobs/244379233#L2074