### PR TITLE
Extracts ChoosingADatabase to 'common/'

### DIFF
--- a/docs/manual/common/guide/cluster/ChoosingADatabase.md
+++ b/docs/manual/common/guide/cluster/ChoosingADatabase.md
@@ -1,0 +1,17 @@
+# Choosing a database
+
+Lagom is compatible with the following databases:
+
+* [Cassandra](https://cassandra.apache.org/)
+* [PostgreSQL](https://www.postgresql.org/)
+* [MySQL](https://www.mysql.com/)
+* [Oracle](https://www.oracle.com/database/index.html)
+* [H2](https://www.h2database.com/)
+* [Microsoft SQL Server](https://www.microsoft.com/en-us/sql-server/)
+* [Couchbase](https://www.couchbase.com/)
+
+For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistence|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistence|PersistentEntityRDBMS]] on how to configure your project. If you wish to use Couchbase, proceed to the [Lagom section of the plugin site](https://doc.akka.io/docs/akka-persistence-couchbase/current/lagom-persistent-entity.html) for all the details.
+
+To see how to combine Cassandra for write-side persistence and JDBC for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-samples/blob/1.6.x/mixed-persistence/) examples.
+
+Lagom provides out of the box support for running Cassandra in a development environment - developers do not need to install, configure or manage Cassandra at all themselves when using Lagom, which makes for great developer velocity, and it means gone are the days where developers spend days setting up their development environment before they can start to be productive on a project.

--- a/docs/manual/java/guide/cluster/PersistentEntity.md
+++ b/docs/manual/java/guide/cluster/PersistentEntity.md
@@ -18,24 +18,6 @@ An entity is kept alive, holding its current state in memory, as long as it is u
 
 When an entity is started it replays the stored events to restore the current state. This can be either the full history of changes or starting from a snapshot which will reduce recovery times.
 
-## Choosing a database
-
-Lagom is compatible with the following databases:
-
-- [Cassandra](https://cassandra.apache.org/)
-- [PostgreSQL](https://www.postgresql.org/)
-- [MySQL](https://www.mysql.com/)
-- [Oracle](https://www.oracle.com/database/index.html)
-- [H2](https://www.h2database.com/)
-- [Microsoft SQL Server](https://www.microsoft.com/en-us/sql-server/)
-- [Couchbase](https://www.couchbase.com/)
-
-For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project. If you wish to use Couchbase, proceed to the [Lagom section of the Akka Persistence Couchbase site](https://doc.akka.io/docs/akka-persistence-couchbase/current/lagom-persistent-entity.html) for all the details.
-
-To see how to combine Cassandra for write-side persistence and JPA for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-samples/blob/1.6.x/mixed-persistence/mixed-persistence-java-sbt/README.md) sample.
-
-Lagom provides out of the box support for running Cassandra in a development environment - developers do not need to install, configure or manage Cassandra at all themselves when using Lagom, which makes for great developer velocity, and it means gone are the days where developers spend days setting up their development environment before they can start to be productive on a project.
-
 ## PersistentEntity Stub
 
 This is what a [PersistentEntity](api/index.html?com/lightbend/lagom/javadsl/persistence/PersistentEntity.html) class looks like before filling in the implementation details:

--- a/docs/manual/java/guide/cluster/index.toc
+++ b/docs/manual/java/guide/cluster/index.toc
@@ -1,8 +1,8 @@
-PersistentEntity:Persistent Entity
+PersistentEntity:Persistent Entity;next=ChoosingADatabase,PersistentEntityCassandra,PersistentEntityRDBMS
 ChoosingADatabase:Choosing A Database
-PersistentEntityCassandra:Cassandra Persistent Entities
-PersistentEntityRDBMS:Relational Database Persistent Entities
-ReadSide:Persistent Read-Side
+PersistentEntityCassandra:Cassandra Setup
+PersistentEntityRDBMS:Relational Database Setup
+ReadSide:Persistent Read-Side;next=ReadSideCassandra,ReadSideRDBMS
 ReadSideCassandra:Cassandra Read-Side Support
 ReadSideRDBMS:Relational Database Read-Side Support;next=ReadSideJDBC,ReadSideJPA
 ReadSideJDBC:JDBC Read-Side Support

--- a/docs/manual/java/guide/cluster/index.toc
+++ b/docs/manual/java/guide/cluster/index.toc
@@ -1,4 +1,5 @@
 PersistentEntity:Persistent Entity
+ChoosingADatabase:Choosing A Database
 PersistentEntityCassandra:Cassandra Persistent Entities
 PersistentEntityRDBMS:Relational Database Persistent Entities
 ReadSide:Persistent Read-Side

--- a/docs/manual/scala/guide/cluster/PersistentEntity.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntity.md
@@ -20,24 +20,6 @@ An entity is kept alive, holding its current state in memory, as long as it is u
 
 When an entity is started it replays the stored events to restore the current state. This can be either the full history of changes or starting from a snapshot which will reduce recovery times.
 
-## Choosing a database
-
-Lagom is compatible with the following databases:
-
-* [Cassandra](https://cassandra.apache.org/)
-* [PostgreSQL](https://www.postgresql.org/)
-* [MySQL](https://www.mysql.com/)
-* [Oracle](https://www.oracle.com/database/index.html)
-* [H2](https://www.h2database.com/)
-* [Microsoft SQL Server](https://www.microsoft.com/en-us/sql-server/)
-* [Couchbase](https://www.couchbase.com/)
-
-For instructions on configuring your project to use Cassandra, see [[Using Cassandra for Persistent Entities|PersistentEntityCassandra]]. If instead you want to use one of the relational databases listed above, see [[Using a Relational Database for Persistent Entities|PersistentEntityRDBMS]] on how to configure your project. If you wish to use Couchbase, proceed to the [Lagom section of the plugin site](https://doc.akka.io/docs/akka-persistence-couchbase/current/lagom-persistent-entity.html) for all the details.
-
-To see how to combine Cassandra for write-side persistence and JDBC for a read-side view, see the [Mixed Persistence Service](https://github.com/lagom/lagom-samples/blob/1.6.x/mixed-persistence/mixed-persistence-scala-sbt/README.md) example.
-
-Lagom provides out of the box support for running Cassandra in a development environment - developers do not need to install, configure or manage Cassandra at all themselves when using Lagom, which makes for great developer velocity, and it means gone are the days where developers spend days setting up their development environment before they can start to be productive on a project.
-
 ## PersistentEntity Stub
 
 This is what a [PersistentEntity](api/index.html#com/lightbend/lagom/scaladsl/persistence/PersistentEntity) class looks like before filling in the implementation details:

--- a/docs/manual/scala/guide/cluster/index.toc
+++ b/docs/manual/scala/guide/cluster/index.toc
@@ -1,5 +1,6 @@
 DomainModelling:Domain Modelling with Akka Persistence Typed
 MigratingToAkkaPersistenceTyped: Migrating to Akka Persistence Typed
+ChoosingADatabase:Choosing A Database
 PersistentEntity:Persistent Entity (classic)
 PersistentEntityCassandra:Cassandra Persistent Entities
 PersistentEntityRDBMS:Relational Database Persistent Entities

--- a/docs/manual/scala/guide/cluster/index.toc
+++ b/docs/manual/scala/guide/cluster/index.toc
@@ -1,10 +1,10 @@
-DomainModelling:Domain Modelling with Akka Persistence Typed
+DomainModelling:Domain Modelling with Akka Persistence Typed;next=MigratingToAkkaPersistenceTyped,ChoosingADatabase,ReadSide
 MigratingToAkkaPersistenceTyped: Migrating to Akka Persistence Typed
-ChoosingADatabase:Choosing A Database
-PersistentEntity:Persistent Entity (classic)
-PersistentEntityCassandra:Cassandra Persistent Entities
-PersistentEntityRDBMS:Relational Database Persistent Entities
-ReadSide:Persistent Read-Side
+PersistentEntity:Persistent Entity (classic);next=ChoosingADatabase
+ChoosingADatabase:Choosing A Database;next=PersistentEntityCassandra,PersistentEntityRDBMS
+PersistentEntityCassandra:Cassandra Setup;next=ReadSide
+PersistentEntityRDBMS:Relational Database Setup;next=ReadSide
+ReadSide:Persistent Read-Side;next=ReadSideCassandra,ReadSideRDBMS
 ReadSideCassandra:Cassandra Read-Side Support
 ReadSideRDBMS:Relational Database Read-Side Support;next=ReadSideJDBC,ReadSideSlick
 ReadSideJDBC:JDBC Read-Side Support

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -3,7 +3,7 @@ lazy val plugins = (project in file(".")).dependsOn(dev)
 lazy val dev = ProjectRef(Path.fileProperty("user.dir").getParentFile, "sbt-plugin")
 
 resolvers += Resolver.typesafeIvyRepo("releases") // sbt 1.3 regression
-addSbtPlugin("com.lightbend.markdown" %% "sbt-lightbend-markdown" % "1.7.0")
+addSbtPlugin("com.lightbend.markdown" %% "sbt-lightbend-markdown" % "1.7.1-SNAPSHOT")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 

--- a/docs/project/plugins.sbt
+++ b/docs/project/plugins.sbt
@@ -3,7 +3,7 @@ lazy val plugins = (project in file(".")).dependsOn(dev)
 lazy val dev = ProjectRef(Path.fileProperty("user.dir").getParentFile, "sbt-plugin")
 
 resolvers += Resolver.typesafeIvyRepo("releases") // sbt 1.3 regression
-addSbtPlugin("com.lightbend.markdown" %% "sbt-lightbend-markdown" % "1.7.1-SNAPSHOT")
+addSbtPlugin("com.lightbend.markdown" %% "sbt-lightbend-markdown" % "1.7.0")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 


### PR DESCRIPTION
Refs #2387 

I've extracted the section on choosing a database to `common/` and rewrote the link to `lagom-samples` so it was not implementation specific. All the rest is the same.

Note the scala docs are more evolved than the java docs at this point reason why `index.toc` files for scala and java are out of sync right now. I expect them to sync back as we bring the java ref docs up to speed.