### PR TITLE
Use consistent link for H2 database

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityRDBMS.md
@@ -29,7 +29,7 @@ Lagom uses the [`akka-persistence-jdbc`](https://github.com/dnvriend/akka-persis
 * [PostgreSQL](https://www.postgresql.org/)
 * [MySQL](https://www.mysql.com/)
 * [Oracle](https://www.oracle.com/database/index.html)
-* [H2](https://www.h2database.com/)](https://www.h2database.com/)
+* [H2](https://www.h2database.com/)
 * [SQL Server](https://www.microsoft.com/en-us/sql-server)
 
 We advise against using H2 in production, however, it is suitable for use in development and testing.


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes hyperlink in docs to H2 database.

## Purpose

Documentation update for the latest RC.

## Background Context

Because the link to the H2 database was inconsistent with the link to other relational databases.

## References

Not that I am aware of.
