### PR TITLE
Revert AbstractPersistentEntityRegistry's binary API

### DIFF
--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -4,6 +4,8 @@
 
 package com.lightbend.lagom.internal.javadsl.persistence.cassandra
 
+import java.util.Optional
+
 import javax.inject.Inject
 import javax.inject.Singleton
 import akka.actor.ActorSystem
@@ -18,9 +20,11 @@ import play.api.inject.Injector
  */
 @Singleton
 private[lagom] final class CassandraPersistentEntityRegistry @Inject() (system: ActorSystem, injector: Injector)
-    extends AbstractPersistentEntityRegistry(system, injector, CassandraReadJournal.Identifier) {
+    extends AbstractPersistentEntityRegistry(system, injector) {
   private val log = Logging.getLogger(system, getClass)
 
   CassandraKeyspaceConfig.validateKeyspace("cassandra-journal", system.settings.config, log)
   CassandraKeyspaceConfig.validateKeyspace("cassandra-snapshot-store", system.settings.config, log)
+
+  protected override val queryPluginId = Optional.of(CassandraReadJournal.Identifier)
 }

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraPersistentEntityRegistry.scala
@@ -16,9 +16,11 @@ import com.lightbend.lagom.internal.scaladsl.persistence.AbstractPersistentEntit
  * Internal API
  */
 private[lagom] final class CassandraPersistentEntityRegistry(system: ActorSystem)
-    extends AbstractPersistentEntityRegistry(system, CassandraReadJournal.Identifier) {
+    extends AbstractPersistentEntityRegistry(system) {
   private val log = Logging.getLogger(system, getClass)
 
   CassandraKeyspaceConfig.validateKeyspace("cassandra-journal", system.settings.config, log)
   CassandraKeyspaceConfig.validateKeyspace("cassandra-snapshot-store", system.settings.config, log)
+
+  protected override val queryPluginId = Some(CassandraReadJournal.Identifier)
 }

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -4,6 +4,8 @@
 
 package com.lightbend.lagom.internal.javadsl.persistence.jdbc
 
+import java.util.Optional
+
 import javax.inject.Inject
 import javax.inject.Singleton
 import akka.actor.ActorSystem
@@ -20,11 +22,13 @@ private[lagom] final class JdbcPersistentEntityRegistry @Inject() (
     system: ActorSystem,
     injector: Injector,
     slickProvider: SlickProvider
-) extends AbstractPersistentEntityRegistry(system, injector, JdbcReadJournal.Identifier) {
+) extends AbstractPersistentEntityRegistry(system, injector) {
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 
   override def register[C, E, S](entityClass: Class[_ <: PersistentEntity[C, E, S]]): Unit = {
     ensureTablesCreated
     super.register(entityClass)
   }
+
+  protected override val queryPluginId = Optional.of(JdbcReadJournal.Identifier)
 }

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/jdbc/JdbcPersistentEntityRegistry.scala
@@ -19,11 +19,13 @@ import com.lightbend.lagom.scaladsl.persistence.PersistentEntity
  * INTERNAL API
  */
 private[lagom] final class JdbcPersistentEntityRegistry(system: ActorSystem, slickProvider: SlickProvider)
-    extends AbstractPersistentEntityRegistry(system, JdbcReadJournal.Identifier) {
+    extends AbstractPersistentEntityRegistry(system) {
   private lazy val ensureTablesCreated = slickProvider.ensureTablesCreated()
 
   override def register(entityFactory: => PersistentEntity): Unit = {
     ensureTablesCreated
     super.register(entityFactory)
   }
+
+  protected override val queryPluginId = Some(JdbcReadJournal.Identifier)
 }


### PR DESCRIPTION
This reverts the material change in #2370, now that it's fixed upstream
with Akka 2.6.0-RC2.

The reason for to revert this is #2414:
CouchbasePersistentEntityRegistry, in the lagom-persistence-couchbase
artifact, which is in the akka-persistence-couchbase repo, depends on
AbstractPersistentEntityRegistry's binary API.  So the change in #2370
broke that.

Sadly this means that eventsByTagQuery goes back to being lazily
evaluated as well as "optional" (but not really).  However, those were
side-effect improvements that we can try and re-introduce later, bearing
in mind this regression.

Fixes #2414