### PR TITLE
Prevent using TLS 1.3 to avoid issues on Java 11.

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,3 +3,4 @@
 -Xss2M
 -XX:MaxInlineLevel=18
 -XX:MaxMetaspaceSize=1G
+-Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2


### PR DESCRIPTION
Fixes #2432 

The issue in JDK 11 is a race condition so quite hard to reproduce. Still this is not the first time we've observed similar problems.

More info at : https://stackoverflow.com/questions/52574050/javax-net-ssl-sslexception-no-psk-available-unable-to-resume