### PR TITLE
Mergify: merge-when-green

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,53 +7,14 @@ pull_request_rules:
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
       - label!=status:block-merge
+      - label=status:merge-when-green
     actions:
       merge:
         method: merge
 
-  - name: backport patches to 1.6.x branch
-    conditions:
-      - merged
-      - label=status:needs-backport
-    actions:
-      backport:
-        branches:
-          - 1.6.x
-      label:
-        remove: [status:needs-backport]
-
-  - name: backport patches to 1.5.x branch
-    conditions:
-      - merged
-      - label=status:needs-backport-1.5
-    actions:
-      backport:
-        branches:
-          - 1.5.x
-      label:
-        remove: [status:needs-backport-1.5]
-
-  - name: backport patches to 1.4.x branch
-    conditions:
-      - merged
-      - label=status:needs-backport-1.4
-    actions:
-      backport:
-        branches:
-          - 1.4.x
-      label:
-        remove: [status:needs-backport-1.4]
 
   - name: Delete the PR branch after merge
     conditions:
       - merged
     actions:
       delete_head_branch: {}
-
-  - name: auto add wip
-    conditions:
-      # match a few flavours of wip
-      - title~=^(\[wip\]( |:) |\[WIP\]( |:) |wip( |:) |WIP( |:)).*
-    actions:
-      label:
-        add: ["status:block-merge"]


### PR DESCRIPTION
Motivation: in the Akka team, it's a common practice to approve a PR, but leave small change request. Basically saying, "this is good for merge after that small change". Mergify gets in the way because it kicks in before the contributor gets the chance to apply the change. 

When we started to use Mergify, the goal was to approve a PR and let it be merged when green so we don't have to come back to merge things. So, with that in mind, I think we should move back to this approach and only merge if marked with `merge-when-green`. 

If the build is already green, a reviewer can review it and merge (without mergify). Just normal flow. 
 
I took the opportunity to do some other clean-up:

* remove backport rulles (we should use Mergify backport command as it's more flexible)
* remove WIP rule, it never worked propertly. 