### PR TITLE
Fix typo in Akka Persistence docs - typedKey to typeKey

### DIFF
--- a/docs/manual/java/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/java/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -135,7 +135,7 @@ The `EntityTypeKey` has as name to uniquely identify this model in the cluster. 
 
 @[shopping-cart-type-key](code/docs/home/persistence/ShoppingCartEntity.java)
 
-Finally, initialize the Entity on the `ClusterSharding` using the `typedKey` and the `create()` static method. Lagom provides an instance of the `clusterSharding` extension through dependency injection for your convenience. Initializing an Entity should be done only once and, in the case of Lagom, it is typically done in the constructor of the service implementation. You should inject the `ClusterSharding` on your service for that matter.
+Finally, initialize the Entity on the `ClusterSharding` using the `typeKey` and the `create()` static method. Lagom provides an instance of the `clusterSharding` extension through dependency injection for your convenience. Initializing an Entity should be done only once and, in the case of Lagom, it is typically done in the constructor of the service implementation. You should inject the `ClusterSharding` on your service for that matter.
 
 @[shopping-cart-init](code/docs/home/persistence/ShoppingCartServiceImpl.java)
 
@@ -189,4 +189,4 @@ Read more about the serialization setup and configuration in the [[serialization
 
 ## Testing
 
-The section in [Testing](https://doc.akka.io/docs/akka/2.6/typed/persistence-testing.html?language=Java) covers all the steps and features you need to write unit tests for your Aggregates. 
+The section in [Testing](https://doc.akka.io/docs/akka/2.6/typed/persistence-testing.html?language=Java) covers all the steps and features you need to write unit tests for your Aggregates.

--- a/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
+++ b/docs/manual/scala/guide/cluster/UsingAkkaPersistenceTyped.md
@@ -133,7 +133,7 @@ In the companion object of `ShoppingCart`, define the `EntityTypeKey` and factor
 
 > **Note**: [Akka style guide](https://doc.akka.io/docs/akka/2.6/typed/persistence-style.html?language=Scala) recommends having an `apply` factory method in the companion object.
 
-Finally, initialize the Entity on the `ClusterSharding` using the `typedKey` and the `behavior`. Lagom provides an instance of the `clusterSharding` extension through dependency injection for your convenience. Initializing an entity should be done only once and, in the case of Lagom, it is typically done in the `LagomApplication`:
+Finally, initialize the Entity on the `ClusterSharding` using the `typeKey` and the `behavior`. Lagom provides an instance of the `clusterSharding` extension through dependency injection for your convenience. Initializing an entity should be done only once and, in the case of Lagom, it is typically done in the `LagomApplication`:
 
 @[shopping-cart-loader](code/docs/home/scaladsl/persistence/ShoppingCartLoader.scala)
 
@@ -195,4 +195,4 @@ Read more about the serialization setup and configuration in the [[serialization
 
 ## Testing
 
-The section in [Testing](https://doc.akka.io/docs/akka/2.6/typed/persistence-testing.html?language=Scala) covers all the steps and features you need to write unit tests for your Aggregates. 
+The section in [Testing](https://doc.akka.io/docs/akka/2.6/typed/persistence-testing.html?language=Scala) covers all the steps and features you need to write unit tests for your Aggregates.


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?

## Fixes

Fixed a typo in docs
