### PR TITLE
fix flaky ClusterDistributionSpec, #2710

### DIFF
--- a/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusterDistributionSpec.scala
+++ b/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusterDistributionSpec.scala
@@ -9,18 +9,29 @@ import com.lightbend.lagom.internal.cluster.ClusterDistribution.EnsureActive
 import akka.pattern._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.ScalaFutures
-
 import scala.concurrent.duration._
+
 import akka.cluster.sharding.ShardRegion.CurrentShardRegionState
 import akka.cluster.sharding.ShardRegion.GetShardRegionState
 
-import scala.concurrent.Await
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 class ClusterDistributionSpecMultiJvmNode1 extends ClusterDistributionSpec
 class ClusterDistributionSpecMultiJvmNode2 extends ClusterDistributionSpec
 class ClusterDistributionSpecMultiJvmNode3 extends ClusterDistributionSpec
 
-class ClusterDistributionSpec extends ClusteredMultiNodeUtils(numOfNodes = 3) with ScalaFutures with Eventually {
+object ClusterDistributionSpec extends ClusterMultiNodeConfig {
+  protected override def systemConfig: Config =
+    ConfigFactory.parseString("""
+      akka.cluster.sharding.rebalance-interval = 1s
+      """).withFallback(super.systemConfig)
+}
+
+class ClusterDistributionSpec
+    extends ClusteredMultiNodeUtils(numOfNodes = 3, ClusterDistributionSpec)
+    with ScalaFutures
+    with Eventually {
   private val ensureActiveInterval: FiniteDuration = 1.second
   private val distributionSettings: ClusterDistributionSettings =
     ClusterDistributionSettings(system)

--- a/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusteredMultiNodeUtils.scala
+++ b/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusteredMultiNodeUtils.scala
@@ -15,8 +15,8 @@ import com.lightbend.lagom.internal.cluster.ClusterMultiNodeConfig.node1
 
 import scala.concurrent.duration._
 
-abstract class ClusteredMultiNodeUtils(val numOfNodes: Int)
-    extends MultiNodeSpec(ClusterMultiNodeConfig, ClusterMultiNodeActorSystemFactory.createActorSystem())
+abstract class ClusteredMultiNodeUtils(val numOfNodes: Int, multiNodeConfig: ClusterMultiNodeConfig)
+    extends MultiNodeSpec(multiNodeConfig, ClusterMultiNodeActorSystemFactory.createActorSystem())
     with STMultiNodeSpec
     with ImplicitSender {
   override def initialParticipants: Int = roles.size

--- a/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusteredTeskit.scala
+++ b/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusteredTeskit.scala
@@ -21,47 +21,46 @@ import com.typesafe.config.Config
 
 import scala.concurrent.duration._
 
-/**
- *
- */
+object ClusterMultiNodeConfig extends ClusterMultiNodeConfig
+
 // this is reused in multiple multi-jvm tests. There's still some copy/paste around though.
-object ClusterMultiNodeConfig extends MultiNodeConfig {
+abstract class ClusterMultiNodeConfig extends MultiNodeConfig {
   val node1 = role("node1")
   val node2 = role("node2")
   val node3 = role("node3")
 
-  commonConfig(
-    ConfigFactory
-      .parseString(
-        """
-      akka.loglevel = INFO
-      akka.actor.provider = cluster
-      terminate-system-after-member-removed = 60s
+  protected def systemConfig: Config =
+    ConfigFactory.parseString(
+      """
+    akka.loglevel = INFO
+    akka.actor.provider = cluster
+    terminate-system-after-member-removed = 60s
 
-      # increase default timeouts to leave wider margin for Travis.
-      # 30s to 60s
-      akka.testconductor.barrier-timeout=60s
-      akka.test.single-expect-default = 15s
+    # increase default timeouts to leave wider margin for Travis.
+    # 30s to 60s
+    akka.testconductor.barrier-timeout=60s
+    akka.test.single-expect-default = 15s
 
-      akka.cluster.sharding.waiting-for-state-timeout = 5s
+    akka.cluster.sharding.waiting-for-state-timeout = 5s
 
-      # Don't terminate the actor system when doing a coordinated shutdown
-      akka.coordinated-shutdown.terminate-actor-system = off
-      akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
-      akka.cluster.run-coordinated-shutdown-when-down = off
+    # Don't terminate the actor system when doing a coordinated shutdown
+    akka.coordinated-shutdown.terminate-actor-system = off
+    akka.coordinated-shutdown.run-by-jvm-shutdown-hook = off
+    akka.cluster.run-coordinated-shutdown-when-down = off
 
-      ## The settings below are incidental because this code lives in a project that depends on lagom-cluster and
-      ## lagom-akka-management-core.
+    ## The settings below are incidental because this code lives in a project that depends on lagom-cluster and
+    ## lagom-akka-management-core.
 
-      # multi-jvm tests forms the cluster programmatically
-      # therefore we disable Akka Cluster Bootstrap
-      lagom.cluster.bootstrap.enabled = off
+    # multi-jvm tests forms the cluster programmatically
+    # therefore we disable Akka Cluster Bootstrap
+    lagom.cluster.bootstrap.enabled = off
 
-      # no jvm exit on tests
-      lagom.cluster.exit-jvm-when-system-terminated = off
+    # no jvm exit on tests
+    lagom.cluster.exit-jvm-when-system-terminated = off
     """
-      )
-  )
+    )
+
+  commonConfig(systemConfig)
 }
 
 // heavily inspired by AbstractClusteredPersistentEntitySpec

--- a/projection/core/src/multi-jvm/scala/com/lightbend/lagom/internal/projection/ProjectionRegistrySpec.scala
+++ b/projection/core/src/multi-jvm/scala/com/lightbend/lagom/internal/projection/ProjectionRegistrySpec.scala
@@ -25,18 +25,22 @@ import org.scalatest.concurrent.Eventually
 import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.ScalaFutures
-
 import scala.concurrent.duration._
+
 import org.scalatest.time.Seconds
 import org.scalatest.time.Span
-
 import scala.concurrent.Await
+
+import com.lightbend.lagom.internal.cluster.ClusterMultiNodeConfig
 
 class ProjectionRegistrySpecMultiJvmNode1 extends ProjectionRegistrySpec
 class ProjectionRegistrySpecMultiJvmNode2 extends ProjectionRegistrySpec
 class ProjectionRegistrySpecMultiJvmNode3 extends ProjectionRegistrySpec
 
-class ProjectionRegistrySpec extends ClusteredMultiNodeUtils(numOfNodes = 3) with Eventually with ScalaFutures {
+class ProjectionRegistrySpec
+    extends ClusteredMultiNodeUtils(numOfNodes = 3, ClusterMultiNodeConfig)
+    with Eventually
+    with ScalaFutures {
   implicit val exCtx             = system.dispatcher
   private val pc                 = PatienceConfig(timeout = Span(20, Seconds), interval = Span(2, Seconds))
   private val projectionRegistry = new ProjectionRegistry(system)


### PR DESCRIPTION
## Fixes

Fixes #2710

## Purpose

ClusterDistributionSpec fails rather often in Travis tests. The problem is that if the ClusterDistribution is started with a delay on different nodes (which can easily happen on Travis) the shards will not be allocated to all nodes initially. Waiting for rebalance takes too long time with the default rebalance interval.

Solution is to reduce the rebalance interval.

## Background Context

Analyzed logs, and reproduced locally with a sleep delay.

