### PR TITLE
Add language selection to Akka links

### DIFF
--- a/docs/manual/scala/guide/cluster/MigratingToAkkaPersistenceTyped.md
+++ b/docs/manual/scala/guide/cluster/MigratingToAkkaPersistenceTyped.md
@@ -19,7 +19,7 @@ So, instead of using a build and adding multiple command and event handlers, a s
 
 @[akka-persistence-command-handler](../../../../../dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-persistence-typed-migration-scala/shopping-cart-akka-persistence-typed/src/main/scala/com/example/shoppingcart/impl/ShoppingCartEntity.scala)
 
-This migration guide will not go into more details related to writing command and event handlers. Refer to the [Akka Persistence Typed docs](https://doc.akka.io/docs/akka/2.6/typed/index-persistence.html) or the section on [[domain modelling with Akka Persistence Typed|UsingAkkaPersistenceTyped]] for more information.
+This migration guide will not go into more details related to writing command and event handlers. Refer to the [Akka Persistence Typed docs](https://doc.akka.io/docs/akka/2.6/typed/index-persistence.html?language=Scala) or the section on [[domain modelling with Akka Persistence Typed|UsingAkkaPersistenceTyped]] for more information.
 
 ### Commands
 

--- a/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -86,7 +86,7 @@ The `commandHandler` is a function `(State, Command) => ReplyEffect[Event, State
 
 ### Changing behavior -- Finite State Machines
 
-If you are familiar with general Akka Actors, you are probably aware that after processing a message, you should return the next behavior to be used. With Akka Persistence Typed this happens differently. Command handlers and event handlers are all dependent on the current state, therefore can you change behavior by returning a new state in the event handler. Consult the [Akka documentation](https://doc.akka.io/docs/akka/2.6/typed/persistence.html?language=Scala#changing-behavior) for more insight on this topic.
+If you are familiar with general Akka Actors, you are probably aware that after processing a message, you should return the next behavior to be used. With Akka Persistence Typed this happens differently. Command handlers and event handlers are all dependent on the current state, therefore you can change behavior by returning a new state in the event handler. Consult the [Akka documentation](https://doc.akka.io/docs/akka/2.6/typed/persistence.html?language=Scala#changing-behavior) for more insight on this topic.
 
 ### Tagging the events -- Akka Persistence Query considerations
 

--- a/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -52,7 +52,7 @@ You can encode it in different ways. The [recommended style](https://doc.akka.io
 
 > **Note**: of course, it is possible to organize the command handlers in a way that you consider more convenient for your use case, but we recommend the `onCommand` pattern since it can help to keep the logic for each command well isolated.
 
-Command handlers are the meat of the model. They encode the business rules of your model and act as a guardian of the model consistency. The command handler must first validate that the incoming command can be applied to the current model state. In case of successful validation, one or mores event expressing the mutations are persisted. Once the events are persisted, they are applied to the state producing a new valid state.
+Command handlers are the meat of the model. They encode the business rules of your model and act as a guardian of the model consistency. The command handler must first validate that the incoming command can be applied to the current model state. In case of successful validation, one or more events expressing the mutations are persisted. Once the events are persisted, they are applied to the state producing a new valid state.
 
 Because an Aggregate is intended to model a consistency boundary, it's not recommended validating commands using data that is not available in scope. Any decision should be solely based on the data passed in the commands and the state of the Aggregate. Any external call should be considered a smell because it means that the Aggregate is not in full control of the invariants it's supposed to be protecting.
 

--- a/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -52,7 +52,7 @@ You can encode it in different ways. The [recommended style](https://doc.akka.io
 
 > **Note**: of course, it is possible to organize the command handlers in a way that you consider more convenient for your use case, but we recommend the `onCommand` pattern since it can help to keep the logic for each command well isolated.
 
-Command handlers are the meat of the model. They encode the business rules of your model and act as a guardian of the model consistency. The command handler must first validate that the incoming command can be applied to the current model state. In case of successful validation, one or more event expressing the mutations are persisted. Once the events are persisted, they are applied to the state producing a new valid state.
+Command handlers are the meat of the model. They encode the business rules of your model and act as a guardian of the model consistency. The command handler must first validate that the incoming command can be applied to the current model state. In case of successful validation, one or mores event expressing the mutations are persisted. Once the events are persisted, they are applied to the state producing a new valid state.
 
 Because an Aggregate is intended to model a consistency boundary, it's not recommended validating commands using data that is not available in scope. Any decision should be solely based on the data passed in the commands and the state of the Aggregate. Any external call should be considered a smell because it means that the Aggregate is not in full control of the invariants it's supposed to be protecting.
 


### PR DESCRIPTION
This PR adds `?language=Scala` to all Akka docs links in the akka persistence typed related pages.

Although the default in Akka docs is 'Scala', we should always add this query string because this information is saved on a cookie and the user may have navigated to a Java page in a previous visit to the documentation. When this happens, the user may be pointed to a code fragment that is in Java, for instance.

> I'm adding it already to all links in the Java documentation (#2435)

We should expand this to all links in our documentation, but on another PR.