### PR TITLE
Bumps dependencies for release 1.6.3

### DIFF
--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala
@@ -52,7 +52,7 @@ object LagomImport extends LagomImportCompat {
   val lagomScaladslTestKit              = component("lagom-scaladsl-testkit") % Test
 
   val lagomJUnitDeps = Seq(
-    "junit"        % "junit"           % "4.12" % Test,
+    "junit"        % "junit"           % "4.13" % Test,
     "com.novocode" % "junit-interface" % "0.11" % Test
   )
 

--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -5,7 +5,7 @@ val ScalaVersion = "2.12.10"
 
 val AkkaVersion = sys.props.getOrElse("lagom.build.akka.version", "2.6.5") // sync with project/Dependencies.scala
 
-val JUnitVersion          = "4.12"
+val JUnitVersion          = "4.13"
 val JUnitInterfaceVersion = "0.11"
 val ScalaTestVersion      = "3.0.8"
 val PlayVersion           = "2.8.2" // sync with project/Dependencies.scala

--- a/docs/src/test/java/docs/home/persistence/CqrsIntegrationTest.java
+++ b/docs/src/test/java/docs/home/persistence/CqrsIntegrationTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import static com.lightbend.lagom.javadsl.testkit.ServiceTest.*;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CqrsIntegrationTest {
   private static TestServer server;

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,15 +38,15 @@ object Dependencies {
 
     // Also be sure to update ScalaTestVersion in docs/build.sbt.
     val ScalaTest            = "3.0.8"
-    val Jackson              = "2.10.3"
+    val Jackson              = "2.10.4"
     val JacksonCore          = Jackson
     val JacksonDatatype      = Jackson
-    val JacksonDatabind      = "2.10.3"
-    val Guava                = "28.1-jre"
+    val JacksonDatabind      = "2.10.4"
+    val Guava                = "28.2-jre"
     val Maven                = "3.6.2"
     val MavenWagon           = "3.3.3"
     val MavenResolver        = "1.4.1"
-    val Netty                = "4.1.43.Final"
+    val Netty                = "4.1.50.Final"
     val NettyReactiveStreams = "2.0.4"
     val Kafka                = "2.1.1"
     // adapt links in (java/scala)/KafkaClient.md for minor version changes
@@ -56,11 +56,14 @@ object Dependencies {
     val HibernateCore = "5.4.8.Final"
     val PCollections  = "3.0.5"
 
-    val ScalaJava8Compat = "0.9.0"
+    val ScalaJava8Compat = "0.9.1"
     val ScalaXml         = "1.2.0"
     val Slick            = "3.3.2"
-    val JUnit            = "4.12"
-    val JUnitInterface   = "0.11"
+    // JUnit[Interface] should be sync with:
+    //   lagomJUnitDeps in dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomImport.scala
+    //   JUnitVersion in docs/build.sbt
+    val JUnit          = "4.13"
+    val JUnitInterface = "0.11"
 
     val Slf4j   = "1.7.30"
     val Logback = "1.2.3"
@@ -96,7 +99,7 @@ object Dependencies {
   private val byteBuddy              = "net.bytebuddy" % "byte-buddy" % Versions.ByteBuddy
   private val scalaParserCombinators = "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
   private val typesafeConfig         = "com.typesafe" % "config" % "1.4.0"
-  private val sslConfig              = "com.typesafe" %% "ssl-config-core" % "0.4.1"
+  private val sslConfig              = "com.typesafe" %% "ssl-config-core" % "0.4.2"
   private val h2                     = "com.h2database" % "h2" % "1.4.192"
   private val cassandraDriverCore =
     ("com.datastax.cassandra" % "cassandra-driver-core" % Versions.CassandraDriver).excludeAll(excludeSlf4j: _*)
@@ -244,15 +247,15 @@ object Dependencies {
       jnra64asm,
       jnrx86asm,
       "com.google.code.findbugs" % "jsr305"                  % "3.0.2",
-      "com.google.errorprone"    % "error_prone_annotations" % "2.3.2",
+      "com.google.errorprone"    % "error_prone_annotations" % "2.3.4",
       guava,
       "com.google.j2objc"            % "j2objc-annotations"   % "1.3",
-      "com.google.inject"            % "guice"                % "4.2.2",
-      "com.google.inject.extensions" % "guice-assistedinject" % "4.2.2",
+      "com.google.inject"            % "guice"                % "4.2.3",
+      "com.google.inject.extensions" % "guice-assistedinject" % "4.2.3",
       "com.googlecode.usc"           % "jdbcdslog"            % "1.0.6.2",
-      "org.checkerframework"         % "checker-qual"         % "2.8.1",
+      "org.checkerframework"         % "checker-qual"         % "2.10.0",
       "javax.xml.bind"               % "jaxb-api"             % "2.3.1",
-      "jakarta.xml.bind"             % "jakarta.xml.bind-api" % "2.3.2",
+      "jakarta.xml.bind"             % "jakarta.xml.bind-api" % "2.3.3",
       h2,
       "com.jolbox"   % "bonecp"          % "0.8.0.RELEASE",
       "com.lmax"     % "disruptor"       % Versions.Disruptor,
@@ -328,7 +331,7 @@ object Dependencies {
       "com.typesafe.play"  %% "twirl-api"      % Versions.Twirl,
       "com.typesafe.slick" %% "slick"          % Versions.Slick,
       "com.typesafe.slick" %% "slick-hikaricp" % Versions.Slick,
-      "com.zaxxer"         % "HikariCP"        % "3.4.1",
+      "com.zaxxer"         % "HikariCP"        % "3.4.5",
       "commons-codec"      % "commons-codec"   % "1.11",
       dropwizardMetricsCore,
       "io.jsonwebtoken" % "jjwt" % "0.9.1",
@@ -343,7 +346,7 @@ object Dependencies {
       "net.jodah"           % "typetools"               % "0.5.0",
       "org.lz4"             % "lz4-java"                % "1.5.0",
       "com.github.luben"    % "zstd-jni"                % "1.3.7-1",
-      "org.agrona"          % "agrona"                  % "1.4.0",
+      "org.agrona"          % "agrona"                  % "1.4.1",
       commonsLang,
       kafkaClients,
       "org.codehaus.mojo"               % "animal-sniffer-annotations" % "1.18",
@@ -372,7 +375,7 @@ object Dependencies {
       "com.google.protobuf"        % "protobuf-java"          % "3.10.0",
       "javax.activation"           % "activation"             % "1.1",
       "javax.activation"           % "javax.activation-api"   % "1.2.0",
-      "jakarta.activation"         % "jakarta.activation-api" % "1.2.1",
+      "jakarta.activation"         % "jakarta.activation-api" % "1.2.2",
       "com.thoughtworks.paranamer" % "paranamer"              % "2.8",
       mockitoCore,
       "org.objenesis" % "objenesis"        % "2.6",

--- a/project/VersionSyncCheckPlugin.scala
+++ b/project/VersionSyncCheckPlugin.scala
@@ -33,7 +33,7 @@ object VersionSyncCheckPlugin extends AutoPlugin {
   )
 
   def versionSyncCheckImpl = Def.task[Unit] {
-    val log = state.value.log
+    val log = streams.value.log
 
     log.info("Running version sync check")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("org.foundweekends" % "sbt-bintray"  % "0.5.5")
 addSbtPlugin("com.typesafe.sbt" % "sbt-multi-jvm"   % "0.4.0")
 addSbtPlugin("com.typesafe"     % "sbt-mima-plugin" % "0.6.1")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("com.lightbend"    % "sbt-whitesource"      % "0.1.18")
 
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")


### PR DESCRIPTION
```
sbt-dependency-graph    -> 0.10.0-RC1 (fix #2961)
Jackson                 -> 2.10.4
Netty                   -> 4.1.50.Final
checker-qual            -> 2.10.0
Guava                   -> 28.2-jre
error_prone_annotations -> 2.3.4
jakarta.xml.bind-api    -> 2.3.3
guice                   -> 4.2.3
ScalaJava8Compat        -> 0.9.1
ssl-config-core         -> 0.4.2
JUnit                   -> 4.13
jakarta.activation-api  -> 1.2.2
agrona                  -> 1.4.1
HikariCP                -> 3.4.5
```
also fixed #2961