### PR TITLE
Fixes #2135 - Duplicate Sec-WebSocket-Protocol headers in respo…

### DIFF
--- a/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
+++ b/dev/service-registry/service-locator/src/main/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGateway.scala
@@ -181,6 +181,8 @@ class AkkaHttpServiceGateway(
     "Sec-WebSocket-Accept",
     "Sec-WebSocket-Version",
     "Sec-WebSocket-Key",
+    "Sec-WebSocket-Extensions",
+    "Sec-WebSocket-Protocol",
     "UpgradeToWebSocket",
     "Upgrade",
     "Connection",

--- a/dev/service-registry/service-locator/src/test/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGatewaySpec.scala
+++ b/dev/service-registry/service-locator/src/test/scala/com/lightbend/lagom/gateway/AkkaHttpServiceGatewaySpec.scala
@@ -14,11 +14,10 @@ import akka.http.scaladsl.model.ws.Message
 import akka.http.scaladsl.model.ws.TextMessage
 import akka.http.scaladsl.model.ws.UpgradeToWebSocket
 import akka.http.scaladsl.model.ws.WebSocketRequest
-import akka.http.scaladsl.model.HttpEntity
-import akka.http.scaladsl.model.HttpRequest
-import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Keep
 import akka.stream.scaladsl.Sink
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
@@ -54,7 +53,17 @@ class AkkaHttpServiceGatewaySpec extends WordSpec with Matchers with BeforeAndAf
           case req if req.uri.path.toString() == "/echo-headers" =>
             HttpResponse(entity = HttpEntity(req.headers.map(h => s"${h.name()}: ${h.value}").mkString("\n")))
           case stream if stream.uri.path.toString() == "/stream" =>
-            stream.header[UpgradeToWebSocket].get.handleMessages(Flow[Message])
+            stream
+              .header[UpgradeToWebSocket]
+              .get
+              .handleMessages(
+                Flow[Message],
+                stream.headers
+                  .find(_.lowercaseName() == "sec-websocket-protocol")
+                  .map(_.value)
+                  .map(_.split(","))
+                  .map(_.head)
+              )
         },
         "localhost",
         port = 0
@@ -116,6 +125,30 @@ class AkkaHttpServiceGatewaySpec extends WordSpec with Matchers with BeforeAndAf
       )
 
       (result should contain).inOrderOnly("Hello", "world")
+    }
+
+    "serve websocket requests with the correct response" in {
+      val flow = http.webSocketClientFlow(
+        WebSocketRequest(
+          s"$gatewayWsUri/stream",
+          collection.immutable.Seq.empty[HttpHeader],
+          collection.immutable.Seq("echo")
+        )
+      )
+      val result = Await.result(
+        Source
+          .single(TextMessage("hello world!"))
+          .viaMat(flow)(Keep.right)
+          .to(Sink.ignore)
+          .run(),
+        10.seconds
+      )
+
+      result.response.status should equal(StatusCodes.SwitchingProtocols)
+      result.response.headers.count(_.lowercaseName() == "sec-websocket-protocol") should equal(1)
+      result.response.headers.find(_.lowercaseName() == "sec-websocket-protocol").map(_.value()).get should equal(
+        "echo"
+      )
     }
 
     "serve not found when no ACL matches" in {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #2135

## Purpose

Stop sending duplicate `Sec-WebSocket-Protocol` header in response when a subprotocol is defined

## Background Context

`AkkaHttpServiceGateway` was blindly concatenating service and client side headers, with this approach it verifies if the header is already on the list before adding it.

## References

Are there any relevant issues / PRs / mailing lists discussions?
