### PR TITLE
Merge pull request #2619 from dwijnand/mergify/scala-steward-review-requested

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -37,18 +37,6 @@ pull_request_rules:
     conditions:
       - author=scala-steward
       - status-success=Travis CI - Pull Request
-      - "#review-requested=0"
-      - "#changes-requested-reviews-by=0"
-      - label!=status:block-merge
-    actions:
-      merge:
-        method: merge
-
-  - name: Merge ScalaSteward's PRs even without core approval
-    conditions:
-      - author=scala-steward
-      - status-success=Travis CI - Pull Request
-      - "review-requested=@lagom/core"
       - "#changes-requested-reviews-by=0"
       - label!=status:block-merge
     actions:


### PR DESCRIPTION
I noticed that https://github.com/lagom/lagom/pull/2617 didn't
auto-merge, despite it should've satisfied all the conditions of the
"Merge ScalaSteward's PRs even without core approval" rule.  On review
it seems that the "review-requested=@lagom/core" condition wasn't
satisfied.  After trying and failing to find out why, I'm proposing (as
a workaround) that we just drop the condition (and, thus, merge the 2
ScalaSteward rules into 1).

The effect of this proposal is: if you previously requested the review of
someone (such as yourself) in a ScalaSteward PR, that will no longer
block the merge.  Personally I think that's fine.  We still have the
"block-merge" tag and the "change request" review as manual ways to
block a merge.

An alternative workaround would be to drop the codeowners setup we have
that auto-requests the review of @lagom/core.