### PR TITLE
Run scripted tests targeting sbt 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
     - script: bin/test-docs-code-only
       env: TRAVIS_JDK=11
       name: "Documentation tests (Java 11)"
+
     - stage: test-build-tools
       script: SCALA_VERSION=2.10.7 bin/test-sbt
       name: "Scripted tests for sbt 0.13"
@@ -70,6 +71,9 @@ jobs:
     - script: bin/test-maven
       name: "PublishM2 and test Maven using Java 11"
       env: TRAVIS_JDK=11
+    - script: SCALA_VERSION=2.12.10 bin/test-sbt-13x
+      name: "Scripted tests for sbt 1.3"
+      if: type = cron
 
 cache:
   directories:

--- a/bin/test-sbt-13x
+++ b/bin/test-sbt-13x
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+
+# shellcheck source=bin/scriptLib
+. "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
+
+SBT_VERSION="1.3.4"
+SCALA_VERSION="${SCALA_VERSION:-2.12.10}"
+
+# disable publishing javadoc for scripted
+runSbtNoisy ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ;+ server-containers/publishLocal;++$SCALA_VERSION publishScriptedDependencies ;project sbt-plugin ;set scriptedSbt := \"${SBT_VERSION}\" ;project / ;++${SCALA_VERSION} scripted"


### PR DESCRIPTION
The key `sbtVersion in pluginCrossBuild` defines the target sbt version
and is the default for `scriptedSbt`, which is the key used when running
scripted.  So by leaving the former set to 1.2.8 (in defineSbtVersion at
the top of build.sbt) but setting scriptedSbt we test that the
1.2.8-targetting build runs on sbt 1.3.

To mitigate the cost on CI times, this will only run in cron builds.