### PR TITLE
Fix duplicate upgrade Jackson version from Scala Steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -10,7 +10,9 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-core" },
   { groupId = "com.fasterxml.jackson.dataformat", artifactId = "jackson-dataformat-cbor" },
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jsr310" },
-  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" }
+  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" },
+  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-pcollections" },
+  { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-guava" }
 ]
 
 updatePullRequests = false


### PR DESCRIPTION
## Fixes

Fix duplicate upgrade Jackson version from Scala Steward.
https://github.com/lagom/lagom/pull/2859 and https://github.com/lagom/lagom/pull/2858 as an example.