### PR TITLE
[WIP ] Projection worker refactor + TopicProducer new API

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,4 @@
 -Xms2G
--Xmx2G
 -Xss2M
 -XX:MaxInlineLevel=18
 -XX:MaxMetaspaceSize=1G

--- a/build.sbt
+++ b/build.sbt
@@ -281,8 +281,10 @@ val mimaSettings: Seq[Setting[_]] = {
       else moduleID
     }.toSet,
     mimaBinaryIssueFilters ++= Seq(
-      // Add mima filters here.
-
+      // Some general filters first.
+      ProblemFilters.exclude[Problem]("com.lightbend.internal.*"),
+      ProblemFilters.exclude[Problem]("com.lightbend.lagom.internal.*"),
+      // Non-general mima filters here.
       // Remove CassandraReadSide legacy implementation
       ProblemFilters
         .exclude[MissingClassProblem]("com.lightbend.lagom.javadsl.persistence.cassandra.CassandraReadSideProcessor"),
@@ -303,6 +305,13 @@ val mimaSettings: Seq[Setting[_]] = {
       ),
       ProblemFilters.exclude[MissingClassProblem](
         "com.lightbend.lagom.internal.javadsl.persistence.cassandra.LegacyCassandraReadSideHandler"
+      ),
+      // TopicProducer API with delegated stream construction (adds PersistentEntityRegistry.eventEnvelopeStream)
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "com.lightbend.lagom.scaladsl.persistence.PersistentEntityRegistry.eventEnvelopeStream"
+      ),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "com.lightbend.lagom.javadsl.persistence.PersistentEntityRegistry.eventEnvelopeStream"
       ),
     )
   )

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -4,11 +4,6 @@
 
 package com.lightbend.lagom.scaladsl.persistence.cassandra
 
-import akka.persistence.query.TimeBasedUUID
-
-import scala.concurrent.Future
-import scala.concurrent.duration._
-import com.typesafe.config.ConfigFactory
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.CassandraPersistentEntityRegistry
@@ -16,6 +11,9 @@ import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.CassandraRead
 import com.lightbend.lagom.internal.scaladsl.persistence.cassandra.ScaladslCassandraOffsetStore
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence._
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.Future
 
 object CassandraReadSideSpec {
   val defaultConfig      = ConfigFactory.parseString("akka.loglevel = INFO")

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -191,7 +191,7 @@ class AbstractPersistentEntityRegistry(
 private[lagom] object AbstractPersistentEntityRegistry {
 
   @InternalApi
-  def toStreamElement[Event <: AggregateEvent[Event]](env: EventEnvelope): japi.Pair[Event, Offset] =
-    japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset))
+  def toStreamElement[Event <: AggregateEvent[Event]]: japi.function.Function[EventEnvelope, japi.Pair[Event, Offset]] =
+    env => japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset))
 
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -146,7 +146,7 @@ class AbstractPersistentEntityRegistry(
       fromOffset: Offset
   ): javadsl.Source[japi.Pair[Event, Offset], NotUsed] = {
     eventEnvelopeStream(aggregateTag, fromOffset)
-      .map(env => japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset)))
+      .map(AbstractPersistentEntityRegistry.toStreamElement)
 
   }
   @InternalApi

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -16,13 +16,11 @@ import akka.cluster.sharding.ClusterSharding
 import akka.cluster.sharding.ClusterShardingSettings
 import akka.cluster.sharding.ShardRegion
 import akka.japi
-import akka.japi.function
 import akka.persistence.query.EventEnvelope
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery
-import akka.persistence.query.{ Offset => AkkaOffset }
+import akka.persistence.query.{Offset => AkkaOffset}
 import akka.stream.javadsl
-import akka.stream.scaladsl
 import com.lightbend.lagom.javadsl.persistence._
 import play.api.inject.Injector
 

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -19,7 +19,7 @@ import akka.japi
 import akka.persistence.query.EventEnvelope
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery
-import akka.persistence.query.{Offset => AkkaOffset}
+import akka.persistence.query.{ Offset => AkkaOffset }
 import akka.stream.javadsl
 import com.lightbend.lagom.javadsl.persistence._
 import play.api.inject.Injector

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -142,11 +142,10 @@ class AbstractPersistentEntityRegistry(
   override def eventStream[Event <: AggregateEvent[Event]](
       aggregateTag: AggregateEventTag[Event],
       fromOffset: Offset
-  ): javadsl.Source[japi.Pair[Event, Offset], NotUsed] = {
+  ): javadsl.Source[japi.Pair[Event, Offset], NotUsed] =
     eventEnvelopeStream(aggregateTag, fromOffset)
-      .map(AbstractPersistentEntityRegistry.toStreamElement)
+      .map(AbstractPersistentEntityRegistry.toStreamElement[Event])
 
-  }
   @InternalApi
   private[lagom] override def eventEnvelopeStream[Event <: AggregateEvent[Event]](
       aggregateTag: AggregateEventTag[Event],
@@ -155,7 +154,6 @@ class AbstractPersistentEntityRegistry(
     eventsByTagQuery match {
       case Some(queries) =>
         val startingOffset = mapStartingOffset(fromOffset)
-
         queries
           .eventsByTag(aggregateTag.tag, startingOffset)
           .asJava
@@ -189,7 +187,7 @@ class AbstractPersistentEntityRegistry(
 private[lagom] object AbstractPersistentEntityRegistry {
 
   @InternalApi
-  def toStreamElement[Event <: AggregateEvent[Event]]: japi.function.Function[EventEnvelope, japi.Pair[Event, Offset]] =
-    env => japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset))
+  def toStreamElement[Event <: AggregateEvent[Event]](env: EventEnvelope): japi.Pair[Event, Offset] =
+    japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset))
 
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -20,7 +20,7 @@ import akka.japi.function
 import akka.persistence.query.EventEnvelope
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery
-import akka.persistence.query.{Offset => AkkaOffset}
+import akka.persistence.query.{ Offset => AkkaOffset }
 import akka.stream.javadsl
 import akka.stream.scaladsl
 import com.lightbend.lagom.javadsl.persistence._
@@ -146,18 +146,14 @@ class AbstractPersistentEntityRegistry(
       fromOffset: Offset
   ): javadsl.Source[japi.Pair[Event, Offset], NotUsed] = {
     eventEnvelopeStream(aggregateTag, fromOffset)
-      .map( env =>
-        japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset))
-      )
+      .map(env => japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset)))
 
   }
-
-
   @InternalApi
   private[lagom] override def eventEnvelopeStream[Event <: AggregateEvent[Event]](
-                                                                                   aggregateTag: AggregateEventTag[Event],
-                                                                                   fromOffset: Offset
-                                                                                 ): javadsl.Source[EventEnvelope, NotUsed] = {
+      aggregateTag: AggregateEventTag[Event],
+      fromOffset: Offset
+  ): javadsl.Source[EventEnvelope, NotUsed] = {
     eventsByTagQuery match {
       case Some(queries) =>
         val startingOffset = mapStartingOffset(fromOffset)
@@ -197,6 +193,5 @@ private[lagom] object AbstractPersistentEntityRegistry {
   @InternalApi
   def toStreamElement[Event <: AggregateEvent[Event]](env: EventEnvelope): japi.Pair[Event, Offset] =
     japi.Pair.create(env.event.asInstanceOf[Event], OffsetAdapter.offsetToDslOffset(env.offset))
-
 
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/OffsetAdapter.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/OffsetAdapter.scala
@@ -20,13 +20,13 @@ object OffsetAdapter {
     case TimeBasedUUID(uuid) => LagomJavaDslOffset.timeBasedUUID(uuid)
     case Sequence(value)     => LagomJavaDslOffset.sequence(value)
     case NoOffset            => LagomJavaDslOffset.NONE
-    case _                   => throw new IllegalArgumentException("Unsuppoerted offset type " + offset.getClass.getName)
+    case _                   => throw new IllegalArgumentException("Unsupported offset type " + offset.getClass.getName)
   }
 
   def dslOffsetToOffset(dslOffset: LagomJavaDslOffset): Offset = dslOffset match {
     case uuid: LagomJavaDslOffset.TimeBasedUUID => TimeBasedUUID(uuid.value())
     case seq: LagomJavaDslOffset.Sequence       => Sequence(seq.value())
     case LagomJavaDslOffset.NONE                => NoOffset
-    case _                                      => throw new IllegalArgumentException("Unsuppoerted offset type " + dslOffset.getClass.getName)
+    case _                                      => throw new IllegalArgumentException("Unsupported offset type " + dslOffset.getClass.getName)
   }
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -104,8 +104,8 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
             .flatMapConcat { offset =>
               val envelopeStreamSource: scaladsl.Source[EventEnvelope, NotUsed] =
                 eventStreamFactory(tag, offset).asScala
-              val toLagom: EventEnvelope => japi.Pair[Event, Offset] =
-                AbstractPersistentEntityRegistry.toStreamElement
+              val toLagom: EventEnvelope => japi.Pair[Event, Offset] = ee =>
+                AbstractPersistentEntityRegistry.toStreamElement(ee)
               val usersFlow: Flow[japi.Pair[Event, Offset], Done, _] = handler.handle()
 
               envelopeStreamSource

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -109,7 +109,6 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
               val usersFlow: Flow[japi.Pair[Event, Offset], Done, _] = handler.handle()
 
               envelopeStreamSource
-                .map(identity) // TODO: use the supporting actor
                 .map(toLagom)
                 .via(usersFlow)
 

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -99,7 +99,7 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
           val futureOffset: Future[Offset]                      = handler.prepare(tag).toScala
 
           scaladsl.Source
-            .fromFuture(futureOffset)
+            .future(futureOffset)
             .initialTimeout(config.offsetTimeout)
             .flatMapConcat { offset =>
               val envelopeStreamSource: scaladsl.Source[EventEnvelope, NotUsed] =

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -104,8 +104,8 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
             .flatMapConcat { offset =>
               val envelopeStreamSource: scaladsl.Source[EventEnvelope, NotUsed] =
                 eventStreamFactory(tag, offset).asScala
-              val toLagom: EventEnvelope => japi.Pair[Event, Offset] = ee =>
-                AbstractPersistentEntityRegistry.toStreamElement(ee)
+              val toLagom: EventEnvelope => japi.Pair[Event, Offset] =
+                ee => AbstractPersistentEntityRegistry.toStreamElement(ee)
               val usersFlow: Flow[japi.Pair[Event, Offset], Done, _] = handler.handle()
 
               envelopeStreamSource

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideImpl.scala
@@ -7,18 +7,17 @@ package com.lightbend.lagom.internal.javadsl.persistence
 import java.net.URLEncoder
 import java.util.Optional
 
-import javax.inject.Inject
-import javax.inject.Provider
-import javax.inject.Singleton
 import akka.actor.ActorSystem
-import akka.cluster.Cluster
 import akka.stream.Materializer
-import com.lightbend.lagom.internal.projection.ProjectionRegistry
 import com.lightbend.lagom.internal.persistence.ReadSideConfig
 import com.lightbend.lagom.internal.persistence.cluster.ClusterStartupTask
+import com.lightbend.lagom.internal.projection.ProjectionRegistry
 import com.lightbend.lagom.internal.projection.ProjectionRegistryActor.WorkerCoordinates
 import com.lightbend.lagom.javadsl.persistence._
 import com.typesafe.config.Config
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
 import play.api.inject.Injector
 
 import scala.collection.JavaConverters._
@@ -101,7 +100,7 @@ private[lagom] class ReadSideImpl @Inject() (
         config,
         eventClass,
         globalPrepareTask,
-        persistentEntityRegistry.eventStream[Event],
+        persistentEntityRegistry.eventEnvelopeStream[Event],
         processorFactory
       )
 

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/javadsl/persistence/PersistentEntityRegistry.scala
@@ -4,19 +4,16 @@
 
 package com.lightbend.lagom.javadsl.persistence
 
-import java.util.concurrent.CompletionStage
 import java.util.Optional
 import java.util.UUID
 
-import akka.japi.Pair
-import akka.japi.function.Creator
-import akka.stream.javadsl
-import akka.Done
 import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.japi.Pair
+import akka.persistence.query.EventEnvelope
+import akka.stream.javadsl
 import com.lightbend.lagom.javadsl.persistence.Offset.Sequence
 import com.lightbend.lagom.javadsl.persistence.Offset.TimeBasedUUID
-
-import scala.concurrent.duration._
 
 /**
  * At system startup all [[PersistentEntity]] classes must be registered here
@@ -54,7 +51,7 @@ trait PersistentEntityRegistry {
    * `fromOffset` to start the stream from events following that one.
    *
    * @throws IllegalArgumentException If the `fromOffset` type is not supported
-   *   by this journal.
+   *                                  by this journal.
    */
   def eventStream[Event <: AggregateEvent[Event]](
       aggregateTag: AggregateEventTag[Event],
@@ -88,4 +85,11 @@ trait PersistentEntityRegistry {
       Pair(pair.first, uuid)
     }.asJava
   }
+
+  @InternalApi
+  private[lagom] def eventEnvelopeStream[Event <: AggregateEvent[Event]](
+      aggregateTag: AggregateEventTag[Event],
+      fromOffset: Offset
+  ): javadsl.Source[EventEnvelope, NotUsed]
+
 }

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -147,6 +147,7 @@ class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEn
 }
 
 private[lagom] object AbstractPersistentEntityRegistry {
+
   @InternalApi
   def toStreamElement[Event <: AggregateEvent[Event]](env: EventEnvelope): EventStreamElement[Event] =
     new EventStreamElement[Event](

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideActor.scala
@@ -108,7 +108,6 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
               val usersFlow: Flow[EventStreamElement[Event], Done, NotUsed] = handler.handle()
 
               envelopeSource
-                .map(identity) // TODO: use the supporting actor
                 .map(toLagom)
                 .via(usersFlow)
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/ReadSideImpl.scala
@@ -63,7 +63,7 @@ private[lagom] class ReadSideImpl(
         config,
         eventClass,
         globalPrepareTask,
-        persistentEntityRegistry.eventStream[Event],
+        persistentEntityRegistry.eventEnvelopeStream[Event],
         processorFactory
       )
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRegistry.scala
@@ -6,11 +6,10 @@ package com.lightbend.lagom.scaladsl.persistence
 
 import akka.persistence.query.Offset
 import akka.stream.scaladsl
-import akka.Done
 import akka.NotUsed
+import akka.annotation.InternalApi
+import akka.persistence.query.EventEnvelope
 
-import scala.concurrent.Future
-import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
 /**
@@ -62,4 +61,10 @@ trait PersistentEntityRegistry {
       aggregateTag: AggregateEventTag[Event],
       fromOffset: Offset
   ): scaladsl.Source[EventStreamElement[Event], NotUsed]
+
+  @InternalApi
+  private[lagom] def eventEnvelopeStream[Event <: AggregateEvent[Event]](
+      aggregateTag: AggregateEventTag[Event],
+      fromOffset: Offset
+  ): scaladsl.Source[EventEnvelope, NotUsed]
 }

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package com.lightbend.lagom.internal.broker.kafka
 
 import akka.NotUsed

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
@@ -6,7 +6,6 @@ import akka.persistence.query.{ Offset => AkkaOffset }
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 
-
 sealed trait EventStreamFactory[BrokerMessage]
 
 case class ClassicLagomEventStreamFactory[BrokerMessage](

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
@@ -1,0 +1,21 @@
+package com.lightbend.lagom.internal.broker.kafka
+
+import akka.NotUsed
+import akka.persistence.query.EventEnvelope
+import akka.persistence.query.{ Offset => AkkaOffset }
+import akka.stream.scaladsl.Flow
+import akka.stream.scaladsl.Source
+
+/**
+ *
+ */
+sealed trait EventStreamFactory[BrokerMessage]
+
+case class ClassicLagomEventStreamFactory[BrokerMessage](
+    factory: (String, AkkaOffset) => Source[(BrokerMessage, AkkaOffset), _]
+) extends EventStreamFactory[BrokerMessage]
+
+case class DelegatedEventStreamFactory[BrokerMessage, Event](
+    factory: (String, AkkaOffset) => Source[EventEnvelope, NotUsed],
+    userFlow: Flow[EventEnvelope, (BrokerMessage, AkkaOffset), NotUsed]
+) extends EventStreamFactory[BrokerMessage]

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/EventStreamFactory.scala
@@ -6,9 +6,7 @@ import akka.persistence.query.{ Offset => AkkaOffset }
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 
-/**
- *
- */
+
 sealed trait EventStreamFactory[BrokerMessage]
 
 case class ClassicLagomEventStreamFactory[BrokerMessage](

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
@@ -6,12 +6,8 @@ package com.lightbend.lagom.internal.broker.kafka
 
 import java.net.URI
 
-import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.persistence.query.EventEnvelope
-import akka.persistence.query.Offset
 import akka.stream.Materializer
-import akka.stream.scaladsl._
 import com.lightbend.lagom.internal.projection.ProjectionRegistry
 import com.lightbend.lagom.internal.projection.ProjectionRegistryActor.WorkerCoordinates
 import com.lightbend.lagom.spi.persistence.OffsetStore

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/Producer.scala
@@ -6,7 +6,9 @@ package com.lightbend.lagom.internal.broker.kafka
 
 import java.net.URI
 
+import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.persistence.query.EventEnvelope
 import akka.persistence.query.Offset
 import akka.stream.Materializer
 import akka.stream.scaladsl._
@@ -29,7 +31,7 @@ private[lagom] object Producer {
       kafkaConfig: KafkaConfig,
       locateService: String => Future[Seq[URI]],
       topicId: String,
-      eventStreamFactory: (String, Offset) => Source[(Message, Offset), _],
+      eventStreamFactory: EventStreamFactory[Message],
       partitionKeyStrategy: Option[Message => String],
       serializer: Serializer[Message],
       offsetStore: OffsetStore,

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/TopicProducerActor.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/TopicProducerActor.scala
@@ -120,7 +120,7 @@ private[lagom] class TopicProducerActor[Message](
         ) { () =>
           val brokersAndOffset: Future[(String, OffsetDao)] = eventualBrokersAndOffset(tagName)
           Source
-            .fromFuture(brokersAndOffset)
+            .future(brokersAndOffset)
             .initialTimeout(producerConfig.offsetTimeout)
             .flatMapConcat {
               case (endpoints, offsetDao) =>

--- a/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/TopicProducerActor.scala
+++ b/service/core/kafka/server/src/main/scala/com/lightbend/lagom/internal/broker/kafka/TopicProducerActor.scala
@@ -124,8 +124,6 @@ private[lagom] class TopicProducerActor[BrokerMessage](
                     case DelegatedEventStreamFactory(factory, userFlow) =>
                       log.debug("Building TopicProducer with delegated API for {}", tagName)
                       factory(tagName, offsetDao.loadedOffset)
-                        .map(identity) // TODO: use the supporting actor
-                        //                        .map(ee => ee.event.asInstanceOf[BrokerMessage] -> ee.offset)
                         .via(userFlow)
                   }
                 val publisherFlow: Flow[(BrokerMessage, AkkaOffset), Future[AkkaOffset], Any] =

--- a/service/javadsl/broker/src/main/java/com/lightbend/lagom/javadsl/broker/TopicProducer.java
+++ b/service/javadsl/broker/src/main/java/com/lightbend/lagom/javadsl/broker/TopicProducer.java
@@ -5,6 +5,7 @@
 package com.lightbend.lagom.javadsl.broker;
 
 import akka.NotUsed;
+import akka.annotation.ApiMayChange;
 import akka.japi.Pair;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Source;
@@ -50,13 +51,10 @@ public final class TopicProducer {
   // When the tagger is not sharded, the user provided Flow is already closing on the actual Tag
   // they want to consume, the (classic) TopicProducer API doesn't  allow the user to pass that Tag
   // as an argument. As a consequence, we use a fake SINGLETON_TAG that will be used as a
-  // placeholder
-  // internally by Lagom but never actually used on a queryByTag.
-  // In the DelegatedTopicProducer API (aka .fromTaggedEntity) the user code is not closing on the
-  // actual
-  // tag so we need to distinguish between what will be used when invoking queryByTag and what will
-  // be
-  // used as an entityId when sharding the actors.
+  // placeholder internally by Lagom but never actually used on a queryByTag.  In the
+  // DelegatedTopicProducer API (aka .fromTaggedEntity) the user code is not closing on the
+  // actual tag so we need to distinguish between what will be used when invoking queryByTag and
+  // what will be used as an entityId when sharding the actors.
   private static final PSequence<AggregateEventTag<SingletonEvent>> SINGLETON_TAG =
       TreePVector.singleton(AggregateEventTag.of(SingletonEvent.class, "singleton"));
 
@@ -106,18 +104,7 @@ public final class TopicProducer {
     return new TaggedOffsetTopicProducer<Message, Event>(shards.allTags(), eventStream);
   }
 
-  //  // Requires fixing https://github.com/lagom/lagom/issues/2699 first
-  //  public static <Message, Event extends AggregateEvent<Event>> Topic<Message> fromTaggedEntity(
-  //      PersistentEntityRegistry persistentEntityRegistry,
-  //      AggregateEventTag<Event> tag,
-  //      Flow<Pair<Event, Offset>, Pair<Message, Offset>, NotUsed> userFlow) {
-  //    return new DelegatedTopicProducer<Message, Event>(
-  //        persistentEntityRegistry,
-  //        TreePVector.singleton(tag),
-  //        TreePVector.singleton(SINGLETON_TAG_NAME),
-  //        userFlow);
-  //  }
-
+  @ApiMayChange
   public static <Message, Event extends AggregateEvent<Event>> Topic<Message> fromTaggedEntity(
       PersistentEntityRegistry persistentEntityRegistry,
       AggregateEventShards<Event> shards,

--- a/service/javadsl/broker/src/main/scala/com/lightbend/lagom/internal/broker/TopicProducers.scala
+++ b/service/javadsl/broker/src/main/scala/com/lightbend/lagom/internal/broker/TopicProducers.scala
@@ -6,15 +6,36 @@ package com.lightbend.lagom.internal.broker
 
 import java.util.function.BiFunction
 
+import akka.NotUsed
 import akka.japi.Pair
-import akka.stream.javadsl.{ Source => JSource }
+import akka.stream.javadsl.Flow
+import akka.stream.javadsl.{Source => JSource}
 import com.lightbend.lagom.internal.javadsl.api.InternalTopic
 import com.lightbend.lagom.javadsl.persistence.AggregateEvent
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTag
 import com.lightbend.lagom.javadsl.persistence.Offset
+import com.lightbend.lagom.javadsl.persistence.PersistentEntityRegistry
 import org.pcollections.PSequence
 
-final class TaggedOffsetTopicProducer[Message, Event <: AggregateEvent[Event]](
+import scala.collection.immutable
+
+trait TaggedInternalTopic[BrokerMessage, Event <: AggregateEvent[Event]] extends InternalTopic[BrokerMessage] {
+  val tags: PSequence[AggregateEventTag[Event]]
+}
+
+// An InternalTopic used by the legacy TopicProducer API. This creates the Source, maps it to
+// Lagom API and also connects it to the user-provided flow in a single shot.
+final class TaggedOffsetTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]](
     val tags: PSequence[AggregateEventTag[Event]],
-    val readSideStream: BiFunction[AggregateEventTag[Event], Offset, JSource[Pair[Message, Offset], _]]
-) extends InternalTopic[Message]
+    val readSideStream: BiFunction[AggregateEventTag[Event], Offset, JSource[Pair[BrokerMessage, Offset], _]]
+) extends TaggedInternalTopic[BrokerMessage, Event]
+
+// An InternalTopic used by the legacy TopicProducer API. This provides the pieces to create the Source, map it
+// to the Lagom API and connect it to the user-provided flow so the ProducerActor can handle that
+// and instrument it internally.
+final class DelegatedTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]](
+    val persistentEntityRegistry: PersistentEntityRegistry,
+    val tags: PSequence[AggregateEventTag[Event]],
+    val clusterShardEntityIds: immutable.Seq[AggregateEventTag[_]],
+    val userFlow: Flow[Pair[Event, Offset], Pair[BrokerMessage, Offset], NotUsed]
+) extends TaggedInternalTopic[BrokerMessage, Event]

--- a/service/javadsl/broker/src/main/scala/com/lightbend/lagom/internal/broker/TopicProducers.scala
+++ b/service/javadsl/broker/src/main/scala/com/lightbend/lagom/internal/broker/TopicProducers.scala
@@ -8,16 +8,17 @@ import java.util.function.BiFunction
 
 import akka.NotUsed
 import akka.japi.Pair
+import akka.persistence.query.EventEnvelope
+import akka.persistence.query.{ Offset => AkkaOffset }
 import akka.stream.javadsl.Flow
-import akka.stream.javadsl.{Source => JSource}
+import akka.stream.javadsl.{ Source => JSource }
 import com.lightbend.lagom.internal.javadsl.api.InternalTopic
+import com.lightbend.lagom.internal.javadsl.persistence.OffsetAdapter
 import com.lightbend.lagom.javadsl.persistence.AggregateEvent
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTag
 import com.lightbend.lagom.javadsl.persistence.Offset
 import com.lightbend.lagom.javadsl.persistence.PersistentEntityRegistry
 import org.pcollections.PSequence
-
-import scala.collection.immutable
 
 trait TaggedInternalTopic[BrokerMessage, Event <: AggregateEvent[Event]] extends InternalTopic[BrokerMessage] {
   val tags: PSequence[AggregateEventTag[Event]]
@@ -27,8 +28,15 @@ trait TaggedInternalTopic[BrokerMessage, Event <: AggregateEvent[Event]] extends
 // Lagom API and also connects it to the user-provided flow in a single shot.
 final class TaggedOffsetTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]](
     val tags: PSequence[AggregateEventTag[Event]],
+    @deprecated("Prefer readSideStreamAkka instead", "1.6.2")
     val readSideStream: BiFunction[AggregateEventTag[Event], Offset, JSource[Pair[BrokerMessage, Offset], _]]
-) extends TaggedInternalTopic[BrokerMessage, Event]
+) extends TaggedInternalTopic[BrokerMessage, Event] {
+  val readSideStreamAkka: BiFunction[AggregateEventTag[Event], Offset, JSource[(BrokerMessage, AkkaOffset), _]] =
+    (tag, offset) =>
+      readSideStream(tag, offset).map { pair =>
+        pair.first -> OffsetAdapter.dslOffsetToOffset(pair.second)
+      }
+}
 
 // An InternalTopic used by the legacy TopicProducer API. This provides the pieces to create the Source, map it
 // to the Lagom API and connect it to the user-provided flow so the ProducerActor can handle that
@@ -36,6 +44,18 @@ final class TaggedOffsetTopicProducer[BrokerMessage, Event <: AggregateEvent[Eve
 final class DelegatedTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]](
     val persistentEntityRegistry: PersistentEntityRegistry,
     val tags: PSequence[AggregateEventTag[Event]],
-    val clusterShardEntityIds: immutable.Seq[AggregateEventTag[_]],
-    val userFlow: Flow[Pair[Event, Offset], Pair[BrokerMessage, Offset], NotUsed]
-) extends TaggedInternalTopic[BrokerMessage, Event]
+    val clusterShardEntityIds: PSequence[String],
+    userFlow: Flow[Pair[Event, Offset], Pair[BrokerMessage, Offset], NotUsed]
+) extends TaggedInternalTopic[BrokerMessage, Event] {
+  private val f1: Flow[EventEnvelope, Pair[Event, Offset], NotUsed] = Flow
+    .create[EventEnvelope]
+    .map { eventEnvelope =>
+      val lagomOffset = OffsetAdapter.offsetToDslOffset(eventEnvelope.offset)
+      Pair(eventEnvelope.event.asInstanceOf[Event], lagomOffset)
+    }
+  val userFlowAkka: Flow[EventEnvelope, (BrokerMessage, AkkaOffset), NotUsed] =
+    f1.via(userFlow)
+      .map { pair =>
+        pair.first -> OffsetAdapter.dslOffsetToOffset(pair.second)
+      }
+}

--- a/service/javadsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslRegisterTopicProducers.scala
+++ b/service/javadsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslRegisterTopicProducers.scala
@@ -22,6 +22,7 @@ import com.lightbend.lagom.internal.broker.kafka.KafkaConfig
 import com.lightbend.lagom.internal.broker.kafka.Producer
 import com.lightbend.lagom.internal.javadsl.api.MethodTopicHolder
 import com.lightbend.lagom.internal.javadsl.api.broker.TopicFactory
+import com.lightbend.lagom.internal.javadsl.persistence.AbstractPersistentEntityRegistry
 import com.lightbend.lagom.internal.javadsl.persistence.OffsetAdapter
 import com.lightbend.lagom.internal.javadsl.server.ResolvedServices
 import com.lightbend.lagom.internal.projection.ProjectionRegistry
@@ -83,7 +84,10 @@ class JavadslRegisterTopicProducers[BrokerMessage, Event <: AggregateEvent[Event
                               .asScala
                           case None => throw new RuntimeException("Unknown tag: " + tag)
                         }
-                      DelegatedEventStreamFactory(sourceFactory, producer.userFlowAkka.asScala)
+                      DelegatedEventStreamFactory(
+                        sourceFactory,
+                        producer.userFlowAkka(AbstractPersistentEntityRegistry.toStreamElement).asScala
+                      )
                     case producer: TaggedOffsetTopicProducer[BrokerMessage, Event] =>
                       ClassicLagomEventStreamFactory((tag, offset) =>
                         tags.find(_.tag == tag) match {

--- a/service/javadsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/KafkaBrokerModule.scala
+++ b/service/javadsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/KafkaBrokerModule.scala
@@ -11,6 +11,6 @@ import play.api.inject.Module
 
 class KafkaBrokerModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
-    bind[JavadslRegisterTopicProducers[_,_]].toSelf.eagerly()
+    bind[JavadslRegisterTopicProducers[_, _]].toSelf.eagerly()
   )
 }

--- a/service/javadsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/KafkaBrokerModule.scala
+++ b/service/javadsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/KafkaBrokerModule.scala
@@ -11,6 +11,6 @@ import play.api.inject.Module
 
 class KafkaBrokerModule extends Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] = Seq(
-    bind[JavadslRegisterTopicProducers].toSelf.eagerly()
+    bind[JavadslRegisterTopicProducers[_,_]].toSelf.eagerly()
   )
 }

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -22,6 +22,7 @@ import akka.stream.scaladsl.Source
 import akka.stream.scaladsl.SourceQueue
 import akka.Done
 import akka.NotUsed
+import akka.persistence.query.EventEnvelope
 import com.google.inject.AbstractModule
 import com.lightbend.lagom.dev.MiniLogger
 import com.lightbend.lagom.dev.Servers.KafkaServer
@@ -492,6 +493,12 @@ object JavadslKafkaApiSpec {
         aggregateTag: AggregateEventTag[Event],
         fromOffset: JOffset
     ): JSource[JPair[Event, JOffset], NotUsed] =
+      JSource.empty()
+
+    private[lagom] override def eventEnvelopeStream[Event <: AggregateEvent[Event]](
+        aggregateTag: AggregateEventTag[Event],
+        fromOffset: JOffset
+    ): JSource[EventEnvelope, NotUsed] =
       JSource.empty()
 
     override def refFor[C](

--- a/service/scaladsl/broker/src/main/scala/com/lightbend/internal/broker/TopicProducers.scala
+++ b/service/scaladsl/broker/src/main/scala/com/lightbend/internal/broker/TopicProducers.scala
@@ -30,7 +30,7 @@ trait TaggedInternalTopic[BrokerMessage, Event <: AggregateEvent[Event]] extends
   val tags: immutable.Seq[AggregateEventTag[Event]]
 }
 
-// An InternalTopic used by the legacy TopicProducer API. This creates the Source, maps it to
+// An InternalTopic used by the TopicProducer API. This creates the Source, maps it to
 // Lagom API and also connects it to the user-provided flow in a single shot.
 final class TaggedOffsetTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]](
     val tags: immutable.Seq[AggregateEventTag[Event]],

--- a/service/scaladsl/broker/src/main/scala/com/lightbend/internal/broker/TopicProducers.scala
+++ b/service/scaladsl/broker/src/main/scala/com/lightbend/internal/broker/TopicProducers.scala
@@ -4,24 +4,55 @@
 
 package com.lightbend.internal.broker
 
+import akka.NotUsed
 import akka.persistence.query.Offset
+import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import com.lightbend.lagom.scaladsl.api.broker.Subscriber
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.persistence.AggregateEvent
 import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
+import com.lightbend.lagom.scaladsl.persistence.EventStreamElement
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntityRegistry
 
 import scala.collection.immutable
 
-trait InternalTopic[Message] extends Topic[Message] {
+trait InternalTopic[BrokerMessage] extends Topic[BrokerMessage] {
   final override def topicId: Topic.TopicId =
     throw new UnsupportedOperationException("Topic#topicId is not permitted in the service's topic implementation")
 
-  final override def subscribe: Subscriber[Message] =
+  final override def subscribe: Subscriber[BrokerMessage] =
     throw new UnsupportedOperationException("Topic#subscribe is not permitted in the service's topic implementation.")
 }
 
-final class TaggedOffsetTopicProducer[Message, Event <: AggregateEvent[Event]](
+trait TaggedInternalTopic[BrokerMessage, Event <: AggregateEvent[Event]] extends InternalTopic[BrokerMessage]{
+  val tags: immutable.Seq[AggregateEventTag[Event]]
+}
+
+// An InternalTopic used by the legacy TopicProducer API. This creates the Source, maps it to
+// Lagom API and also connects it to the user-provided flow in a single shot.
+final class TaggedOffsetTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]](
     val tags: immutable.Seq[AggregateEventTag[Event]],
-    val readSideStream: (AggregateEventTag[Event], Offset) => Source[(Message, Offset), _]
-) extends InternalTopic[Message]
+    val readSideStream: (AggregateEventTag[Event], Offset) => Source[(BrokerMessage, Offset), _]
+) extends TaggedInternalTopic[BrokerMessage, Event]
+
+/**
+ *
+ * @param persistentEntityRegistry PersistentEntityRegistry to build the event stream from.
+ * @param tags collection of tags to consume from the journal
+ * @param clusterShardEntityIds identifier for each entityId (worker actor) when distribution the shards around
+ *                              the cluster. This is unnecessary complexity because of the SINGLETON_TAG introduced
+ *                              in the legacy implementation for non-sharded tags.
+ * @param userFlow flow with user code (and nothing else, no framework code)
+ * @tparam BrokerMessage the type published to the broker
+ * @tparam Event the type consumed from the journal
+ */
+// An InternalTopic used by the legacy TopicProducer API. This provides the pieces to create the Source, map it
+// to the Lagom API and connect it to the user-provided flow so the ProducerActor can handle that
+// and instrument it internally.
+final class DelegatedTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]](
+    val persistentEntityRegistry: PersistentEntityRegistry,
+    val tags: immutable.Seq[AggregateEventTag[Event]],
+    val clusterShardEntityIds: immutable.Seq[AggregateEventTag[_]],
+    val userFlow: Flow[EventStreamElement[Event], (BrokerMessage, Offset), NotUsed]
+) extends TaggedInternalTopic[BrokerMessage, Event]

--- a/service/scaladsl/broker/src/main/scala/com/lightbend/internal/broker/TopicProducers.scala
+++ b/service/scaladsl/broker/src/main/scala/com/lightbend/internal/broker/TopicProducers.scala
@@ -5,7 +5,6 @@
 package com.lightbend.internal.broker
 
 import akka.NotUsed
-import akka.persistence.query.EventEnvelope
 import akka.persistence.query.Offset
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
@@ -55,12 +54,5 @@ final class DelegatedTopicProducer[BrokerMessage, Event <: AggregateEvent[Event]
     val persistentEntityRegistry: PersistentEntityRegistry,
     val tags: immutable.Seq[AggregateEventTag[Event]],
     val clusterShardEntityIds: immutable.Seq[String],
-    userFlow: Flow[EventStreamElement[Event], (BrokerMessage, Offset), NotUsed]
-) extends TaggedInternalTopic[BrokerMessage, Event] {
-  def userFlowAkka(
-      toUserApi: EventEnvelope => EventStreamElement[Event]
-  ): Flow[EventEnvelope, (BrokerMessage, Offset), NotUsed] =
-    Flow[EventEnvelope]
-      .map(toUserApi)
-      .via(userFlow)
-}
+    val userFlow: Flow[EventStreamElement[Event], (BrokerMessage, Offset), NotUsed]
+) extends TaggedInternalTopic[BrokerMessage, Event] {}

--- a/service/scaladsl/broker/src/main/scala/com/lightbend/lagom/scaladsl/broker/TopicProducer.scala
+++ b/service/scaladsl/broker/src/main/scala/com/lightbend/lagom/scaladsl/broker/TopicProducer.scala
@@ -5,6 +5,7 @@
 package com.lightbend.lagom.scaladsl.broker
 
 import akka.NotUsed
+import akka.annotation.ApiMayChange
 import akka.persistence.query.Offset
 import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
@@ -87,19 +88,7 @@ object TopicProducer {
   ): Topic[Message] =
     new TaggedOffsetTopicProducer[Message, Event](shards.allTags.toList, eventStream)
 
-//  // Requires fixing https://github.com/lagom/lagom/issues/2699 first
-//  def fromTaggedEntity[BrokerMessage, Event <: AggregateEvent[Event]](
-//                        registry: PersistentEntityRegistry,
-//                        tag: AggregateEventTag[Event])(
-//                        userFlow: Flow[EventStreamElement[Event], (BrokerMessage, Offset), NotUsed]
-//                      ): Topic[BrokerMessage] = {
-//    // The legacy implementation used the SINGLETON_TAG while we use the user-provided tag this time.
-//    // We need the user provided tag because the invocation to `registry.eventStream` (which now happens on the actor)
-//    // will require the user provided tag so we must make sure the internal implementation will continue to
-//    // use SINGLETON_TAG for the cluster distribution.
-//    new DelegatedTopicProducer(registry, immutable.Seq(tag), "singleton", userFlow)
-//  }
-
+  @ApiMayChange
   def fromTaggedEntity[BrokerMessage, Event <: AggregateEvent[Event]](
       registry: PersistentEntityRegistry,
       tags: AggregateEventShards[Event]

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaTopic.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaTopic.scala
@@ -16,18 +16,18 @@ import com.lightbend.lagom.scaladsl.api.broker.Topic.TopicId
 
 import scala.concurrent.ExecutionContext
 
-private[lagom] class ScaladslKafkaTopic[Message](
+private[lagom] class ScaladslKafkaTopic[BrokerEvent](
     kafkaConfig: KafkaConfig,
-    topicCall: TopicCall[Message],
+    topicCall: TopicCall[BrokerEvent],
     info: ServiceInfo,
     system: ActorSystem,
     serviceLocator: ServiceLocator
 )(implicit mat: Materializer, ec: ExecutionContext)
-    extends Topic[Message] {
+    extends Topic[BrokerEvent] {
   override def topicId: TopicId = topicCall.topicId
 
-  override def subscribe: Subscriber[Message] =
-    new ScaladslKafkaSubscriber[Message, Message](
+  override def subscribe: Subscriber[BrokerEvent] =
+    new ScaladslKafkaSubscriber[BrokerEvent, BrokerEvent](
       kafkaConfig,
       topicCall,
       ScaladslKafkaSubscriber.GroupId.default(info),

--- a/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslRegisterTopicProducers.scala
+++ b/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslRegisterTopicProducers.scala
@@ -59,10 +59,6 @@ class ScaladslRegisterTopicProducers[BrokerMessage, Event <: AggregateEvent[Even
   } {
     topicCall.topicHolder match {
       case holder: ScalaMethodTopic[BrokerMessage] =>
-        // `topicProducer` is the user-provided method (implemented in a ServiceImp). Before Lago 1.6.2 only
-        // `TaggedOffsetTopicProducer` was supported. `TaggedOffsetTopicProducer` wraps the collection
-        // of `tags` to fetch and the a factory:
-        //    (tag, fromOffset) => Source[(Message, Offset), _]
         val topicProducer: AnyRef  = holder.method.invoke(service.service)
         val topicId: Topic.TopicId = topicCall.topicId
 

--- a/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslRegisterTopicProducers.scala
+++ b/service/scaladsl/kafka/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslRegisterTopicProducers.scala
@@ -7,8 +7,12 @@ package com.lightbend.lagom.internal.scaladsl.broker.kafka
 import akka.actor.ActorSystem
 import akka.persistence.query.Offset
 import akka.stream.Materializer
-import akka.stream.scaladsl.Source
+import com.lightbend.internal.broker.DelegatedTopicProducer
+import com.lightbend.internal.broker.TaggedInternalTopic
 import com.lightbend.internal.broker.TaggedOffsetTopicProducer
+import com.lightbend.lagom.internal.broker.kafka.ClassicLagomEventStreamFactory
+import com.lightbend.lagom.internal.broker.kafka.DelegatedEventStreamFactory
+import com.lightbend.lagom.internal.broker.kafka.EventStreamFactory
 import com.lightbend.lagom.internal.broker.kafka.KafkaConfig
 import com.lightbend.lagom.internal.broker.kafka.Producer
 import com.lightbend.lagom.internal.projection.ProjectionRegistry
@@ -17,7 +21,9 @@ import com.lightbend.lagom.scaladsl.api.Descriptor.TopicCall
 import com.lightbend.lagom.scaladsl.api.ServiceInfo
 import com.lightbend.lagom.scaladsl.api.ServiceLocator
 import com.lightbend.lagom.scaladsl.api.ServiceSupport.ScalaMethodTopic
+import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.api.broker.kafka.KafkaProperties
+import com.lightbend.lagom.scaladsl.persistence.AggregateEvent
 import com.lightbend.lagom.scaladsl.server.LagomServer
 import com.lightbend.lagom.scaladsl.server.LagomServiceBinding
 import com.lightbend.lagom.spi.persistence.OffsetStore
@@ -25,7 +31,7 @@ import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
 
-class ScaladslRegisterTopicProducers(
+class ScaladslRegisterTopicProducers[BrokerMessage, Event <: AggregateEvent[Event]](
     lagomServer: LagomServer,
     topicFactory: TopicFactory,
     info: ServiceInfo,
@@ -34,7 +40,7 @@ class ScaladslRegisterTopicProducers(
     serviceLocator: ServiceLocator,
     projectionRegistryImpl: ProjectionRegistry
 )(implicit ec: ExecutionContext, mat: Materializer) {
-  private val log         = LoggerFactory.getLogger(classOf[ScaladslRegisterTopicProducers])
+  private val log         = LoggerFactory.getLogger(classOf[ScaladslRegisterTopicProducers[_, _]])
   private val kafkaConfig = KafkaConfig(actorSystem.settings.config)
 
   // Goes through the services' descriptors and publishes the streams registered in
@@ -43,27 +49,46 @@ class ScaladslRegisterTopicProducers(
   val service: LagomServiceBinding[_] = lagomServer.serviceBinding
   for {
     tc <- service.descriptor.topics
-    topicCall = tc.asInstanceOf[TopicCall[Any]]
+    topicCall = tc.asInstanceOf[TopicCall[BrokerMessage]]
   } {
     topicCall.topicHolder match {
-      case holder: ScalaMethodTopic[Any] =>
-        val topicProducer = holder.method.invoke(service.service)
-        val topicId       = topicCall.topicId
+      case holder: ScalaMethodTopic[BrokerMessage] =>
+        // `topicProducer` is the user-provided method (implemented in a ServiceImp). Currently only
+        // `TaggedOffsetTopicProducer` is supported. `TaggedOffsetTopicProducer` wraps the collection
+        // of `tags` to fetch and the a factory:
+        //    (tag, fromOffset) => Source[(Message, Offset), _]
+        val topicProducer: AnyRef  = holder.method.invoke(service.service)
+        val topicId: Topic.TopicId = topicCall.topicId
 
+        // the `topicFactory` creates broker-specific producers to implement the `topicCall`
+        // provided by the user
         topicFactory.create(topicCall) match {
-          case topicImpl: ScaladslKafkaTopic[Any] =>
+          case _: ScaladslKafkaTopic[BrokerMessage] =>
             topicProducer match {
-              case tagged: TaggedOffsetTopicProducer[Any, _] =>
+              case tagged: TaggedInternalTopic[BrokerMessage, Event] =>
                 val tags = tagged.tags
 
-                val eventStreamFactory: (String, Offset) => Source[(Any, Offset), _] = { (tag, offset) =>
-                  tags.find(_.tag == tag) match {
-                    case Some(aggregateTag) => tagged.readSideStream(aggregateTag, offset)
-                    case None               => throw new RuntimeException("Unknown tag: " + tag)
+                val eventStreamFactory: EventStreamFactory[BrokerMessage] =
+                  tagged match {
+                    case producer: DelegatedTopicProducer[BrokerMessage, Event] =>
+                      DelegatedEventStreamFactory((tag, offset: Offset) =>
+                        tags.find(_.tag == tag) match {
+                          case Some(aggregateTag) =>
+                            producer.persistentEntityRegistry.eventEnvelopeStream(aggregateTag, offset)
+                          case None => throw new RuntimeException("Unknown tag: " + tag)
+                        }
+                      )
+                    case producer: TaggedOffsetTopicProducer[BrokerMessage, Event] =>
+                      ClassicLagomEventStreamFactory((tag, offset: Offset) =>
+                        tags.find(_.tag == tag) match {
+                          case Some(aggregateTag) =>
+                            producer.readSideStream(aggregateTag, offset)
+                          case None => throw new RuntimeException("Unknown tag: " + tag)
+                        }
+                      )
                   }
-                }
 
-                val partitionKeyStrategy: Option[Any => String] = {
+                val partitionKeyStrategy: Option[BrokerMessage => String] = {
                   topicCall.properties.get(KafkaProperties.partitionKeyStrategy).map { pks => message =>
                     pks.computePartitionKey(message)
                   }


### PR DESCRIPTION
Projection worker actors (`TopicProducerActor` and `ReadSideActor`) don't have access to the `EventEnvelope` produced by Akka Persistence Query's `eventByTag` query. This PR introduces:

```scala
private[lagom] def eventEnvelopeStream[...](...): Source[EventEnvelope, NotUsed]
```

in `PersistentEntityRegistry`.

This PR also introduces a new mechanism to create `Topic`'s on the `ServiceImpl` so the `TopicProducerActor` has access to the `Source[EventEnvelope, NotUsed]`:


```scala
  override def shoppingCartTopic: Topic[BrokerMessage] = {
    TopicProducer.fromTaggedEntity(
      persistentEntityRegistry,
      Event.Tag) {
      Flow[EventStreamElement[MyEvent]]
        .filter(...)
        .map(...)
    }
  }

```

```java
 @Override
    public Topic<BrokerMessage> shoppingCartTopic() {
        AggregateEventShards<MyEvent> tags = MyEvent.TAG;
        Flow<Pair<MyEvent, Offset>, Pair<BrokerMessage, Offset>, NotUsed> userFlow =
                Flow.<Pair<MyEvent, Offset>>create()
                        .filter(...)
                        .mapAsync(...);
        return TopicProducer.fromTaggedEntity(
                persistentEntityRegistry,
                tagger,
                userFlow);
    }
```

A difference on this API (compared to the [existing](https://www.lagomframework.com/documentation/1.6.x/scala/MessageBrokerApi.html#Implementing-a-topic) one) is that user doesn't access the `eventStream` or the new `eventStreamEnvelope` and, instead, provides the `persistentEntityRegistry` as an argument.

Note also, how the new API `TopicProducer.fromTaggedEntity` only supports `AggregateEventShards`. The reason to only support sharded tags is https://github.com/lagom/lagom/issues/2699: users of non-sharded tags migrating from the old `TopicProducer.singleStreamWithOffset` to a new `TopicProducer.fromTaggedEntity` would require a cluster startup. Until #2699 is solved, users with non-sharded tags can't migrate to the new API.
