### PR TITLE
Makes PersistentEntityXyz.md implementation agnostic

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -1,6 +1,6 @@
-# Storing Persistent Entities in Cassandra
+# Storing Persistent Events in Cassandra
 
-This page describes how to configure Cassandra for use with Lagom's [[Persistent Entity|PersistentEntity]] API.
+This page describes how to configure Cassandra for use with [[Persistent Entity|PersistentEntity]] API or Akka Typed Persistence in a Lagom service .
 
 ## Project dependencies
 

--- a/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
@@ -1,6 +1,6 @@
-# Storing Persistent Entities in a Relational Database
+# Storing Persistent Events in a Relational Database
 
-This page describes how to configure a relational database for use with Lagom's [[Persistent Entity|PersistentEntity]] API.
+This page describes how to configure a relational database for use with [[Persistent Entity|PersistentEntity]] API or Akka Typed Persistence in a Lagom service .
 
 ## Project dependencies
 
@@ -24,12 +24,13 @@ You will also need to add the jar for your JDBC database driver.
 
 ## Configuration
 
-Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin to persist entities to the database.  This supports four different relational databases:
+Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin.  This supports four different relational databases:
 
 * [PostgreSQL](https://www.postgresql.org/)
 * [MySQL](https://www.mysql.com/)
 * [Oracle](https://www.oracle.com/database/index.html)
-* [H2](https://www.h2database.com/)
+* [H2](https://www.h2database.com/)](https://www.h2database.com/)
+* [SQL Server](https://www.microsoft.com/en-us/sql-server)
 
 We advise against using H2 in production, however, it is suitable for use in development and testing.
 

--- a/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
@@ -24,7 +24,7 @@ You will also need to add the jar for your JDBC database driver.
 
 ## Configuration
 
-Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin.  This supports four different relational databases:
+Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin.  This supports the following relational databases:
 
 * [PostgreSQL](https://www.postgresql.org/)
 * [MySQL](https://www.mysql.com/)

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -1,6 +1,6 @@
-# Storing Persistent Entities in Cassandra
+# Storing Persistent Events in Cassandra
 
-This page describes how to configure Cassandra for use with Lagom's [[Persistent Entity|PersistentEntity]] API.
+This page describes how to configure Cassandra for use with [[Persistent Entity|PersistentEntity]] API or Akka Typed Persistence in a Lagom service .
 
 ## Project dependencies
 

--- a/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
@@ -27,7 +27,7 @@ To enable the RDBMS Persistence on your Application you will have to mix in | [J
 
 ## Configuration
 
-Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin.  This supports four different relational databases:
+Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin.  This supports the following relational databases:
 
 * [PostgreSQL](https://www.postgresql.org/)
 * [MySQL](https://www.mysql.com/)

--- a/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityRDBMS.md
@@ -1,6 +1,6 @@
-# Storing Persistent Entities in a Relational Database
+# Storing Persistent Events in a Relational Database
 
-This page describes how to configure a relational database for use with Lagom's [[Persistent Entity|PersistentEntity]] API.
+This page describes how to configure a relational database for use with [[Persistent Entity|PersistentEntity]] API or Akka Typed Persistence in a Lagom service .
 
 ## Project dependencies
 
@@ -27,12 +27,13 @@ To enable the RDBMS Persistence on your Application you will have to mix in | [J
 
 ## Configuration
 
-Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin to persist entities to the database.  This supports four different relational databases:
+Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persistence-jdbc) plugin.  This supports four different relational databases:
 
 * [PostgreSQL](https://www.postgresql.org/)
 * [MySQL](https://www.mysql.com/)
 * [Oracle](https://www.oracle.com/database/index.html)
 * [H2](https://www.h2database.com/)
+* [SQL Server](https://www.microsoft.com/en-us/sql-server)
 
 We advise against using H2 in production, however, it is suitable for use in development and testing.
 


### PR DESCRIPTION
Refs #2387 

I've reviewd all four flavors of the page but tried to keep the change as small as possible so I haven't renamed the files from `PersistentEntityXyz.md` to something agnostic.

> Note: the scala docs are more evolved than the java docs at this point reason why `index.toc` files for scala and java are out of sync right now. I expect them to sync back as we bring the java ref docs up to speed.