### PR TITLE
Fixed ports for DB multi-jvm tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,20 +193,6 @@ val defaultMultiJvmOptions: List[String] = {
   "-Xmx256m" :: properties
 }
 
-def databasePortSetting: List[String] = {
-  def gimmePort = {
-    val serverSocket = ServerSocketChannel.open().socket()
-    try {
-      serverSocket.bind(new InetSocketAddress("127.0.0.1", 0))
-      serverSocket.getLocalPort
-    } finally serverSocket.close()
-  }
-  List(
-    s"-Djavadsl.database.port=$gimmePort",
-    s"-Dscaladsl.database.port=$gimmePort",
-  )
-}
-
 def multiJvm(project: Project): Project = {
   project
     .enablePlugins(MultiJvmPlugin)
@@ -234,7 +220,7 @@ def multiJvm(project: Project): Project = {
           // -o D(report the duration of the tests) F(show full stack traces)
           // -u select the JUnit XML reporter
           scalatestOptions in MultiJvm := Seq("-oDF", "-u", (target.value / "test-reports").getAbsolutePath),
-          MultiJvmKeys.jvmOptions in MultiJvm := databasePortSetting ::: defaultMultiJvmOptions,
+          MultiJvmKeys.jvmOptions in MultiJvm := defaultMultiJvmOptions,
           // tag MultiJvm tests so that we can use concurrentRestrictions to disable parallel tests
           executeTests in MultiJvm := (executeTests in MultiJvm).tag(Tags.Test).value,
           // change multi-jvm lib folder to reflect the scala version used during crossbuild

--- a/persistence-cassandra/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
+++ b/persistence-cassandra/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
@@ -15,11 +15,16 @@ import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersis
 import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntitySpec
 import com.lightbend.lagom.javadsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.javadsl.persistence.TestEntityReadSide
+import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntityConfig.Ports
+import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntityConfig.Ports.SpecPorts
 import com.typesafe.config.Config
 
 object CassandraClusteredPersistentEntityConfig extends AbstractClusteredPersistentEntityConfig {
-  override def additionalCommonConfig(databasePort: Int): Config = {
-    cassandraConfigOnly("ClusteredPersistentEntitySpec", databasePort)
+
+  override def specPorts: SpecPorts = Ports.cassandraSpecPorts
+
+  override def additionalCommonConfig: Config = {
+    cassandraConfigOnly("ClusteredPersistentEntitySpec", specPorts.database)
       .withFallback(CassandraReadSideSpec.readSideConfig)
   }
 }
@@ -41,7 +46,7 @@ class CassandraClusteredPersistentEntitySpec
         cassandraDirectory,
         "lagom-test-embedded-cassandra.yaml",
         clean = true,
-        port = databasePort
+        port = specPorts.database
       )
       awaitPersistenceInit(system)
     }

--- a/persistence-cassandra/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
+++ b/persistence-cassandra/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraClusteredPersistentEntitySpec.scala
@@ -19,6 +19,7 @@ import com.lightbend.lagom.scaladsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.scaladsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntityConfig
 import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntitySpec
+import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntitySpec.Ports
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.typesafe.config.Config
 import play.api.inject.DefaultApplicationLifecycle
@@ -31,10 +32,14 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 object CassandraClusteredPersistentEntityConfig extends AbstractClusteredPersistentEntityConfig {
-  override def additionalCommonConfig(databasePort: Int): Config = {
-    cassandraConfigOnly("CassandraClusteredPersistentEntityConfig", databasePort)
+
+  override def specPorts: Ports.SpecPorts = Ports.cassandraSpecPorts
+
+  override def additionalCommonConfig: Config = {
+    cassandraConfigOnly("CassandraClusteredPersistentEntityConfig", specPorts.database)
       .withFallback(CassandraReadSideSpec.readSideConfig)
   }
+
 }
 
 class CassandraClusteredPersistentEntitySpecMultiJvmNode1 extends CassandraClusteredPersistentEntitySpec
@@ -43,6 +48,7 @@ class CassandraClusteredPersistentEntitySpecMultiJvmNode3 extends CassandraClust
 
 class CassandraClusteredPersistentEntitySpec
     extends AbstractClusteredPersistentEntitySpec(CassandraClusteredPersistentEntityConfig) {
+
   import CassandraClusteredPersistentEntityConfig._
 
   protected override def atStartup(): Unit = {
@@ -54,7 +60,7 @@ class CassandraClusteredPersistentEntitySpec
         cassandraDirectory,
         "lagom-test-embedded-cassandra.yaml",
         clean = true,
-        port = databasePort
+        port = specPorts.database
       )
       awaitPersistenceInit(system)
     }

--- a/persistence-jdbc/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcClusteredPersistentEntitySpec.scala
+++ b/persistence-jdbc/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcClusteredPersistentEntitySpec.scala
@@ -9,16 +9,21 @@ import java.util.concurrent.CompletionStage
 import com.lightbend.lagom.javadsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.javadsl.persistence.TestEntity.Evt
 import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntityConfig
+import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntityConfig.Ports
+import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntityConfig.Ports.SpecPorts
 import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntitySpec
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.h2.tools.Server
 
 object JdbcClusteredPersistentEntityConfig extends AbstractClusteredPersistentEntityConfig {
-  override def additionalCommonConfig(databasePort: Int): Config = ConfigFactory.parseString(
+
+  override def specPorts: SpecPorts = Ports.jdbcSpecPorts
+
+  override def additionalCommonConfig: Config = ConfigFactory.parseString(
     s"""
       db.default.driver=org.h2.Driver
-      db.default.url="jdbc:h2:tcp://localhost:$databasePort/mem:JdbcClusteredPersistentEntitySpec"
+      db.default.url="jdbc:h2:tcp://localhost:${specPorts.database}/mem:JdbcClusteredPersistentEntitySpec"
     """
   )
 }
@@ -35,7 +40,7 @@ class JdbcClusteredPersistentEntitySpec
 
   protected override def atStartup() {
     runOn(node1) {
-      h2 = Server.createTcpServer("-tcpPort", databasePort.toString, "-ifNotExists").start()
+      h2 = Server.createTcpServer("-tcpPort", specPorts.database.toString, "-ifNotExists").start()
     }
 
     enterBarrier("h2-started")

--- a/persistence-jdbc/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcClusteredPersistentEntitySpec.scala
+++ b/persistence-jdbc/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/jdbc/JdbcClusteredPersistentEntitySpec.scala
@@ -13,6 +13,7 @@ import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersi
 import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntitySpec
 import com.lightbend.lagom.scaladsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.scaladsl.persistence.TestEntitySerializerRegistry
+import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntitySpec.Ports
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -28,10 +29,13 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 object JdbcClusteredPersistentEntityConfig extends AbstractClusteredPersistentEntityConfig {
-  override def additionalCommonConfig(databasePort: Int): Config = ConfigFactory.parseString(
+
+  override def specPorts: Ports.SpecPorts = Ports.jdbcSpecPorts
+
+  override def additionalCommonConfig: Config = ConfigFactory.parseString(
     s"""
       db.default.driver=org.h2.Driver
-      db.default.url="jdbc:h2:tcp://localhost:$databasePort/mem:JdbcClusteredPersistentEntitySpec"
+      db.default.url="jdbc:h2:tcp://localhost:${specPorts.database}/mem:JdbcClusteredPersistentEntitySpec"
     """
   )
 }
@@ -48,7 +52,7 @@ class JdbcClusteredPersistentEntitySpec
 
   protected override def atStartup(): Unit = {
     runOn(node1) {
-      h2 = Server.createTcpServer("-tcpPort", databasePort.toString, "-ifNotExists").start()
+      h2 = Server.createTcpServer("-tcpPort", specPorts.database.toString, "-ifNotExists").start()
     }
 
     enterBarrier("h2-started")

--- a/persistence-jdbc/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickClusteredPersistentEntitySpec.scala
+++ b/persistence-jdbc/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/slick/SlickClusteredPersistentEntitySpec.scala
@@ -13,6 +13,7 @@ import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersi
 import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntitySpec
 import com.lightbend.lagom.scaladsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.scaladsl.persistence.TestEntitySerializerRegistry
+import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntitySpec.Ports
 import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
@@ -28,10 +29,13 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 object SlickClusteredPersistentEntityConfig extends AbstractClusteredPersistentEntityConfig {
-  override def additionalCommonConfig(databasePort: Int): Config = ConfigFactory.parseString(
+
+  override def specPorts: Ports.SpecPorts = Ports.slickSpecPorts
+
+  override def additionalCommonConfig: Config = ConfigFactory.parseString(
     s"""
       db.default.driver=org.h2.Driver
-      db.default.url="jdbc:h2:tcp://localhost:$databasePort/mem:JdbcClusteredPersistentEntitySpec"
+      db.default.url="jdbc:h2:tcp://localhost:${specPorts.database}/mem:JdbcClusteredPersistentEntitySpec"
     """
   )
 }
@@ -48,7 +52,7 @@ class SlickClusteredPersistentEntitySpec
 
   protected override def atStartup(): Unit = {
     runOn(node1) {
-      h2 = Server.createTcpServer("-tcpPort", databasePort.toString, "-ifNotExists").start()
+      h2 = Server.createTcpServer("-tcpPort", specPorts.database.toString, "-ifNotExists").start()
     }
     enterBarrier("h2-started")
     super.atStartup()

--- a/persistence/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -124,8 +124,8 @@ object AbstractClusteredPersistentEntityConfig {
       val node3    = base + 3
     }
 
-    val cassandraSpecPorts = new SpecPorts(10030)
-    val jdbcSpecPorts      = new SpecPorts(10040)
+    val cassandraSpecPorts = new SpecPorts(20030)
+    val jdbcSpecPorts      = new SpecPorts(20040)
   }
 
 }

--- a/persistence/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/javadsl/src/multi-jvm/scala/com/lightbend/lagom/javadsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -32,17 +32,19 @@ import scala.compat.java8.FutureConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import com.lightbend.lagom.internal.cluster.STMultiNodeSpec
+import com.lightbend.lagom.javadsl.persistence.multinode.AbstractClusteredPersistentEntityConfig.Ports.SpecPorts
 
 abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
+
   val node1 = role("node1")
   val node2 = role("node2")
   val node3 = role("node3")
 
-  val databasePort = System.getProperty("javadsl.database.port").toInt
-  val environment  = Environment.simple()
+  def specPorts: SpecPorts
+  val environment = Environment.simple()
 
   commonConfig(
-    additionalCommonConfig(databasePort).withFallback(
+    additionalCommonConfig.withFallback(
       ConfigFactory
         .parseString(
           """
@@ -86,27 +88,47 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
     )
   )
 
-  def additionalCommonConfig(databasePort: Int): Config
+  def additionalCommonConfig: Config
 
   nodeConfig(node1) {
-    ConfigFactory.parseString("""akka.cluster.roles = ["backend", "read-side"]""")
+    ConfigFactory.parseString(s"""
+      akka.cluster.roles = ["backend", "read-side"]
+      akka.remote.artery.canonical.port = ${specPorts.node1}
+      """.stripMargin)
   }
 
   nodeConfig(node2) {
-    ConfigFactory.parseString("""
+    ConfigFactory.parseString(s"""
       akka.cluster.roles = ["backend"]
       cassandra-journal.keyspace-autocreate = false
+      akka.remote.artery.canonical.port = ${specPorts.node2}
       """.stripMargin)
   }
 
   nodeConfig(node3) {
-    ConfigFactory.parseString("""
+    ConfigFactory.parseString(s"""
       akka.cluster.roles = ["read-side"]
       cassandra-journal.keyspace-autocreate = false
+      akka.remote.artery.canonical.port = ${specPorts.node3}
       """.stripMargin)
   }
 }
 
+object AbstractClusteredPersistentEntityConfig {
+
+  object Ports {
+    class SpecPorts(base: Int) {
+      val database = base
+      val node1    = base + 1
+      val node2    = base + 2
+      val node3    = base + 3
+    }
+
+    val cassandraSpecPorts = new SpecPorts(10030)
+    val jdbcSpecPorts      = new SpecPorts(10040)
+  }
+
+}
 abstract class AbstractClusteredPersistentEntitySpec(config: AbstractClusteredPersistentEntityConfig)
     extends MultiNodeSpec(config)
     with STMultiNodeSpec

--- a/persistence/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -27,17 +27,19 @@ import scala.concurrent.duration._
 import scala.concurrent.Await
 import scala.concurrent.Future
 import com.lightbend.lagom.internal.cluster.STMultiNodeSpec
+import com.lightbend.lagom.scaladsl.persistence.multinode.AbstractClusteredPersistentEntitySpec.Ports.SpecPorts
 
 abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
   val node1 = role("node1")
   val node2 = role("node2")
   val node3 = role("node3")
 
-  val databasePort = System.getProperty("scaladsl.database.port").toInt
-  val environment  = Environment.simple()
+  def specPorts: SpecPorts
+
+  val environment = Environment.simple()
 
   commonConfig(
-    additionalCommonConfig(databasePort).withFallback(
+    additionalCommonConfig.withFallback(
       ConfigFactory
         .parseString(
           """
@@ -81,24 +83,29 @@ abstract class AbstractClusteredPersistentEntityConfig extends MultiNodeConfig {
     )
   )
 
-  def additionalCommonConfig(databasePort: Int): Config
+  def additionalCommonConfig: Config
 
   nodeConfig(node1) {
-    ConfigFactory.parseString("""akka.cluster.roles = ["backend", "read-side"]""")
+    ConfigFactory.parseString(s"""
+      akka.cluster.roles = ["backend", "read-side"]
+      akka.remote.artery.canonical.port = ${specPorts.node1}
+      """)
   }
 
   nodeConfig(node2) {
-    ConfigFactory.parseString("""
+    ConfigFactory.parseString(s"""
       akka.cluster.roles = ["backend"]
       cassandra-journal.keyspace-autocreate = false
-      """.stripMargin)
+      akka.remote.artery.canonical.port = ${specPorts.node2}
+      """)
   }
 
   nodeConfig(node3) {
-    ConfigFactory.parseString("""
+    ConfigFactory.parseString(s"""
       akka.cluster.roles = ["read-side"]
       cassandra-journal.keyspace-autocreate = false
-      """.stripMargin)
+      akka.remote.artery.canonical.port = ${specPorts.node3}
+      """)
   }
 }
 
@@ -119,6 +126,19 @@ object AbstractClusteredPersistentEntitySpec {
       JsonSerializerRegistry.serializationSetupFor(jsonSerializerRegistry)
     )
     ActorSystem(getCallerName(classOf[MultiNodeSpec]), setup)
+  }
+
+  object Ports {
+    class SpecPorts(base: Int) {
+      val database = base
+      val node1    = base + 1
+      val node2    = base + 2
+      val node3    = base + 3
+    }
+
+    val cassandraSpecPorts = new SpecPorts(10000)
+    val jdbcSpecPorts      = new SpecPorts(10010)
+    val slickSpecPorts     = new SpecPorts(10020)
   }
 }
 

--- a/persistence/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
+++ b/persistence/scaladsl/src/multi-jvm/scala/com/lightbend/lagom/scaladsl/persistence/multinode/AbstractClusteredPersistentEntitySpec.scala
@@ -136,9 +136,9 @@ object AbstractClusteredPersistentEntitySpec {
       val node3    = base + 3
     }
 
-    val cassandraSpecPorts = new SpecPorts(10000)
-    val jdbcSpecPorts      = new SpecPorts(10010)
-    val slickSpecPorts     = new SpecPorts(10020)
+    val cassandraSpecPorts = new SpecPorts(20000)
+    val jdbcSpecPorts      = new SpecPorts(20010)
+    val slickSpecPorts     = new SpecPorts(20020)
   }
 }
 


### PR DESCRIPTION
References: #2751

multi-jvm tests were a little bit more trick regarding the startup of Cassandra. 

Previously, this was picking a port from sbt task, passing it to configurations, then starting the JVMs and on node 1 starting Cassandra. If could happen that one of the remotes pick the Cassandra port causing conflicts. 

The same could occur when starting H2.