### PR TITLE
Handle StartEntity in extractShardId

### DIFF
--- a/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/HashCodeMessageExtractor.scala
+++ b/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/cluster/HashCodeMessageExtractor.scala
@@ -1,0 +1,11 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.internal.persistence.cluster
+
+object HashCodeMessageExtractor {
+  def shardId(id: String, maxNumberOfShards: Int): String = {
+    (math.abs(id.hashCode) % maxNumberOfShards).toString
+  }
+}

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -5,27 +5,22 @@
 package com.lightbend.lagom.internal.javadsl.persistence
 
 import java.util.Optional
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
 import akka.cluster.Cluster
 import akka.cluster.sharding.ClusterSharding
 import akka.cluster.sharding.ClusterShardingSettings
 import akka.cluster.sharding.ShardRegion
-import akka.event.Logging
 import akka.japi.Pair
 import akka.persistence.query.scaladsl.EventsByTagQuery
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.{ Offset => AkkaOffset }
 import akka.stream.javadsl
-import akka.Done
 import akka.NotUsed
+import com.lightbend.lagom.internal.persistence.cluster.HashCodeMessageExtractor
 import com.lightbend.lagom.javadsl.persistence._
 import play.api.inject.Injector
-
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
@@ -77,9 +72,9 @@ class AbstractPersistentEntityRegistry(
 
   private val extractShardId: ShardRegion.ExtractShardId = {
     case CommandEnvelope(entityId, _) =>
-      (math.abs(entityId.hashCode) % maxNumberOfShards).toString
+      HashCodeMessageExtractor.shardId(entityId, maxNumberOfShards)
     case ShardRegion.StartEntity(entityId) =>
-      (math.abs(entityId.hashCode) % maxNumberOfShards).toString
+      HashCodeMessageExtractor.shardId(entityId, maxNumberOfShards)
   }
 
   private val registeredTypeNames = new ConcurrentHashMap[String, Class[_]]()

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -78,6 +78,8 @@ class AbstractPersistentEntityRegistry(
   private val extractShardId: ShardRegion.ExtractShardId = {
     case CommandEnvelope(entityId, _) =>
       (math.abs(entityId.hashCode) % maxNumberOfShards).toString
+    case ShardRegion.StartEntity(entityId) =>
+      (math.abs(entityId.hashCode) % maxNumberOfShards).toString
   }
 
   private val registeredTypeNames = new ConcurrentHashMap[String, Class[_]]()

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -72,7 +72,9 @@ class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEn
   }
 
   private val extractShardId: ShardRegion.ExtractShardId = {
-    case CommandEnvelope(entityId, payload) =>
+    case CommandEnvelope(entityId, _) =>
+      (math.abs(entityId.hashCode) % maxNumberOfShards).toString
+    case ShardRegion.StartEntity(entityId) =>
       (math.abs(entityId.hashCode) % maxNumberOfShards).toString
   }
 

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/AbstractPersistentEntityRegistry.scala
@@ -4,28 +4,21 @@
 
 package com.lightbend.lagom.internal.scaladsl.persistence
 
-import java.util.Optional
-import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
-
 import akka.actor.ActorSystem
-import akka.actor.CoordinatedShutdown
 import akka.cluster.Cluster
 import akka.cluster.sharding.ClusterSharding
 import akka.cluster.sharding.ClusterShardingSettings
 import akka.cluster.sharding.ShardRegion
 import akka.event.Logging
-import akka.pattern.ask
 import akka.persistence.query.Offset
 import akka.persistence.query.PersistenceQuery
 import akka.persistence.query.scaladsl.EventsByTagQuery
 import akka.stream.scaladsl
-import akka.util.Timeout
-import akka.Done
 import akka.NotUsed
+import com.lightbend.lagom.internal.persistence.cluster.HashCodeMessageExtractor
 import com.lightbend.lagom.scaladsl.persistence._
-import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
@@ -73,9 +66,9 @@ class AbstractPersistentEntityRegistry(system: ActorSystem) extends PersistentEn
 
   private val extractShardId: ShardRegion.ExtractShardId = {
     case CommandEnvelope(entityId, _) =>
-      (math.abs(entityId.hashCode) % maxNumberOfShards).toString
+      HashCodeMessageExtractor.shardId(entityId, maxNumberOfShards)
     case ShardRegion.StartEntity(entityId) =>
-      (math.abs(entityId.hashCode) % maxNumberOfShards).toString
+      HashCodeMessageExtractor.shardId(entityId, maxNumberOfShards)
   }
 
   private val registeredTypeNames = new ConcurrentHashMap[String, Class[_]]()


### PR DESCRIPTION
This is important for users who want to enable `remember-entities` in Akka.

For context:
https://discuss.lightbend.com/t/how-to-use-remember-entities-feature-in-lagom/4396

I use lagom in a production setting and would like to explore enabling this option to avoid elevated response times when rolling out a new deploy.



