### PR TITLE
Remove use of getClass in constructors

### DIFF
--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -26,7 +26,8 @@ class CassandraPersistenceSpec(system: ActorSystem) extends ActorSystemSpec(syst
       )
     )
 
-  def this(config: Config) = this(PersistenceSpec.getCallerName(getClass), config)
+  def this(config: Config) =
+    this(PersistenceSpec.testNameFromCallStack(classOf[CassandraPersistenceSpec]), config)
 
   def this() = this(ConfigFactory.empty())
 

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceSpec.scala
@@ -35,7 +35,7 @@ class CassandraPersistenceSpec private (system: ActorSystem) extends ActorSystem
     )
 
   def this(config: Config, jsonSerializerRegistry: JsonSerializerRegistry) =
-    this(PersistenceSpec.getCallerName(getClass), config, jsonSerializerRegistry)
+    this(PersistenceSpec.testNameFromCallStack(classOf[CassandraPersistenceSpec]), config, jsonSerializerRegistry)
 
   def this(jsonSerializerRegistry: JsonSerializerRegistry) = this(ConfigFactory.empty(), jsonSerializerRegistry)
 

--- a/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -25,7 +25,7 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     this(ActorSystem(testName, config.withFallback(Configuration.load(Environment.simple()).underlying)))
   }
 
-  def this(config: Config) = this(PersistenceSpec.getCallerName(getClass), config)
+  def this(config: Config) = this(PersistenceSpec.testNameFromCallStack(classOf[JdbcPersistenceSpec]), config)
 
   def this() = this(ConfigFactory.empty())
 

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/jdbc/JdbcPersistenceSpec.scala
@@ -41,7 +41,7 @@ abstract class JdbcPersistenceSpec private (_system: ActorSystem) extends ActorS
     )
 
   def this(config: Config, registry: JsonSerializerRegistry) =
-    this(PersistenceSpec.getCallerName(getClass), config, registry)
+    this(PersistenceSpec.testNameFromCallStack(classOf[JdbcPersistenceSpec]), config, registry)
 
   def this(registry: JsonSerializerRegistry) = this(ConfigFactory.empty(), registry)
 

--- a/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
+++ b/persistence-jdbc/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickPersistenceSpec.scala
@@ -41,7 +41,7 @@ abstract class SlickPersistenceSpec private (_system: ActorSystem) extends Actor
     )
 
   def this(config: Config, registry: JsonSerializerRegistry) =
-    this(PersistenceSpec.getCallerName(getClass), config, registry)
+    this(PersistenceSpec.testNameFromCallStack(classOf[SlickPersistenceSpec]), config, registry)
 
   def this(registry: JsonSerializerRegistry) =
     this(ConfigFactory.empty(), registry)

--- a/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/persistence/ActorSystemSpec.scala
@@ -4,6 +4,8 @@
 
 package com.lightbend.lagom.persistence
 
+import java.lang.reflect.Modifier
+
 import akka.actor.ActorSystem
 import akka.actor.CoordinatedShutdown
 import akka.actor.setup.ActorSystemSetup
@@ -20,16 +22,48 @@ import org.scalatest.Matchers
 import org.scalatest.WordSpecLike
 
 object ActorSystemSpec {
-  def getCallerName(clazz: Class[_]): String = {
-    val s = Thread.currentThread.getStackTrace
-      .map(_.getClassName)
-      .drop(1)
-      .dropWhile(_.matches("(java.lang.Thread|.*ActorSystemSpec.?$)"))
-    val reduced = s.lastIndexWhere(_ == clazz.getName) match {
-      case -1 => s
-      case z  => s.drop(z + 1)
+  // taken from akka-testkit's AkkaSpec
+  private def testNameFromCallStack(classToStartFrom: Class[_]): String = {
+
+    def isAbstractClass(className: String): Boolean = {
+      try {
+        Modifier.isAbstract(Class.forName(className).getModifiers)
+      } catch {
+        case _: Throwable => false // yes catch everything, best effort check
+      }
     }
-    reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
+
+    val startFrom = classToStartFrom.getName
+    val filteredStack = Thread.currentThread.getStackTrace.iterator
+      .map(_.getClassName)
+      // drop until we find the first occurrence of classToStartFrom
+      .dropWhile(!_.startsWith(startFrom))
+      // then continue to the next entry after classToStartFrom that makes sense
+      .dropWhile {
+        case `startFrom`                            => true
+        case str if str.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
+        case str if isAbstractClass(str)            => true
+        case _                                      => false
+      }
+
+    if (filteredStack.isEmpty)
+      throw new IllegalArgumentException(s"Couldn't find [${classToStartFrom.getName}] in call stack")
+
+    // sanitize for actor system name
+    scrubActorSystemName(filteredStack.next())
+  }
+
+  // taken from akka-testkit's AkkaSpec
+  /**
+   * Sanitize the `name` to be used as valid actor system name by
+   * replacing invalid characters. `name` may for example be a fully qualified
+   * class name and then the short class name will be used.
+   */
+  private def scrubActorSystemName(name: String): String = {
+    name
+      .replaceFirst("""^.*\.""", "")  // drop package name
+      .replaceAll("""\$\$?\w+""", "") // drop scala anonymous functions/classes
+      .replaceAll("[^a-zA-Z_0-9]", "_")
   }
 }
 
@@ -43,9 +77,10 @@ abstract class ActorSystemSpec(system: ActorSystem)
   def this(testName: String, config: Config) =
     this(ActorSystem(testName, config))
 
-  def this(config: Config) = this(ActorSystemSpec.getCallerName(getClass), config)
+  def this(config: Config) = this(ActorSystemSpec.testNameFromCallStack(classOf[ActorSystemSpec]), config)
 
-  def this(setup: ActorSystemSetup) = this(ActorSystem(ActorSystemSpec.getCallerName(getClass), setup))
+  def this(setup: ActorSystemSetup) =
+    this(ActorSystem(ActorSystemSpec.testNameFromCallStack(classOf[ActorSystemSpec]), setup))
 
   def this() = this(ConfigFactory.empty())
 

--- a/persistence/core/src/test/scala/com/lightbend/lagom/persistence/PersistenceSpec.scala
+++ b/persistence/core/src/test/scala/com/lightbend/lagom/persistence/PersistenceSpec.scala
@@ -4,16 +4,50 @@
 
 package com.lightbend.lagom.persistence
 
+import java.lang.reflect.Modifier
+
 object PersistenceSpec {
-  def getCallerName(clazz: Class[_]): String = {
-    val s = Thread.currentThread.getStackTrace
-      .map(_.getClassName)
-      .drop(1)
-      .dropWhile(_.matches("(java.lang.Thread|.*PersistenceSpec.?$)"))
-    val reduced = s.lastIndexWhere(_ == clazz.getName) match {
-      case -1 => s
-      case z  => s.drop(z + 1)
+  // taken from akka-testkit's AkkaSpec
+  private[lagom] def testNameFromCallStack(classToStartFrom: Class[_]): String = {
+
+    def isAbstractClass(className: String): Boolean = {
+      try {
+        Modifier.isAbstract(Class.forName(className).getModifiers)
+      } catch {
+        case _: Throwable => false // yes catch everything, best effort check
+      }
     }
-    reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
+
+    val startFrom = classToStartFrom.getName
+    val filteredStack = Thread.currentThread.getStackTrace.iterator
+      .map(_.getClassName)
+      // drop until we find the first occurrence of classToStartFrom
+      .dropWhile(!_.startsWith(startFrom))
+      // then continue to the next entry after classToStartFrom that makes sense
+      .dropWhile {
+        case `startFrom`                            => true
+        case str if str.startsWith(startFrom + "$") => true // lambdas inside startFrom etc
+        case str if isAbstractClass(str)            => true
+        case _                                      => false
+      }
+
+    if (filteredStack.isEmpty)
+      throw new IllegalArgumentException(s"Couldn't find [${classToStartFrom.getName}] in call stack")
+
+    // sanitize for actor system name
+    scrubActorSystemName(filteredStack.next())
+  }
+
+  // taken from akka-testkit's AkkaSpec
+  /**
+   * Sanitize the `name` to be used as valid actor system name by
+   * replacing invalid characters. `name` may for example be a fully qualified
+   * class name and then the short class name will be used.
+   */
+  private def scrubActorSystemName(name: String): String = {
+    name
+      .replaceFirst("""^.*\.""", "")  // drop package name
+      .replaceAll("""\$\$?\w+""", "") // drop scala anonymous functions/classes
+      .replaceAll("[^a-zA-Z_0-9]", "_")
   }
 }


### PR DESCRIPTION
Copy akka/akka#28355.

This getClass was using Predef.getClass, which is why it's now illegal
(in Scala's 2.13.x HEAD).

Fixes #2579.