### PR TITLE
Expand the documentation on multiple builds

### DIFF
--- a/docs/manual/java/guide/build/MultipleBuilds.md
+++ b/docs/manual/java/guide/build/MultipleBuilds.md
@@ -81,9 +81,25 @@ The first argument passed to `lagomExternalJavadslProject` is the name that will
 
 You can further configure the service (what ports it is available on, the address it is bound to, etc...) using [[the same settings as a managed Lagom Service|ConfiguringServicesInDevelopment]].
 
-## Using the External Service
+## Mocking a service
 
-After having added the external Lagom project to your build, we need to provide the binding as it's necessary to consume a service, so that Lagom can provide an implementation for your application to use.  This can be done using the `bindClient` method on [ServiceClientGuiceSupport](api/index.html?com/lightbend/lagom/javadsl/client/ServiceClientGuiceSupport.html) as explained in [[Binding a service client|ServiceClients#Binding-a-service-client]] .
+Sometimes a service that you import will depend on other services in turn. This can lead to a cascade of importing one service after another, until you find yourself having to run the entire system in your build. Other than being inconvenient to manage, for large systems this may not be feasible. Instead, you might choose to mock some services, providing a fake implementation of a real service's API. The mock implementation is only used to run _other_ services in development that consume that service's API, without having to import the real implementation into their builds. This is similar to the use of mocking libraries in unit tests---such as [Mockito](https://site.mockito.org/), [jMock](http://jmock.org/), or [ScalaMock](https://scalamock.org/)---but at the service level instead of the class level.
+
+Writing and using a mock service implementation is just like writing and using a real service implementation, but with the business logic replaced by simple hard-coded responses. A mock service implementation should not depend on any other services, databases, message brokers, or any other infrastructure. For example, you might be developing an OAuth service that validates user credentials using a separate user authentication service, and then generates and stores API tokens for authenticated users. The user authentication service in turn might interact with a service that handles new user registration, a user profile management service that handles password changes, and an LDAP server for SSO integration. When testing the OAuth service, it isn't always necessary to include all of that additional complexity and test it end-to-end. Instead, you can run a mock user authentication service that implements the same API as the real one, but only supports a small set of test users. Running the mock service in the build for the OAuth service allows you to test the OAuth functionality in isolation from those unrelated concerns.
+
+You can choose to implement the mock service in the same build as the consuming service, by creating a new service implementation in that project that depends on the API library published by the original service. Alternatively, you could implement the mock service in the same build as the real service, publish it alongside the real implementation, and import the mock into the builds of consuming services, as described above.
+
+The benefit of locating the mock in the consuming service build is that it makes it very easy to change the mock implementation as the consuming service is developed, with all of the benefits of Lagom's automatic reloading, and no need to publish the mock to an artifact repository for each change. If the real service has multiple consumers, it allows each consumer to have a custom mock implementation, tailored to its own use of the service.
+
+On the other hand, the benefit of locating the mock next to the real implementation is that a single mock implementation can be shared by multiple consuming service projects. Sometimes, this will be more convenient than creating a mock implementation for each consuming service. The choice is yours.
+
+## Using the external service
+
+Now that you have integrated the `hello` service in your build (or a mock equivalent), any of your Lagom projects can communicate with it after adding a library dependency to its `hello-api` artifact:
+
+@[hello-communication](code/multiple-builds.sbt)
+
+After having added the API dependency to your build for each consumer of the service, we need bind the service client. Lagom uses this binding to provide an implementation of the service's API that uses a client to communicate with the remote service. This can be done using the `bindClient` method on [ServiceClientGuiceSupport](api/index.html?com/lightbend/lagom/javadsl/client/ServiceClientGuiceSupport.html) as explained in [[Binding a service client|ServiceClients#Binding-a-service-client]] .
 
 @[bind-hello-client](../services/code/docs/services/client/Module.java)
 
@@ -98,6 +114,6 @@ After providing the binding, just type `reload` in the sbt console. Then, when e
 (Services started, use Ctrl+D to stop and go back to the console...)
 ```
 
-Now that you have integrated the `hello` service in your build, any of your Lagom projects can communicate with it after adding a library dependency to its `hello-api` artefact:
+## Decoupling with a message broker
 
-@[hello-communication](code/multiple-builds.sbt)
+Services that use Lagom's [[Message Broker|MessageBroker]] support can entirely avoid the need to run other services in their builds. These services don't need to connect to each other directly, only to Kafka. For development purposes, you can use the `kafka-console-producer` and `kafka-console-consumer` command-line scripts (or other simple Kafka clients) to simulate interactions with other services.

--- a/docs/manual/scala/guide/build/MultipleBuilds.md
+++ b/docs/manual/scala/guide/build/MultipleBuilds.md
@@ -42,9 +42,25 @@ The first argument passed to `lagomExternalScaladslProject` is the name that wil
 
 You can further configure the service (what ports it is available on, the address it is bound to, etc...) using [[the same settings as a managed Lagom Service|ConfiguringServicesInDevelopment]].
 
-## Binding the service
+## Mocking a service
 
-After having added the external Lagom project to your build, we need to provide the binding as it's necessary to consume a service, so that Lagom can provide an implementation for your application to use.  This can be done using `serviceClient.implement[T]` as explained in [[Binding a service client|ServiceClients#Binding-a-service-client]] .
+Sometimes a service that you import will depend on other services in turn. This can lead to a cascade of importing one service after another, until you find yourself having to run the entire system in your build. Other than being inconvenient to manage, for large systems this may not be feasible. Instead, you might choose to mock some services, providing a fake implementation of a real service's API. The mock implementation is only used to run _other_ services in development that consume that service's API, without having to import the real implementation into their builds. This is similar to the use of mocking libraries in unit tests---such as [Mockito](https://site.mockito.org/), [jMock](http://jmock.org/), or [ScalaMock](https://scalamock.org/)---but at the service level instead of the class level.
+
+Writing and using a mock service implementation is just like writing and using a real service implementation, but with the business logic replaced by simple hard-coded responses. A mock service implementation should not depend on any other services, databases, message brokers, or any other infrastructure. For example, you might be developing an OAuth service that validates user credentials using a separate user authentication service, and then generates and stores API tokens for authenticated users. The user authentication service in turn might interact with a service that handles new user registration, a user profile management service that handles password changes, and an LDAP server for SSO integration. When testing the OAuth service, it isn't always necessary to include all of that additional complexity and test it end-to-end. Instead, you can run a mock user authentication service that implements the same API as the real one, but only supports a small set of test users. Running the mock service in the build for the OAuth service allows you to test the OAuth functionality in isolation from those unrelated concerns.
+
+You can choose to implement the mock service in the same build as the consuming service, by creating a new service implementation in that project that depends on the API library published by the original service. Alternatively, you could implement the mock service in the same build as the real service, publish it alongside the real implementation, and import the mock into the builds of consuming services, as described above.
+
+The benefit of locating the mock in the consuming service build is that it makes it very easy to change the mock implementation as the consuming service is developed, with all of the benefits of Lagom's automatic reloading, and no need to publish the mock to an artifact repository for each change. If the real service has multiple consumers, it allows each consumer to have a custom mock implementation, tailored to its own use of the service.
+
+On the other hand, the benefit of locating the mock next to the real implementation is that a single mock implementation can be shared by multiple consuming service projects. Sometimes, this will be more convenient than creating a mock implementation for each consuming service. The choice is yours.
+
+## Using the external service
+
+Now that you have integrated the `hello` service in your build (or a mock equivalent), any of your Lagom projects can communicate with it after adding a library dependency to its `hello-api` artifact:
+
+@[hello-communication](code/multiple-builds.sbt)
+
+After having added the API dependency to your build for each consumer of the service, we need bind the service client. Lagom uses this binding to provide an implementation of the service's API that uses a client to communicate with the remote service. This can be done using `serviceClient.implement[T]` as explained in [[Binding a service client|ServiceClients#Binding-a-service-client]] .
 
 After providing the binding, just type `reload` in the sbt console. Then, when executing `runAll`, you should see that the `hello` service is started, together with all other services defined in the build:
 
@@ -57,6 +73,6 @@ After providing the binding, just type `reload` in the sbt console. Then, when e
 (Services started, use Ctrl+D to stop and go back to the console...)
 ```
 
-Now that you have integrated the `hello` service in your build, any of your Lagom projects can communicate with it after adding a library dependency to its `hello-api` artefact:
+## Decoupling with a message broker
 
-@[hello-communication](code/multiple-builds.sbt)
+Services that use Lagom's [[Message Broker|MessageBroker]] support can entirely avoid the need to run other services in their builds. These services don't need to connect to each other directly, only to Kafka. For development purposes, you can use the `kafka-console-producer` and `kafka-console-consumer` command-line scripts (or other simple Kafka clients) to simulate interactions with other services.


### PR DESCRIPTION
- Describe how to implement a mock service
- Clarify the explanation of binding a client
- Add a note on decoupling services with the Message Broker API

## References

Raised in an internal discussion with Lightbend professional services.