### PR TITLE
Pass initial configuration to additional configuration override.

### DIFF
--- a/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/AdditionalConfiguration.scala
+++ b/service/scaladsl/api/src/main/scala/com/lightbend/lagom/scaladsl/api/AdditionalConfiguration.scala
@@ -15,6 +15,9 @@ import play.api.Configuration
  * can control which order this configuration gets applied by changing the order in which traits are mixed together.
  */
 trait ProvidesAdditionalConfiguration {
+  @deprecated(message = "prefer `additionalConfiguration(initialConfiguration: Configuration)`", since = "1.6.0")
+  def additionalConfiguration: AdditionalConfiguration = AdditionalConfiguration.empty
+
   /**
    * Define the additional configuration to add to the application.
    *
@@ -23,8 +26,11 @@ trait ProvidesAdditionalConfiguration {
    *
    * When overriding, the overridden file should be a def, so as to ensure multiple components can all override it.
    * Lagom will only invoke this method once from a lazy val, so it will effectively be calculated once.
+   *
+   * @param initialConfiguration A reference to the application configuration prior to override.
    */
-  def additionalConfiguration: AdditionalConfiguration = AdditionalConfiguration.empty
+  def additionalConfiguration(initialConfiguration: Configuration): AdditionalConfiguration =
+    AdditionalConfiguration.empty
 }
 
 /**

--- a/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslErrorHandlingSpec.scala
+++ b/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslErrorHandlingSpec.scala
@@ -248,9 +248,9 @@ class ScaladslErrorHandlingSpec extends WordSpec with Matchers {
         override lazy val lagomServer = serverFor[MockService](new MockServiceImpl)
         override lazy val environment = Environment.simple(mode = mode)
 
-        override def additionalConfiguration: AdditionalConfiguration = {
+        override def additionalConfiguration(initialConfiguration: Configuration): AdditionalConfiguration = {
           import scala.collection.JavaConverters._
-          super.additionalConfiguration ++ ConfigFactory.parseMap(
+          super.additionalConfiguration(initialConfiguration) ++ ConfigFactory.parseMap(
             Map(
               "play.server.provider" -> httpBackend.provider
             ).asJava

--- a/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslMockServiceSpec.scala
+++ b/service/scaladsl/integration-tests/src/test/scala/com/lightbend/lagom/scaladsl/it/ScaladslMockServiceSpec.scala
@@ -223,9 +223,9 @@ class ScaladslMockServiceSpec extends WordSpec with Matchers {
       new LagomApplication(LagomApplicationContext.Test) with AhcWSComponents with LocalServiceLocator {
         override lazy val lagomServer = serverFor[MockService](new MockServiceImpl)
 
-        override def additionalConfiguration: AdditionalConfiguration = {
+        override def additionalConfiguration(initialConfiguration: Configuration): AdditionalConfiguration = {
           import scala.collection.JavaConverters._
-          super.additionalConfiguration ++ ConfigFactory.parseMap(
+          super.additionalConfiguration(initialConfiguration) ++ ConfigFactory.parseMap(
             Map(
               "play.server.provider" -> httpBackend.provider
             ).asJava

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -27,6 +27,7 @@ import com.lightbend.lagom.scaladsl.api.broker.Message
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.api.broker.kafka.KafkaProperties
 import com.lightbend.lagom.scaladsl.api.broker.kafka.PartitionKeyStrategy
+import com.lightbend.lagom.scaladsl.api.AdditionalConfiguration
 import com.lightbend.lagom.scaladsl.api.Descriptor
 import com.lightbend.lagom.scaladsl.api.Service
 import com.lightbend.lagom.scaladsl.broker.TopicProducer
@@ -43,6 +44,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest._
 import org.slf4j.LoggerFactory
 import play.api.libs.ws.ahc.AhcWSComponents
+import play.api.Configuration
 
 import scala.collection.mutable
 import scala.concurrent.Await
@@ -76,9 +78,9 @@ class ScaladslKafkaApiSpec
       override lazy val jsonSerializerRegistry = EmptyJsonSerializerRegistry
       override lazy val lagomServer            = serverFor[TestService](new TestServiceImpl)
 
-      override def additionalConfiguration = {
+      override def additionalConfiguration(initialConfiguration: Configuration): AdditionalConfiguration = {
         import scala.collection.JavaConverters._
-        super.additionalConfiguration ++ ConfigFactory.parseMap(
+        super.additionalConfiguration(initialConfiguration) ++ ConfigFactory.parseMap(
           Map(
             "akka.remote.artery.canonical.port"             -> "0",
             "akka.remote.artery.canonical.hostname"         -> "127.0.0.1",

--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationLoader.scala
@@ -213,8 +213,9 @@ abstract class LagomApplication(context: LagomApplicationContext)
 
   @deprecated(message = "prefer `config` using typesafe Config instead", since = "1.4.0")
   override lazy val configuration: Configuration = {
-    val additionalConfig = new Configuration(additionalConfiguration.configuration)
-    Configuration.load(environment) ++ context.playContext.initialConfiguration ++ additionalConfig
+    val initialConfiguration = Configuration.load(environment) ++ context.playContext.initialConfiguration
+    val additionalConfig     = new Configuration(additionalConfiguration(initialConfiguration).configuration)
+    initialConfiguration ++ additionalConfig
   }
 
   override lazy val actorSystem: ActorSystem =

--- a/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationSpec.scala
+++ b/service/scaladsl/server/src/test/scala/com/lightbend/lagom/scaladsl/server/LagomApplicationSpec.scala
@@ -17,6 +17,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.Matchers
 import org.scalatest.WordSpec
 import play.api.ApplicationLoader.Context
+import play.api.Configuration
 import play.api.Environment
 import play.api.inject.DefaultApplicationLifecycle
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -67,8 +68,8 @@ class LagomApplicationSpec extends WordSpec with Matchers {
   private val configKey = "akka.cluster.seed-nodes"
 
   trait FakeComponent extends ProvidesAdditionalConfiguration {
-    override def additionalConfiguration: AdditionalConfiguration =
-      super.additionalConfiguration ++
+    override def additionalConfiguration(initialConfiguration: Configuration): AdditionalConfiguration =
+      super.additionalConfiguration(initialConfiguration) ++
         ConfigFactory.parseString(configKey + "=\"via additional\"")
   }
 

--- a/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/services/FakeServices.scala
+++ b/testkit/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/testkit/services/FakeServices.scala
@@ -63,9 +63,9 @@ abstract class DownstreamApplication(context: LagomApplicationContext)
     with AhcWSComponents {
   // This is a hack so C* persistence in this Applicaiton doesn't complain. C* Persistence is only used
   // so intances of this Application can mix-in a TopicComponents implementation (Test or Kafka)
-  override def additionalConfiguration: AdditionalConfiguration = {
+  override def additionalConfiguration(initialConfiguration: Configuration): AdditionalConfiguration = {
     import scala.collection.JavaConverters._
-    super.additionalConfiguration ++ ConfigFactory.parseMap(
+    super.additionalConfiguration(initialConfiguration) ++ ConfigFactory.parseMap(
       Map(
         "cassandra-journal.keyspace"                     -> "asdf",
         "cassandra-snapshot-store.keyspace"              -> "asdf",


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #2448 

## Purpose

Allow `additionalConfiguration` access to the initial application configuration which it may override.

## Background Context

I had a use-case where I needed to reference values in the initial application configuration in order to implement my override logic. Currently this would require explicitly compiling the initial application configuration in the same way it is already compiled in `LagomApplication` inside of my additional configuration implementation. See #2448 for more details.

This PR still requires documentation updates and test coverage. I would also like guidance on deprecation: should we allow both methods to exist? If not, what should be provided in `since`? I have stubbed it out with `1.6.0` for now.