### PR TITLE
Add notice about jdbc plugin tagging limitation

### DIFF
--- a/docs/manual/java/guide/cluster/ReadSide.md
+++ b/docs/manual/java/guide/cluster/ReadSide.md
@@ -52,7 +52,7 @@ Lagom provides some utilities for helping create sharded tags. To create the sha
 
 Now Lagom here will generate a tag name that appends the hash code of the entity ID modulo the number of shards to the class name.
 
-> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+> **Note**: if you're using a JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
 
 ### Defining a read side processor
 

--- a/docs/manual/java/guide/cluster/ReadSide.md
+++ b/docs/manual/java/guide/cluster/ReadSide.md
@@ -52,6 +52,8 @@ Lagom provides some utilities for helping create sharded tags. To create the sha
 
 Now Lagom here will generate a tag name that appends the hash code of the entity ID modulo the number of shards to the class name.
 
+> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+
 ### Defining a read side processor
 
 This is how a [`ReadSideProcessor`](api/index.html?com/lightbend/lagom/javadsl/persistence/ReadSideProcessor.html) class looks like before filling in the implementation details:

--- a/docs/manual/java/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/java/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -104,7 +104,7 @@ This example splits the tags into 10 shards and defines the event tagger in the 
 
 @[shopping-cart-event-tag](code/docs/home/persistence/ShoppingCartEntity.java)
 
-> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+> **Note**: if you're using a JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
 
 The `AggregateEventTag` is a Lagom class used by Lagom's [[Read-Side Processor|ReadSide]] and [[Topic Producers|MessageBrokerApi#Implementing-a-topic]], however Akka Persistence Typed provides a method accepting an `Event` and returning a `Set<String>` to tag events before persisting them. Therefore, we need to use an adapter to transform Lagom's `AggregateEventTag` to the required Akka tagger function. As shown in the constructor section, we instantiate a `tagger` field using `AkkaTaggerAdapter`. This field can then be used when implementing the tagging method.
 

--- a/docs/manual/java/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/java/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -104,6 +104,8 @@ This example splits the tags into 10 shards and defines the event tagger in the 
 
 @[shopping-cart-event-tag](code/docs/home/persistence/ShoppingCartEntity.java)
 
+> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+
 The `AggregateEventTag` is a Lagom class used by Lagom's [[Read-Side Processor|ReadSide]] and [[Topic Producers|MessageBrokerApi#Implementing-a-topic]], however Akka Persistence Typed provides a method accepting an `Event` and returning a `Set<String>` to tag events before persisting them. Therefore, we need to use an adapter to transform Lagom's `AggregateEventTag` to the required Akka tagger function. As shown in the constructor section, we instantiate a `tagger` field using `AkkaTaggerAdapter`. This field can then be used when implementing the tagging method.
 
 @[shopping-cart-akka-tagger](code/docs/home/persistence/ShoppingCartEntity.java)

--- a/docs/manual/java/guide/cluster/code/docs/home/persistence/BlogEvent.java
+++ b/docs/manual/java/guide/cluster/code/docs/home/persistence/BlogEvent.java
@@ -16,6 +16,7 @@ import org.pcollections.PSequence;
 // #sharded-tags
 interface BlogEvent extends Jsonable, AggregateEvent<BlogEvent> {
 
+  // will produce tags with shard numbers from 0 to 9
   int NUM_SHARDS = 10;
 
   AggregateEventShards<BlogEvent> TAG = AggregateEventTag.sharded(BlogEvent.class, NUM_SHARDS);

--- a/docs/manual/java/guide/cluster/code/docs/home/persistence/BlogEvent.java
+++ b/docs/manual/java/guide/cluster/code/docs/home/persistence/BlogEvent.java
@@ -16,7 +16,7 @@ import org.pcollections.PSequence;
 // #sharded-tags
 interface BlogEvent extends Jsonable, AggregateEvent<BlogEvent> {
 
-  int NUM_SHARDS = 20;
+  int NUM_SHARDS = 10;
 
   AggregateEventShards<BlogEvent> TAG = AggregateEventTag.sharded(BlogEvent.class, NUM_SHARDS);
 

--- a/docs/manual/scala/guide/cluster/ReadSide.md
+++ b/docs/manual/scala/guide/cluster/ReadSide.md
@@ -52,7 +52,7 @@ Lagom provides some utilities for helping create sharded tags. To create the sha
 
 Now Lagom here will generate a tag name that appends the hash code of the entity ID modulo the number of shards to the class name.
 
-> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+> **Note**: if you're using a JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
 
 ### Defining a read side processor
 

--- a/docs/manual/scala/guide/cluster/ReadSide.md
+++ b/docs/manual/scala/guide/cluster/ReadSide.md
@@ -52,6 +52,8 @@ Lagom provides some utilities for helping create sharded tags. To create the sha
 
 Now Lagom here will generate a tag name that appends the hash code of the entity ID modulo the number of shards to the class name.
 
+> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+
 ### Defining a read side processor
 
 This is how a [`ReadSideProcessor`](api/index.html#com/lightbend/lagom/scaladsl/persistence/ReadSideProcessor) class looks like before filling in the implementation details:

--- a/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -99,7 +99,7 @@ This example splits the tags into 10 shards and defines the event tagger in the 
 
 @[shopping-cart-events-object](code/docs/home/scaladsl/persistence/ShoppingCart.scala)
 
-> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+> **Note**: if you're using a JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
 
 The `AggregateEventTag` is a Lagom class used by Lagom's [[Read-Side Processor|ReadSide]] and [[Topic Producers|MessageBrokerApi#Implementing-a-topic]], however Akka Persistence Typed expects a function `Event => Set[String]`. Therefore, we need to use an adapter to transform Lagom's `AggregateEventTag` to the required Akka tagger function.
 

--- a/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -99,6 +99,8 @@ This example splits the tags into 10 shards and defines the event tagger in the 
 
 @[shopping-cart-events-object](code/docs/home/scaladsl/persistence/ShoppingCart.scala)
 
+> **Note**: if you're using JDBC database to store your journal, the number of sharded tags (`NumShards`) should not be greater then 10. This is due to an existing [bug](https://github.com/dnvriend/akka-persistence-jdbc/issues/168) in the plugin. Failing to follow this directive will result in some events being delivered more than once on the read-side or topic producers.
+
 The `AggregateEventTag` is a Lagom class used by Lagom's [[Read-Side Processor|ReadSide]] and [[Topic Producers|MessageBrokerApi#Implementing-a-topic]], however Akka Persistence Typed expects a function `Event => Set[String]`. Therefore, we need to use an adapter to transform Lagom's `AggregateEventTag` to the required Akka tagger function.
 
 @[shopping-cart-create-behavior-with-tagger](code/docs/home/scaladsl/persistence/ShoppingCart.scala)

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogEvent.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/BlogEvent.scala
@@ -11,7 +11,7 @@ import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializer
 
 object BlogEvent {
-  val NumShards = 20
+  val NumShards = 10
   // second param is optional, defaults to the class name
   val Tag = AggregateEventTag.sharded[BlogEvent](NumShards)
 

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShardedBlogEventTag.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShardedBlogEventTag.scala
@@ -11,6 +11,7 @@ import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
 class ShardedBlogEventTag {
   //#sharded-tags
   object BlogEvent {
+    // will produce tags with shard numbers from 0 to 9
     val NumShards = 10
     val Tag       = AggregateEventTag.sharded[BlogEvent](NumShards)
   }

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShardedBlogEventTag.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShardedBlogEventTag.scala
@@ -11,7 +11,7 @@ import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
 class ShardedBlogEventTag {
   //#sharded-tags
   object BlogEvent {
-    val NumShards = 20
+    val NumShards = 10
     val Tag       = AggregateEventTag.sharded[BlogEvent](NumShards)
   }
 

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShoppingCart.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShoppingCart.scala
@@ -74,6 +74,7 @@ object ShoppingCartExamples {
 
   // #shopping-cart-events-object
   object ShoppingCartEvent {
+    // will produce tags with shard numbers from 0 to 9
     val Tag: AggregateEventShards[ShoppingCartEvent] =
       AggregateEventTag.sharded[ShoppingCartEvent](numShards = 10)
   }

--- a/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShoppingCart.scala
+++ b/docs/manual/scala/guide/cluster/code/docs/home/scaladsl/persistence/ShoppingCart.scala
@@ -74,7 +74,8 @@ object ShoppingCartExamples {
 
   // #shopping-cart-events-object
   object ShoppingCartEvent {
-    val Tag: AggregateEventShards[ShoppingCartEvent] = AggregateEventTag.sharded[ShoppingCartEvent](numShards = 10)
+    val Tag: AggregateEventShards[ShoppingCartEvent] =
+      AggregateEventTag.sharded[ShoppingCartEvent](numShards = 10)
   }
   // #shopping-cart-events-object
 


### PR DESCRIPTION
We must backport it to 1.5.x. Potentially to 1.4.x as well.
Users can run into this issue better to warn about it as much as possible.