### PR TITLE
DB (Slick/JPA) shutdown must happen after cluster is shut down

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -374,6 +374,8 @@ def mimaSettings(since: String = version150): Seq[Setting[_]] = {
       exclude[MissingClassProblem]("*.lagom.dev.Servers*"),
       // PubSub module extending SimpleModule instead of Module
       ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.inject.Module.bindings"),
+      // Fix shutdown ordering for Slick and JPA
+      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.jdbc.GuiceSlickProvider.this"),
     )
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -375,8 +375,10 @@ def mimaSettings(since: String = version150): Seq[Setting[_]] = {
       // PubSub module extending SimpleModule instead of Module
       ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.inject.Module.bindings"),
       // Fix shutdown ordering for Slick and JPA
-      ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.jdbc.GuiceSlickProvider.this"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.javadsl.persistence.jdbc.GuiceSlickProvider.this"),
+      ProblemFilters
+        .exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.jdbc.GuiceSlickProvider.this"),
+      ProblemFilters
+        .exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.javadsl.persistence.jdbc.GuiceSlickProvider.this"),
     )
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -376,6 +376,7 @@ def mimaSettings(since: String = version150): Seq[Setting[_]] = {
       ProblemFilters.exclude[DirectAbstractMethodProblem]("play.api.inject.Module.bindings"),
       // Fix shutdown ordering for Slick and JPA
       ProblemFilters.exclude[DirectMissingMethodProblem]("com.lightbend.lagom.javadsl.persistence.jdbc.GuiceSlickProvider.this"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("com.lightbend.lagom.javadsl.persistence.jdbc.GuiceSlickProvider.this"),
     )
   )
 }

--- a/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
+++ b/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
@@ -26,7 +26,9 @@ object SlickDbTestProvider {
   }
 
   /** Builds Slick Database (with AsyncExecutor) and bind it as JNDI resource for test purposes  */
-  def buildAndBindSlickDb(baseName: String, lifecycle: ApplicationLifecycle, coordinatedShutdown: CoordinatedShutdown)(implicit executionContext: ExecutionContext): Unit = {
+  def buildAndBindSlickDb(baseName: String, lifecycle: ApplicationLifecycle, coordinatedShutdown: CoordinatedShutdown)(
+      implicit executionContext: ExecutionContext
+  ): Unit = {
     val dbName = s"${baseName}_${Random.alphanumeric.take(8).mkString}"
     val db     = Databases.inMemory(dbName, config = Map("jndiName" -> JNDIName))
 
@@ -37,6 +39,8 @@ object SlickDbTestProvider {
       Future.successful(db.shutdown()).map(_ => Done)
     }
 
-    SlickDbProvider.buildAndBindSlickDatabase(db, AsyncExecConfig, JNDIDBName, lifecycle, coordinatedShutdown)(executionContext)
+    SlickDbProvider.buildAndBindSlickDatabase(db, AsyncExecConfig, JNDIDBName, lifecycle, coordinatedShutdown)(
+      executionContext
+    )
   }
 }

--- a/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
+++ b/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
@@ -7,7 +7,6 @@ package com.lightbend.lagom.internal.persistence.jdbc
 import akka.Done
 import akka.actor.CoordinatedShutdown
 import play.api.db.Databases
-import play.api.inject.ApplicationLifecycle
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
@@ -26,7 +25,7 @@ object SlickDbTestProvider {
   }
 
   /** Builds Slick Database (with AsyncExecutor) and bind it as JNDI resource for test purposes  */
-  def buildAndBindSlickDb(baseName: String, lifecycle: ApplicationLifecycle, coordinatedShutdown: CoordinatedShutdown)(
+  def buildAndBindSlickDb(baseName: String, coordinatedShutdown: CoordinatedShutdown)(
       implicit executionContext: ExecutionContext
   ): Unit = {
     val dbName = s"${baseName}_${Random.alphanumeric.take(8).mkString}"
@@ -39,8 +38,6 @@ object SlickDbTestProvider {
       Future.successful(db.shutdown()).map(_ => Done)
     }
 
-    SlickDbProvider.buildAndBindSlickDatabase(db, AsyncExecConfig, JNDIDBName, lifecycle, coordinatedShutdown)(
-      executionContext
-    )
+    SlickDbProvider.buildAndBindSlickDatabase(db, AsyncExecConfig, JNDIDBName, coordinatedShutdown)
   }
 }

--- a/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
+++ b/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
@@ -4,9 +4,11 @@
 
 package com.lightbend.lagom.internal.persistence.jdbc
 
+import akka.actor.CoordinatedShutdown
 import play.api.db.Databases
 import play.api.inject.ApplicationLifecycle
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Random
 
@@ -23,11 +25,11 @@ object SlickDbTestProvider {
   }
 
   /** Builds Slick Database (with AsyncExecutor) and bind it as JNDI resource for test purposes  */
-  def buildAndBindSlickDb(baseName: String, lifecycle: ApplicationLifecycle): Unit = {
+  def buildAndBindSlickDb(baseName: String, lifecycle: ApplicationLifecycle, coordinatedShutdown: CoordinatedShutdown)(implicit executionContext: ExecutionContext): Unit = {
     val dbName = s"${baseName}_${Random.alphanumeric.take(8).mkString}"
     val db     = Databases.inMemory(dbName, config = Map("jndiName" -> JNDIName))
     lifecycle.addStopHook(() => Future.successful(db.shutdown()))
 
-    SlickDbProvider.buildAndBindSlickDatabase(db, AsyncExecConfig, JNDIDBName, lifecycle)
+    SlickDbProvider.buildAndBindSlickDatabase(db, AsyncExecConfig, JNDIDBName, lifecycle, coordinatedShutdown)(executionContext)
   }
 }

--- a/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
+++ b/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickDbTestProvider.scala
@@ -31,13 +31,6 @@ object SlickDbTestProvider {
     val dbName = s"${baseName}_${Random.alphanumeric.take(8).mkString}"
     val db     = Databases.inMemory(dbName, config = Map("jndiName" -> JNDIName))
 
-    coordinatedShutdown.addTask(
-      CoordinatedShutdown.PhaseBeforeActorSystemTerminate,
-      s"shutdown-managed-test-slick"
-    ) { () =>
-      Future.successful(db.shutdown()).map(_ => Done)
-    }
-
     SlickDbProvider.buildAndBindSlickDatabase(db, AsyncExecConfig, JNDIDBName, coordinatedShutdown)
   }
 }

--- a/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStoreSpec.scala
+++ b/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStoreSpec.scala
@@ -4,14 +4,11 @@
 
 package com.lightbend.lagom.internal.persistence.jdbc
 
-import akka.actor.CoordinatedShutdown
 import akka.cluster.Cluster
 import akka.pattern.AskTimeoutException
 import com.lightbend.lagom.persistence.ActorSystemSpec
 import play.api.Configuration
 import play.api.Environment
-import play.api.inject.ApplicationLifecycle
-import play.api.inject.DefaultApplicationLifecycle
 import slick.jdbc.meta.MTable
 
 import scala.concurrent.Await
@@ -21,8 +18,7 @@ import scala.concurrent.duration._
 class SlickOffsetStoreSpec extends ActorSystemSpec(Configuration.load(Environment.simple()).underlying) {
   import system.dispatcher
 
-  private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-  private lazy val slick                                      = new SlickProvider(system, coordinatedShutdown)
+  private lazy val slick = new SlickProvider(system, coordinatedShutdown)
 
   private lazy val offsetStore = new SlickOffsetStore(
     system,
@@ -33,13 +29,7 @@ class SlickOffsetStoreSpec extends ActorSystemSpec(Configuration.load(Environmen
   protected override def beforeAll(): Unit = {
     super.beforeAll()
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
-  }
-
-  override def afterAll(): Unit = {
-    Await.ready(applicationLifecycle.stop(), 20.seconds)
-
-    super.afterAll()
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, coordinatedShutdown)
   }
 
   "SlickOffsetStoreSpec" when {

--- a/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStoreSpec.scala
+++ b/persistence-jdbc/core/src/test/scala/com/lightbend/lagom/internal/persistence/jdbc/SlickOffsetStoreSpec.scala
@@ -4,6 +4,7 @@
 
 package com.lightbend.lagom.internal.persistence.jdbc
 
+import akka.actor.CoordinatedShutdown
 import akka.cluster.Cluster
 import akka.pattern.AskTimeoutException
 import com.lightbend.lagom.persistence.ActorSystemSpec
@@ -21,7 +22,7 @@ class SlickOffsetStoreSpec extends ActorSystemSpec(Configuration.load(Environmen
   import system.dispatcher
 
   private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-  private lazy val slick                                      = new SlickProvider(system)
+  private lazy val slick                                      = new SlickProvider(system, coordinatedShutdown)
 
   private lazy val offsetStore = new SlickOffsetStore(
     system,
@@ -32,7 +33,7 @@ class SlickOffsetStoreSpec extends ActorSystemSpec(Configuration.load(Environmen
   protected override def beforeAll(): Unit = {
     super.beforeAll()
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle)
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
   }
 
   override def afterAll(): Unit = {

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/SlickProvider.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/jdbc/SlickProvider.scala
@@ -6,11 +6,12 @@ package com.lightbend.lagom.internal.javadsl.persistence.jdbc
 
 import javax.inject.Inject
 import javax.inject.Singleton
-
 import akka.actor.ActorSystem
+import akka.actor.CoordinatedShutdown
 
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class SlickProvider @Inject() (system: ActorSystem)(implicit ec: ExecutionContext)
-    extends com.lightbend.lagom.internal.persistence.jdbc.SlickProvider(system)(ec)
+class SlickProvider @Inject() (system: ActorSystem, coordinatedShutdown: CoordinatedShutdown)(
+    implicit ec: ExecutionContext
+) extends com.lightbend.lagom.internal.persistence.jdbc.SlickProvider(system, coordinatedShutdown)(ec)

--- a/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceModule.scala
+++ b/persistence-jdbc/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceModule.scala
@@ -17,7 +17,6 @@ import com.lightbend.lagom.spi.persistence.OffsetStore
 import play.api.Configuration
 import play.api.Environment
 import play.api.db.DBApi
-import play.api.inject.ApplicationLifecycle
 import play.api.inject.Binding
 import play.api.inject.Module
 
@@ -38,7 +37,6 @@ class JdbcPersistenceModule extends Module {
 class GuiceSlickProvider @Inject() (
     dbApi: DBApi,
     actorSystem: ActorSystem,
-    applicationLifecycle: ApplicationLifecycle,
     coordinatedShutdown: CoordinatedShutdown
 )(
     implicit ec: ExecutionContext
@@ -48,7 +46,6 @@ class GuiceSlickProvider @Inject() (
     SlickDbProvider.buildAndBindSlickDatabases(
       dbApi,
       actorSystem.settings.config,
-      applicationLifecycle,
       coordinatedShutdown
     )
     new SlickProvider(actorSystem, coordinatedShutdown)

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -33,7 +33,7 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
 
   import system.dispatcher
 
-  protected lazy val slick = new SlickProvider(system)
+  protected lazy val slick = new SlickProvider(system, coordinatedShutdown)
 
   protected lazy val offsetStore =
     new JavadslJdbcOffsetStore(
@@ -57,7 +57,7 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     cluster.join(cluster.selfAddress)
 
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle)
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
 
     // Trigger tables to be created
     Await.ready(slick.ensureTablesCreated(), 20.seconds)

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -14,8 +14,6 @@ import com.lightbend.lagom.persistence.ActorSystemSpec
 import com.lightbend.lagom.persistence.PersistenceSpec
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import play.api.inject.ApplicationLifecycle
-import play.api.inject.DefaultApplicationLifecycle
 import play.api.Configuration
 import play.api.Environment
 
@@ -47,8 +45,6 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     )
   protected lazy val jdbcReadSide: JdbcReadSide = new JdbcReadSideImpl(slick, offsetStore)
 
-  private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-
   override def beforeAll(): Unit = {
     super.beforeAll()
 
@@ -57,16 +53,11 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     cluster.join(cluster.selfAddress)
 
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, coordinatedShutdown)
 
     // Trigger tables to be created
     Await.ready(slick.ensureTablesCreated(), 20.seconds)
 
     awaitPersistenceInit(system)
-  }
-
-  override def afterAll(): Unit = {
-    Await.ready(applicationLifecycle.stop(), 20.seconds)
-    super.afterAll()
   }
 }

--- a/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceComponents.scala
+++ b/persistence-jdbc/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceComponents.scala
@@ -40,7 +40,6 @@ private[lagom] trait SlickProviderComponents extends DBComponents {
     SlickDbProvider.buildAndBindSlickDatabases(
       dbApi,
       actorSystem.settings.config,
-      applicationLifecycle,
       coordinatedShutdown
     )(executionContext)
     new SlickProvider(actorSystem, coordinatedShutdown)(executionContext)

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -49,7 +49,7 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
 
   import system.dispatcher
 
-  protected lazy val slick = new SlickProvider(system)
+  protected lazy val slick = new SlickProvider(system, coordinatedShutdown)
   protected lazy val jdbcReadSide: JdbcReadSide = new JdbcReadSideImpl(
     slick,
     new SlickOffsetStore(
@@ -69,7 +69,7 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     cluster.join(cluster.selfAddress)
 
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle)
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
 
     // Trigger tables to be created
     Await.ready(slick.ensureTablesCreated(), 20.seconds)

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -20,8 +20,6 @@ import com.lightbend.lagom.persistence.PersistenceSpec
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import play.api.inject.ApplicationLifecycle
-import play.api.inject.DefaultApplicationLifecycle
 import play.api.Configuration
 import play.api.Environment
 
@@ -59,8 +57,6 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     )
   )
 
-  private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-
   override def beforeAll(): Unit = {
     super.beforeAll()
 
@@ -69,16 +65,11 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     cluster.join(cluster.selfAddress)
 
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, coordinatedShutdown)
 
     // Trigger tables to be created
     Await.ready(slick.ensureTablesCreated(), 20.seconds)
 
     awaitPersistenceInit(system)
-  }
-
-  override def afterAll(): Unit = {
-    Await.ready(applicationLifecycle.stop(), 20.seconds)
-    super.afterAll()
   }
 }

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
@@ -50,7 +50,7 @@ abstract class SlickPersistenceSpec private (_system: ActorSystem) extends Actor
 
   import system.dispatcher
 
-  protected lazy val slick = new SlickProvider(system)
+  protected lazy val slick = new SlickProvider(system, coordinatedShutdown)
   protected lazy val slickReadSide: SlickReadSide = {
     val offsetStore =
       new SlickOffsetStore(
@@ -71,7 +71,7 @@ abstract class SlickPersistenceSpec private (_system: ActorSystem) extends Actor
     cluster.join(cluster.selfAddress)
 
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle)
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
 
     // Trigger tables to be created
     Await.ready(slick.ensureTablesCreated(), 20.seconds)

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
@@ -20,8 +20,6 @@ import com.lightbend.lagom.persistence.PersistenceSpec
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import play.api.inject.ApplicationLifecycle
-import play.api.inject.DefaultApplicationLifecycle
 import play.api.Configuration
 import play.api.Environment
 
@@ -61,8 +59,6 @@ abstract class SlickPersistenceSpec private (_system: ActorSystem) extends Actor
     new SlickReadSideImpl(slick, offsetStore)
   }
 
-  private lazy val applicationLifecycle: ApplicationLifecycle = new DefaultApplicationLifecycle
-
   override def beforeAll(): Unit = {
     super.beforeAll()
 
@@ -71,16 +67,11 @@ abstract class SlickPersistenceSpec private (_system: ActorSystem) extends Actor
     cluster.join(cluster.selfAddress)
 
     // Trigger database to be loaded and registered to JNDI
-    SlickDbTestProvider.buildAndBindSlickDb(system.name, applicationLifecycle, coordinatedShutdown)
+    SlickDbTestProvider.buildAndBindSlickDb(system.name, coordinatedShutdown)
 
     // Trigger tables to be created
     Await.ready(slick.ensureTablesCreated(), 20.seconds)
 
     awaitPersistenceInit(system)
-  }
-
-  override def afterAll(): Unit = {
-    applicationLifecycle.stop()
-    super.afterAll()
   }
 }

--- a/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaPersistenceSpec.scala
+++ b/persistence-jpa/javadsl/src/test/scala/com/lightbend/lagom/internal/javadsl/persistence/jpa/JpaPersistenceSpec.scala
@@ -14,7 +14,7 @@ abstract class JpaPersistenceSpec extends JdbcPersistenceSpec {
   protected lazy val config                       = system.settings.config
   protected lazy val applicationLifecycle         = new DefaultApplicationLifecycle
   protected lazy val delegateApplicationLifecycle = new DelegateApplicationLifecycle(applicationLifecycle)
-  protected lazy val jpa: JpaSession              = new JpaSessionImpl(config, slick, system, delegateApplicationLifecycle)
+  protected lazy val jpa: JpaSession              = new JpaSessionImpl(config, slick, system, coordinatedShutdown)
 
   override def afterAll(): Unit = {
     applicationLifecycle.stop()

--- a/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
@@ -54,7 +54,7 @@ abstract class ActorSystemSpec(system: ActorSystem)
     super.afterAll()
   }
 
-  val log: LoggingAdapter = Logging(system, this.getClass)
+  val log: LoggingAdapter                      = Logging(system, this.getClass)
   val coordinatedShutdown: CoordinatedShutdown = CoordinatedShutdown(system)
 
   // for ScalaTest === compare of Class objects

--- a/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
@@ -5,6 +5,7 @@
 package com.lightbend.lagom.persistence
 
 import akka.actor.ActorSystem
+import akka.actor.CoordinatedShutdown
 import akka.actor.setup.ActorSystemSetup
 import akka.event.Logging
 import akka.event.LoggingAdapter
@@ -54,6 +55,7 @@ abstract class ActorSystemSpec(system: ActorSystem)
   }
 
   val log: LoggingAdapter = Logging(system, this.getClass)
+  val coordinatedShutdown: CoordinatedShutdown = CoordinatedShutdown(system)
 
   // for ScalaTest === compare of Class objects
   implicit def classEqualityConstraint[A, B]: CanEqual[Class[A], Class[B]] =


### PR DESCRIPTION
As detected in https://github.com/lagom/lagom-samples/issues/121 when shutting down clustered `ProjectionWorker`s the database connection pools and thread pools are already shutdown and the projection worker fails to shutdown cleanly.

The problem is Slick and JPA were registering stop hooks on `ApplicationLifecycle` which are run _before_ the cluster shuts down. That means the actual behavior is (summing up and focusing on relevant bits):

1. shutdown of the system starts
2. `ApplicationLifecycle` runs all stop hooks (JPA and Slick are stoped)
3. cluter sharded actors are stopped. This includes Projection Workers (which use Slick and JPA)
4. Actor System shuts down

The actual solution is to remove the stop hooks for anything that's infrastructure from `ApplicationLifecycle` and, instead, register `CoordinatedShutdown` tasks which are invoked _after_ the cluster has shut down.

- - - - - - - - - 

As a bonus, a clean shutdown should stop all Projection workers early (instead of trusting they'll be shutdown as part of the cluster shutdown).