### PR TITLE
build: use publish/skip to opt out of publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -663,7 +663,7 @@ lazy val `integration-tests-javadsl` = (project in file("service/javadsl/integra
     name := "lagom-javadsl-integration-tests",
     Dependencies.`integration-tests-javadsl`,
     PgpKeys.publishSigned := {},
-    publish := {}
+    publish / skip := true
   )
   .dependsOn(
     `server-javadsl`,
@@ -681,7 +681,7 @@ lazy val `integration-tests-scaladsl` = (project in file("service/scaladsl/integ
     name := "lagom-scaladsl-integration-tests",
     Dependencies.`integration-tests-scaladsl`,
     PgpKeys.publishSigned := {},
-    publish := {}
+    publish / skip := true
   )
   .dependsOn(`server-scaladsl`, logback, `testkit-scaladsl`)
 
@@ -1123,7 +1123,7 @@ lazy val `dev-environment` = (project in file("dev"))
     PgpKeys.publishSigned := {},
     publishLocal := {},
     publishArtifact in Compile := false,
-    publish := {}
+    publish / skip := true
   )
 
 lazy val `reloadable-server` = (project in file("dev") / "reloadable-server")
@@ -1489,7 +1489,7 @@ lazy val `sbt-scripted-library` = (project in file("dev") / "sbt-scripted-librar
   .settings(
     name := "lagom-sbt-scripted-library",
     PgpKeys.publishSigned := {},
-    publish := {}
+    publish / skip := true
   )
   .dependsOn(`server-javadsl`)
 
@@ -1617,5 +1617,5 @@ lazy val `macro-testkit` = (project in file("macro-testkit"))
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     ),
     PgpKeys.publishSigned := {},
-    publish := {}
+    publish / skip := true
   )


### PR DESCRIPTION
## Fixes

Fixes #2938 

## Purpose

This avoids the duplicate module problem in #2938 

By switching to the later introduced `publish / skip` sbt-whitesource will not run for those projects as they are not published anyway.