### PR TITLE
Get latest Akka snapshot with dynver-style version

### DIFF
--- a/bin/scriptLib
+++ b/bin/scriptLib
@@ -15,8 +15,7 @@ EXTRA_OPTS=("-Dakka.test.timefactor=10")
 
 # Check if it is a scheduled build
 if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-    # `sort` is not necessary, but it is good to make it predictable.
-    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.12/ | grep -oEi '2\.6-[0-9]{8}-[0-9]{6}' | sort | tail -n 1)
+    AKKA_VERSION=$(curl -s https://repo.akka.io/snapshots/com/typesafe/akka/akka-actor_2.13/ | grep -oEi '2\.6\.[0-9]+\+[0-9]+-[0-9a-f]{8}' | sort -V | tail -n 1)
 
     echo "Using Akka SNAPSHOT ${AKKA_VERSION}"
 


### PR DESCRIPTION
Manually backport #2567 to `1.6.x` 