### PR TITLE
#1334 remove SBT_OPTS documentation in favor of .jvmopts

### DIFF
--- a/docs/manual/common/guide/build/JVMMemoryOnDev.md
+++ b/docs/manual/common/guide/build/JVMMemoryOnDev.md
@@ -19,12 +19,6 @@ Stating the `MAVEN_OPTS` on every invocation is error prone and exporting it glo
 
 ## sbt
 
-You can start sbt with extra memory using `SBT_OPTS` environment variable.
-
-```bash
-$ SBT_OPTS="-Xms512M -Xmx1024M -Xss2M -XX:MaxMetaspaceSize=1024M" sbt
-```
-
 sbt lets you list the JVM options you need to run your project on a file named `.jvmopts` in the root of your project.
 
 ```


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #1334.

## Purpose

What does this PR do?

## Background Context

I haven't really found a documentation page about the `.jvmopts` on the sbt website, but in my opinion it is fine like that as the page already includes an example on how to use the `.jvmopts`

## References

#1334 
