### PR TITLE
Let users disable metrics to process in batches

### DIFF
--- a/persistence/core/src/main/resources/reference.conf
+++ b/persistence/core/src/main/resources/reference.conf
@@ -76,6 +76,10 @@ lagom.persistence.read-side {
 
   # The Akka dispatcher to use for read-side actors and tasks.
   use-dispatcher = "lagom.persistence.dispatcher"
+
+  # Enables capture and reporting of metrics on the Read-Side. The metrics
+  # reporting enforces consuming events one at a time.
+  projection-metrics = on
 }
 #//#persistence-read-side
 

--- a/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/ReadSideConfig.scala
+++ b/persistence/core/src/main/scala/com/lightbend/lagom/internal/persistence/ReadSideConfig.scala
@@ -16,7 +16,8 @@ case class ReadSideConfig(
     maxBackoff: FiniteDuration = 30.seconds,
     randomBackoffFactor: Double = 0.2,
     globalPrepareTimeout: FiniteDuration = 20.seconds,
-    role: Option[String] = None
+    role: Option[String] = None,
+    withMetrics: Boolean = true
 )
 
 object ReadSideConfig {
@@ -30,7 +31,8 @@ object ReadSideConfig {
       conf.getString("run-on-role") match {
         case "" => None
         case r  => Some(r)
-      }
+      },
+      conf.getBoolean("projection-metrics")
     )
   }
 }

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -137,11 +137,12 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
                   .asJava
 
               if (config.withMetrics) {
-                val wrappedFlow: Flow[japi.Pair[Event, LagomOffset], Done, NotUsed] = Flow[japi.Pair[Event, LagomOffset]]
-                  .map { pair =>
-                    (pair, OffsetAdapter.dslOffsetToOffset(pair.second))
-                  }
-                  .via(userFlowWrapper(workerCoordinates, userFlow.asScala))
+                val wrappedFlow: Flow[japi.Pair[Event, LagomOffset], Done, NotUsed] =
+                  Flow[japi.Pair[Event, LagomOffset]]
+                    .map { pair =>
+                      (pair, OffsetAdapter.dslOffsetToOffset(pair.second))
+                    }
+                    .via(userFlowWrapper(workerCoordinates, userFlow.asScala))
                 eventStreamSource.via(wrappedFlow)
               } else {
                 eventStreamSource.via(userFlow)

--- a/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
+++ b/persistence/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/ReadSideActor.scala
@@ -20,6 +20,7 @@ import akka.util.Timeout
 import akka.Done
 import akka.NotUsed
 import akka.japi
+import akka.persistence.query.Offset
 import akka.persistence.query.{ Offset => AkkaOffset }
 import akka.stream.FlowShape
 import akka.stream.javadsl
@@ -33,6 +34,7 @@ import com.lightbend.lagom.internal.projection.ProjectionRegistryActor.WorkerCoo
 import com.lightbend.lagom.internal.spi.projection.ProjectionSpi
 import com.lightbend.lagom.javadsl.persistence.AggregateEvent
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTag
+import com.lightbend.lagom.javadsl.persistence.Offset
 import com.lightbend.lagom.javadsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.javadsl.persistence.{ Offset => LagomOffset }
 
@@ -101,7 +103,7 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
   def receive: Receive = {
     case Start =>
       val tag = new AggregateEventTag(clazz, tagName)
-      val backOffSource =
+      val backOffSource: scaladsl.Source[Done, NotUsed] =
         RestartSource.withBackoff(
           config.minBackoff,
           config.maxBackoff,
@@ -134,13 +136,16 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
                   }
                   .asJava
 
-              val wrappedFlow = Flow[japi.Pair[Event, LagomOffset]]
-                .map { pair =>
-                  (pair, OffsetAdapter.dslOffsetToOffset(pair.second))
-                }
-                .via(userFlowWrapper(workerCoordinates, userFlow.asScala))
-
-              eventStreamSource.via(wrappedFlow)
+              if (config.withMetrics) {
+                val wrappedFlow: Flow[japi.Pair[Event, LagomOffset], Done, NotUsed] = Flow[japi.Pair[Event, LagomOffset]]
+                  .map { pair =>
+                    (pair, OffsetAdapter.dslOffsetToOffset(pair.second))
+                  }
+                  .via(userFlowWrapper(workerCoordinates, userFlow.asScala))
+                eventStreamSource.via(wrappedFlow)
+              } else {
+                eventStreamSource.via(userFlow)
+              }
             }
         }
 
@@ -165,12 +170,12 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
   private def userFlowWrapper(
       workerCoordinates: WorkerCoordinates,
       userFlow: Flow[japi.Pair[Event, LagomOffset], Done, _]
-  ): Flow[(japi.Pair[Event, LagomOffset], AkkaOffset), AkkaOffset, _] =
+  ): Flow[(japi.Pair[Event, LagomOffset], AkkaOffset), Done, _] =
     Flow.fromGraph(GraphDSL.create(userFlow) { implicit builder => wrappedFlow =>
       import GraphDSL.Implicits._
       val unzip = builder.add(Unzip[japi.Pair[Event, LagomOffset], AkkaOffset])
       val zip   = builder.add(Zip[Done, AkkaOffset])
-      val metricsReporter: FlowShape[(Done, AkkaOffset), AkkaOffset] = builder.add(Flow.fromFunction {
+      val metricsReporter: FlowShape[(Done, AkkaOffset), Done] = builder.add(Flow.fromFunction {
         case (_, akkaOffset) =>
           // TODO: in ReadSide processor we can't report `afterUserFlow` and `completedProcessing` separately
           //  as we do in TopicProducerActor, unless we moved the invocation of `afterUserFlow` to each
@@ -181,7 +186,7 @@ private[lagom] class ReadSideActor[Event <: AggregateEvent[Event]](
             workerCoordinates.tagName,
             akkaOffset
           )
-          akkaOffset
+          Done
       })
 
       unzip.out0 ~> wrappedFlow ~> zip.in0


### PR DESCRIPTION
In order to provide metrics over read side processors, it is mandatory to consume events one at a time. 

Power-users implementing their own offset storage and strategy using their own `ReadSideHandler` may implement `handle(): Flow` with grouping (which allows consuming multiple events at once).

