### PR TITLE
Play-test should not bring in the AkkaHTTP and Netty impls transitively

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -663,12 +663,12 @@ object Dependencies {
   )
 
   val `integration-tests-javadsl` = libraryDependencies ++= Seq(
-    playNettyServer,
-    playAkkaHttpServer,
-    playTest       % Test,
-    junit          % Test,
-    slf4jApi       % Test,
-    "com.novocode" % "junit-interface" % "0.11" % Test,
+    playAkkaHttpServer % Test,
+    playNettyServer    % Test,
+    playTest           % Test,
+    junit              % Test,
+    slf4jApi           % Test,
+    "com.novocode"     % "junit-interface" % "0.11" % Test,
     scalaTest,
     // Upgrades needed to match whitelist versions
     okio        % Test,
@@ -681,11 +681,12 @@ object Dependencies {
   )
 
   val `integration-tests-scaladsl` = libraryDependencies ++= Seq(
-    playAkkaHttpServer,
-    playTest       % Test,
-    junit          % Test,
-    slf4jApi       % Test,
-    "com.novocode" % "junit-interface" % "0.11" % Test,
+    playAkkaHttpServer % Test,
+    playNettyServer    % Test,
+    playTest           % Test,
+    junit              % Test,
+    slf4jApi           % Test,
+    "com.novocode"     % "junit-interface" % "0.11" % Test,
     scalaTest,
     okio        % Test,
     byteBuddy   % Test,


### PR DESCRIPTION
Related to https://github.com/playframework/playframework/pull/9838

Play-test should not bring in the AkkaHTTP and Netty impls transitively. The internal integration tests for Lagom are run for both Akka HTTP and Netty backends and use `play-test`. At the moment, things work as expected by coincidence because `play-test` depends on both backends. These transitive dependency should be removed.

This PR adds an explicit dependency to both backends and limits it to the `Test` scope.