### PR TITLE
Don't run validateDependencies (whitelist) in CI

### DIFF
--- a/bin/test-code-style
+++ b/bin/test-code-style
@@ -17,8 +17,6 @@ runSbt  +headerCheck \
 declare -a EXTRA_TASKS
 if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
     EXTRA_TASKS+=("versionSyncCheck")
-    # only safe when not cron, b/c snapshot akka versions can break validateDependencies
-    EXTRA_TASKS+=("validateDependencies")
 fi
 
 runSbt  "${EXTRA_TASKS[@]}" \


### PR DESCRIPTION
This need to be backported to 1.5.x and merged back in master when we do the branch merging of 1.6.x -> master