### PR TITLE
Fix scripted tests using Akka 2.6

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-persistence-typed-migration-java/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-persistence-typed-migration-java/test
@@ -1,5 +1,3 @@
-# PENDING, see https://github.com/lagom/lagom/issues/2357
-
 # Structure of this test:
 # =======================
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-persistence-typed-migration-scala/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-persistence-typed-migration-scala/test
@@ -1,5 +1,3 @@
-# PENDING, see https://github.com/lagom/lagom/issues/2357
-
 # Structure of this test:
 # =======================
 

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -4,8 +4,6 @@
 
 package com.lightbend.lagom.internal.javadsl.persistence.cassandra
 
-import java.util.Optional
-
 import javax.inject.Inject
 import javax.inject.Singleton
 import akka.actor.ActorSystem
@@ -20,13 +18,11 @@ import play.api.inject.Injector
  */
 @Singleton
 private[lagom] final class CassandraPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector)
-    extends AbstractPersistentEntityRegistry(system, injector) {
+    extends AbstractPersistentEntityRegistry(system, injector, CassandraReadJournal.Identifier) {
 
   private val log = Logging.getLogger(system, getClass)
 
   CassandraKeyspaceConfig.validateKeyspace("cassandra-journal", system.settings.config, log)
   CassandraKeyspaceConfig.validateKeyspace("cassandra-snapshot-store", system.settings.config, log)
-
-  protected override val queryPluginId = Optional.of(CassandraReadJournal.Identifier)
 
 }

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -16,12 +16,11 @@ import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntit
  * Internal API
  */
 private[lagom] final class CassandraPersistentEntityRegistry(system: ActorSystem)
-    extends AbstractPersistentEntityRegistry(system) {
+    extends AbstractPersistentEntityRegistry(system, CassandraReadJournal.Identifier) {
 
   private val log = Logging.getLogger(system, getClass)
 
   CassandraKeyspaceConfig.validateKeyspace("cassandra-journal", system.settings.config, log)
   CassandraKeyspaceConfig.validateKeyspace("cassandra-snapshot-store", system.settings.config, log)
 
-  protected override val queryPluginId = Some(CassandraReadJournal.Identifier)
 }

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -4,8 +4,6 @@
 
 package com.lightbend.lagom.internal.javadsl.persistence.jdbc
 
-import java.util.Optional
-
 import javax.inject.Inject
 import javax.inject.Singleton
 import akka.actor.ActorSystem
@@ -22,7 +20,7 @@ private[lagom] final class JdbcPersistentEntityRegistry @Inject() (
     system: ActorSystem,
     injector: Injector,
     slickProvider: SlickProvider
-) extends AbstractPersistentEntityRegistry(system, injector) {
+) extends AbstractPersistentEntityRegistry(system, injector, JdbcReadJournal.Identifier) {
 
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 
@@ -30,7 +28,5 @@ private[lagom] final class JdbcPersistentEntityRegistry @Inject() (
     ensureTablesCreated
     super.register(entityClass)
   }
-
-  protected override val queryPluginId = Optional.of(JdbcReadJournal.Identifier)
 
 }

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -19,7 +19,7 @@ import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
  * INTERNAL API
  */
 private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, slickProvider: SlickProvider)
-    extends AbstractPersistentEntityRegistry(system) {
+    extends AbstractPersistentEntityRegistry(system, JdbcReadJournal.Identifier) {
 
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 
@@ -27,7 +27,5 @@ private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, sli
     ensureTablesCreated
     super.register(entityFactory)
   }
-
-  protected override val queryPluginId = Some(JdbcReadJournal.Identifier)
 
 }

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -34,15 +34,17 @@ import scala.reflect.ClassTag
  *
  * Akka persistence plugins can extend this to implement a custom registry.
  */
-class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEntityRegistry {
+class AbstractPersistentEntityRegistry(
+    system: ActorSystem,
+    queryPluginId: String,
+) extends PersistentEntityRegistry {
 
-  protected val name: Option[String]          = None
-  protected val journalPluginId: String       = ""
-  protected val snapshotPluginId: String      = ""
-  protected val queryPluginId: Option[String] = None
+  protected val name: Option[String]     = None
+  protected val journalPluginId: String  = ""
+  protected val snapshotPluginId: String = ""
 
-  private lazy val eventsByTagQuery: Option[EventsByTagQuery] =
-    queryPluginId.map(id => PersistenceQuery(system).readJournalFor[EventsByTagQuery](id))
+  private val persistenceQuery: PersistenceQuery = PersistenceQuery(system)
+  private val eventsByTagQuery: EventsByTagQuery = persistenceQuery.readJournalFor(queryPluginId)
 
   private val sharding = ClusterSharding(system)
   private val conf     = system.settings.config.getConfig("lagom.persistence")
@@ -131,25 +133,18 @@ class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEn
       aggregateTag: AggregateEventTag[Event],
       fromOffset: Offset
   ): scaladsl.Source[EventStreamElement[Event], NotUsed] = {
-    eventsByTagQuery match {
-      case Some(queries) =>
-        val tag = aggregateTag.tag
+    val tag = aggregateTag.tag
 
-        queries
-          .eventsByTag(tag, fromOffset)
-          .map(
-            env =>
-              new EventStreamElement[Event](
-                PersistentEntityActor.extractEntityId(env.persistenceId),
-                env.event.asInstanceOf[Event],
-                env.offset
-              )
+    eventsByTagQuery
+      .eventsByTag(tag, fromOffset)
+      .map(
+        env =>
+          new EventStreamElement[Event](
+            PersistentEntityActor.extractEntityId(env.persistenceId),
+            env.event.asInstanceOf[Event],
+            env.offset
           )
-      case None =>
-        throw new UnsupportedOperationException(
-          s"The Lagom persistence plugin does not support streaming events by tag"
-        )
-    }
+      )
   }
 
 }


### PR DESCRIPTION
Make AbstractPersistentEntityRegistry's eventsByTagQuery non-lazy, so
that it doesn't run into a thread starvation issue on environments like
Travis CI.

Then make its queryPluginId a constructor parameter (and non-optional)
so that it doesn't run into initialisation order issues.

Fixes #2357