### PR TITLE
fix jabba script url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
 before_install:
   # See https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-239493916
   - rm ~/.m2/settings.xml
-  - curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
+  - curl -Ls https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
 install: jabba install $(jabba ls-remote "adopt@~1.$TRAVIS_JDK.0-0" --latest=patch) && jabba use "$_" && java -Xmx32m -version
 
 git:


### PR DESCRIPTION
We had lots of errors recently while downloading the Jabba script. I notice that Lagom is the only project with that problem. Other Akka projects are also using it, but never get issues. 

I suspect that this may be due to the redirect we were using. Let's try if w fixed URL.

Refs: #2777