### PR TITLE
Adds an AkkaTaggerAdapter.fromLagom(String,..)

### DIFF
--- a/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/AkkaTaggerAdapter.java
+++ b/persistence/javadsl/src/main/java/com/lightbend/lagom/javadsl/persistence/AkkaTaggerAdapter.java
@@ -6,6 +6,7 @@ package com.lightbend.lagom.javadsl.persistence;
 
 import akka.annotation.ApiMayChange;
 import akka.cluster.sharding.typed.javadsl.EntityContext;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -21,13 +22,23 @@ public class AkkaTaggerAdapter {
   public static <Command, Event extends AggregateEvent<Event>>
       Function<Event, Set<String>> fromLagom(
           EntityContext<Command> entityContext, AggregateEventTagger<Event> lagomTagger) {
+    return fromLagom(entityContext.getEntityId(), lagomTagger);
+  }
+
+  /**
+   * Adapts an existing Lagom {@code AggregateEventTagger} to a function {@code Function<Event,
+   * Set<String>>} as expected by Akka Persistence Typed {@code EventSourcedBehavior.withTagger}
+   * API.
+   */
+  public static <Command, Event extends AggregateEvent<Event>>
+      Function<Event, Set<String>> fromLagom(
+          String entityId, AggregateEventTagger<Event> lagomTagger) {
     return evt -> {
       Set<String> tags = new HashSet<>();
       if (lagomTagger instanceof AggregateEventTag) {
         tags.add(((AggregateEventTag) lagomTagger).tag());
       } else if (lagomTagger instanceof AggregateEventShards) {
-        tags.add(
-            ((AggregateEventShards) lagomTagger).forEntityId(entityContext.getEntityId()).tag());
+        tags.add(((AggregateEventShards) lagomTagger).forEntityId(entityId).tag());
       }
       return tags;
     };

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AkkaTaggerAdapter.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/AkkaTaggerAdapter.scala
@@ -17,14 +17,24 @@ object AkkaTaggerAdapter {
   def fromLagom[Command, Event <: AggregateEvent[Event]](
       entityCtx: EntityContext[Command],
       lagomTagger: AggregateEventTagger[Event]
+  ): Event => Set[String] = fromLagom(entityCtx.entityId, lagomTagger)
+
+  /**
+   * Adapts an existing Lagom [[AggregateEventTagger]] to a
+   * function {{{Event => Set[String]}}} as expected by Akka Persistence Typed {{{EventSourcedBehavior.withTagger}}} API.
+   */
+  def fromLagom[Command, Event <: AggregateEvent[Event]](
+      entityId: String,
+      lagomTagger: AggregateEventTagger[Event]
   ): Event => Set[String] = { evt =>
     val tag =
       lagomTagger match {
         case tagger: AggregateEventTag[_] =>
           tagger.tag
         case shardedTagger: AggregateEventShards[_] =>
-          shardedTagger.forEntityId(entityCtx.entityId).tag
+          shardedTagger.forEntityId(entityId).tag
       }
     Set(tag)
   }
+
 }

--- a/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AkkaTaggerAdapterSpec.scala
+++ b/persistence/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/AkkaTaggerAdapterSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.scaladsl.persistence
+
+import akka.cluster.sharding.typed.scaladsl.EntityContext
+import akka.cluster.sharding.typed.scaladsl.EntityTypeKey
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+/**
+ *
+ */
+class AkkaTaggerAdapterSpec extends WordSpec with Matchers {
+  val typeKey: EntityTypeKey[FakeCommand] = EntityTypeKey[FakeCommand]("fakeCommand")
+  private val entityId                    = "123"
+
+  val baseTagName = "baseName"
+  val expectedTag = s"${baseTagName}0"
+
+  "A AkkaTaggerAdapter" should {
+
+    "produce Lagom-compatible tags" in {
+      val entityContext: EntityContext[FakeCommand] = new EntityContext(typeKey, entityId, null)
+      val tagger: FakeEvent => Set[String]          = AkkaTaggerAdapter.fromLagom(entityContext, FakeEvent.FakeEventTag)
+      tagger(EventFaked) shouldBe Set(expectedTag)
+    }
+
+    "produce Lagom-compatible tags (without an EntityContext)" in {
+      val tagger: FakeEvent => Set[String] = AkkaTaggerAdapter.fromLagom(entityId, FakeEvent.FakeEventTag)
+      tagger(EventFaked) shouldBe Set(expectedTag)
+    }
+
+  }
+
+  class FakeCommand
+
+  object FakeEvent {
+    val FakeEventTag: AggregateEventTagger[FakeEvent] = AggregateEventTag.sharded(baseTagName, 3)
+  }
+
+  sealed trait FakeEvent extends AggregateEvent[FakeEvent] {
+    override def aggregateTag: AggregateEventTagger[FakeEvent] =
+      FakeEvent.FakeEventTag
+  }
+  case object EventFaked extends FakeEvent
+
+}


### PR DESCRIPTION
Fixes #2346

I'm creating this as a DRAFT because I plan to remove `fromLagom(EntityContext,...)` but wanted to leave this here for an extra round of discussion first.