### PR TITLE
Move shutdown-after-unsuccessful-join-seed-nodes

### DIFF
--- a/cluster/core/src/main/resources/play/reference-overrides.conf
+++ b/cluster/core/src/main/resources/play/reference-overrides.conf
@@ -8,6 +8,10 @@ akka {
     # Make cluster failure detector more tolerant, by default
     failure-detector.acceptable-heartbeat-pause = 5 s
 
+    # Shut down the actor system if it can't join a cluster after 60s
+    # Useful in production environments to let the deployment orchestration solutions restart the service
+    shutdown-after-unsuccessful-join-seed-nodes = 60s
+
     # Enable Split Brain Resolver keep-majority if Lightbend Platform is used
     split-brain-resolver.active-strategy = keep-majority
 

--- a/cluster/core/src/main/resources/reference.conf
+++ b/cluster/core/src/main/resources/reference.conf
@@ -20,10 +20,6 @@ lagom.cluster {
 }
 lagom.defaults.cluster.join-self = off
 
-# shutdown the actor system if it can't join a cluster after 60s
-# useful in production environments to let the deployment orchestration solutions restart the service
-akka.cluster.shutdown-after-unsuccessful-join-seed-nodes = 60s
-
 # Cluster distribution settings
 lagom.persistence.cluster.distribution {
 


### PR DESCRIPTION
This should be in reference-overrides.conf since it overrides an Akka setting.