### PR TITLE
Revert "Update kafka, kafka-clients to 2.5.0"

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,16 +44,6 @@ pull_request_rules:
       label:
         remove: [status:needs-backport-1.4]
 
-  - name: Merge ScalaSteward's PRs that are ready
-    conditions:
-      - author=scala-steward
-      - status-success=Travis CI - Pull Request
-      - "#changes-requested-reviews-by=0"
-      - label!=status:block-merge
-    actions:
-      merge:
-        method: merge
-
   - name: Delete the PR branch after merge
     conditions:
       - merged

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
     // adapt links in (java/scala)/KafkaClient.md for minor version changes
     val AlpakkaKafka = "2.0.2"
     // Keep this version consistent with Alpakka Kafka Connector
-    val Kafka = "2.5.0"
+    val Kafka = "2.4.1"
 
     val Curator       = "2.12.0"
     val Immutables    = "2.8.3"


### PR DESCRIPTION
We can't have mergify just update the Kafka client library with a new minor version.

Reverts lagom/lagom#2819