### PR TITLE
Disable scala-steward updates for scalafmt-core

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,6 @@
+updates.ignore = [
+  // explicit updates
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+]
+
 updatePullRequests = false


### PR DESCRIPTION
We get very often updates for scalafmt that requires a code reformatting. While is nice to have it each time it's adding some unnecessary overhead.

This PR disable it. We can apply updates from time to time manually when we get to know about any performance improvements or new formatting rule of interest.