### PR TITLE
harden joining in ClusteredMultiNodeUtils

### DIFF
--- a/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusteredMultiNodeUtils.scala
+++ b/cluster/core/src/multi-jvm/scala/com/lightbend/lagom/internal/cluster/ClusteredMultiNodeUtils.scala
@@ -33,7 +33,8 @@ abstract class ClusteredMultiNodeUtils(val numOfNodes: Int)
     else ref.path.address
 
   protected override def atStartup(): Unit = {
-    roles.foreach(n => join(n, node1))
+    join(node1, node1)
+    roles.tail.foreach(n => join(n, node1))
     within(15.seconds) {
       awaitAssert(Cluster(system).state.members.size should be(numOfNodes))
       awaitAssert(


### PR DESCRIPTION
* join node1 to self before others join, because theoretically node2 and node3
  may send their join message to node1 before it has joined itself and that
  will result in that they will not join
* alternatively we could use joinSeedNodes, which handles retries, but better
  to just do it orderly
