### PR TITLE
Tweak Akka snapshot handling

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1258,7 +1258,7 @@ def scriptedSettings: Seq[Setting[_]] =
           .get("scripted.scala.version")
           .getOrElse((scalaVersion in `reloadable-server`).value),
         s"-Dsbt.boot.directory=${file(sys.props("user.home")) / ".sbt" / "boot"}",
-      )
+      ) ++ sys.props.get("lagom.build.akka.version").map(v => s"-Dlagom.build.akka.version=$v").toSeq
     )
 
 def archetypeVariables(lagomVersion: String) = Map(

--- a/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
+++ b/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
@@ -46,7 +46,7 @@ object ScriptedTools extends AutoPlugin {
     // This is copy & pasted from project/AkkaSnapshotRepositories so that scripted tests
     // can use Akka snapshot repositories as well. If you change it here, remember to keep
     // project/AkkaSnapshotRepositories in sync.
-    resolvers ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+    resolvers ++= (sys.props.get("lagom.build.akka.version") match {
       case Some(_) =>
         Seq(
           "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),

--- a/project/AkkaSnapshotRepositories.scala
+++ b/project/AkkaSnapshotRepositories.scala
@@ -14,9 +14,9 @@ object AkkaSnapshotRepositories extends AutoPlugin {
   // can use Akka snapshot repositories as well. If you change it here, remember to keep
   // ScriptedTools in sync.
   override def projectSettings: Seq[Def.Setting[_]] = {
-    // If this is a cron job in Travis:
-    // https://docs.travis-ci.com/user/cron-jobs/#detecting-builds-triggered-by-cron
-    resolvers ++= (sys.env.get("TRAVIS_EVENT_TYPE").filter(_.equalsIgnoreCase("cron")) match {
+    // The system property lagom.build.akka.version is regularly used for snapshot versions
+    // so it's the trigger for adding the snapshots resolvers
+    resolvers ++= (sys.props.get("lagom.build.akka.version") match {
       case Some(_) =>
         Seq(
           "akka-snapshot-repository".at("https://repo.akka.io/snapshots"),


### PR DESCRIPTION
Use the system property instead of the TRAVIS_EVENT_TYPE env var as a trigger.

Requires adding to scriptedLaunchOpts, though...