### PR TITLE
Scala Steward: exclude Akka libs, pin Jackson

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,6 @@
 updates.ignore = [
   // explicit updates
+  { groupId = "com.typesafe.akka" },
   { groupId = "org.scalameta", artifactId = "scalafmt-core" },
   // these will get updated along with jackson-databind, so no need to update them
   // separately
@@ -13,6 +14,10 @@ updates.ignore = [
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-jdk8" },
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-pcollections" },
   { groupId = "com.fasterxml.jackson.datatype", artifactId = "jackson-datatype-guava" }
+]
+updates.pin = [
+  # To be updated in tandem with upstream Akka
+  { groupId = "com.fasterxml.jackson.core", artifactId = "jackson-databind", version = "2.10." }
 ]
 
 updatePullRequests = false

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,6 +2,8 @@ updates.ignore = [
   // explicit updates
   { groupId = "com.typesafe.akka" },
   { groupId = "org.scalameta", artifactId = "scalafmt-core" },
+  // upgrade only together with Alpakka Kafka
+  { groupId = "org.apache.kafka" },
   // these will get updated along with jackson-databind, so no need to update them
   // separately
   { groupId = "com.fasterxml.jackson.module", artifactId = "jackson-module-parameter-names" },


### PR DESCRIPTION
Akka and Akka HTTP should be updated conciously.
Jackson should stay on 2.10.x for now.