### PR TITLE
Marks AkkaTaggerAdapter as ApiMayChange

### DIFF
--- a/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/AkkaTaggerAdapter.java
+++ b/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/AkkaTaggerAdapter.java
@@ -4,11 +4,13 @@
 
 package com.lightbend.lagom.javadsl.persistence;
 
+import akka.annotation.ApiMayChange;
 import akka.cluster.sharding.typed.javadsl.EntityContext;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
+@ApiMayChange
 public class AkkaTaggerAdapter {
 
   /**

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AkkaTaggerAdapter.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AkkaTaggerAdapter.scala
@@ -4,8 +4,10 @@
 
 package com.lightbend.lagom.scaladsl.persistence
 
+import akka.annotation.ApiMayChange
 import akka.cluster.sharding.typed.scaladsl.EntityContext
 
+@ApiMayChange
 object AkkaTaggerAdapter {
 
   /**


### PR DESCRIPTION
As I was rewriting lagom/lagom-scala.g8 and lagom/lagom-java.g8 to use Akka Persistence Typed I kept stumbling upon `EntityContext` on the `Aggregate` code. I think there's some for a second review of the API of `AkkaTaggerAdapter` but I'd like inputs from users on that.

In the meantime, we can mark it as `@ApiMayChange` to stay on the safe side.