### PR TITLE
Remove unnecessary `maven-enforcer-plugin` from maven archetype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1410,8 +1410,8 @@ lazy val `maven-plugin` = (project in file("dev") / "maven-plugin")
     pomExtra ~= (existingPomExtra => {
       existingPomExtra ++
         <prerequisites>
-        <maven>{Dependencies.Versions.Maven}</maven>
-      </prerequisites>
+          <maven>{CrossVersion.partialVersion(Dependencies.Versions.Maven).get.productIterator.mkString(".")}</maven>
+        </prerequisites>
     })
   )
   .dependsOn(`build-tool-support`)

--- a/dev/archetypes/maven-java/src/main/resources/archetype-resources/pom.xml
+++ b/dev/archetypes/maven-java/src/main/resources/archetype-resources/pom.xml
@@ -45,27 +45,6 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce-maven-version</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <!-- Lagom requires at least Maven version 3.6.0 -->
-                                <requireMavenVersion>
-                                    <version>[3.6.0,)</version>
-                                </requireMavenVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/docs/manual/java/gettingstarted/GettingStartedMaven.md
+++ b/docs/manual/java/gettingstarted/GettingStartedMaven.md
@@ -1,6 +1,6 @@
 # Creating and running Hello World with Maven
 
-> **Note**: Lagom requires Maven 3.6.2 or later.
+> **Note**: Lagom requires Maven 3.6.0 or later.
 
 The easiest way to get started with Lagom and Maven is to use the Maven archetype plugin and a Lagom archetype to create a new project.  A Maven project includes sub-projects organized in sub-directories. The top-level and sub-project directories each include a [Project Object Model (POM)](https://maven.apache.org/pom.html) that contains build configuration. When you run the `generate` command, Maven prompts you for POM element values. The Lagom archetype creates a project that includes two Lagom services, `hello` and `stream`.
 


### PR DESCRIPTION
`maven-enforcer-plugin` unnecessary now.
This check on the plugin level:

https://github.com/lagom/lagom/blob/2c7eb5fb23d47a1667ca9837eedd2be77bf29d3d/build.sbt#L1412-L1416