### PR TITLE
travis: fix coursier/ivy caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ jobs:
 
 cache:
   directories:
-    - $HOME/.coursier/cache
-    - $HOME/.ivy2
+    - $HOME/.cache/coursier
+    - $HOME/.ivy2/cache
     - $HOME/.jabba/jdk
     - $HOME/.sbt
     - $HOME/.m2/repository
@@ -87,8 +87,6 @@ before_cache:
   # Ensure changes to the cache aren't persisted
   - rm -rf $HOME/.ivy2/cache/com.lightbend.lagom/*
   - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.lightbend.lagom/*
-  - rm -rf $HOME/.ivy2/local/com.lightbend.lagom/*
-  - rm -rf $HOME/.ivy2/local/scala_*/sbt_*/com.lightbend.lagom/*
   - rm -r $HOME/.m2/repository/com/lightbend/lagom/*
   # Delete all ivydata files since ivy touches them on each build
   - find $HOME/.ivy2 -name "ivydata-*.properties" -delete


### PR DESCRIPTION
Switch to Coursier's new cache path (XDG).

Also, only cache ~/.ivy2/cache, as ~/.ivy2/local is only meant for local
publishes, and shouldn't persist jobs or builds.