### PR TITLE
Improve event migration

### DIFF
--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonMigration.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonMigration.scala
@@ -22,7 +22,7 @@ object JsonMigrations {
 
   def apply(
       currentVersion: Int,
-      supportedForwardVersion:Int,
+      supportedForwardVersion: Int,
       transformation: (Int, JsValue) => JsValue,
       classNameTransformation: (Int, String) => String
   ): JsonMigration =
@@ -39,10 +39,14 @@ object JsonMigrations {
    *                        through the play-json transformation DSL)
    */
   def transform[T: ClassTag](transformations: immutable.SortedMap[Int, Reads[JsObject]]): (String, JsonMigration) = {
-    val currentVersion= transformations.keys.last + 1
+    val currentVersion = transformations.keys.last + 1
     transform(transformations, currentVersion, currentVersion)
   }
-  def transform[T: ClassTag](transformations: immutable.SortedMap[Int, Reads[JsObject]], currentVersion:Int, supportedForwardVersion: Int): (String, JsonMigration) = {
+  def transform[T: ClassTag](
+      transformations: immutable.SortedMap[Int, Reads[JsObject]],
+      currentVersion: Int,
+      supportedForwardVersion: Int
+  ): (String, JsonMigration) = {
     val className = implicitly[ClassTag[T]].runtimeClass.getName
     className -> new JsonMigration(currentVersion, supportedForwardVersion) {
       override def transform(fromVersion: Int, json: JsObject): JsObject = {
@@ -92,7 +96,8 @@ abstract class JsonMigration(val currentVersion: Int, val supportedForwardVersio
 
   require(
     currentVersion <= supportedForwardVersion,
-    s"""The "currentVersion" [$currentVersion] of a JsonMigration must be less or equal to the "supportedForwardVersion" [$supportedForwardVersion].""")
+    s"""The "currentVersion" [$currentVersion] of a JsonMigration must be less or equal to the "supportedForwardVersion" [$supportedForwardVersion]."""
+  )
 
   /**
    * Override to provide transformation of the old JSON structure to the new

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonMigration.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/JsonMigration.scala
@@ -92,7 +92,7 @@ abstract class JsonMigration(val currentVersion: Int, val supportedForwardVersio
 
   require(
     currentVersion <= supportedForwardVersion,
-    """The "currentVersion" of a JacksonMigration must be less or equal to the "supportedForwardVersion".""")
+    s"""The "currentVersion" [$currentVersion] of a JsonMigration must be less or equal to the "supportedForwardVersion" [$supportedForwardVersion].""")
 
   /**
    * Override to provide transformation of the old JSON structure to the new

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
@@ -98,13 +98,13 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
     val renameMigration = migrations.get(manifestClassName)
 
     val migratedManifest = renameMigration match {
-      case Some(migration) if  fromVersion < migration.currentVersion =>
+      case Some(migration) if fromVersion < migration.currentVersion =>
         migration.transformClassName(fromVersion, manifestClassName)
-      case Some(migration) if  fromVersion == migration.currentVersion =>
+      case Some(migration) if fromVersion == migration.currentVersion =>
         manifestClassName
-      case Some(migration) if  fromVersion <= migration.supportedForwardVersion =>
+      case Some(migration) if fromVersion <= migration.supportedForwardVersion =>
         migration.transformClassName(fromVersion, manifestClassName)
-      case Some(migration) if fromVersion > migration.supportedForwardVersion  =>
+      case Some(migration) if fromVersion > migration.supportedForwardVersion =>
         throw new IllegalStateException(
           s"Migration supported version ${migration.supportedForwardVersion} is " +
             s"behind version $fromVersion of deserialized type [$manifestClassName]"
@@ -138,7 +138,7 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
     }
 
     val migratedJson = transformMigration match {
-      case None => json
+      case None                                                       => json
       case Some(migration) if fromVersion == migration.currentVersion => json
       case Some(migration) if fromVersion <= migration.supportedForwardVersion =>
         json match {
@@ -148,7 +148,6 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
             migration.transformValue(fromVersion, js)
         }
     }
-
 
     val result = format.reads(migratedJson) match {
       case JsSuccess(obj, _) => obj

--- a/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
+++ b/play-json/src/main/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializer.scala
@@ -98,14 +98,18 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
     val renameMigration = migrations.get(manifestClassName)
 
     val migratedManifest = renameMigration match {
-      case Some(migration) if migration.currentVersion > fromVersion =>
+      case Some(migration) if  fromVersion < migration.currentVersion =>
         migration.transformClassName(fromVersion, manifestClassName)
-      case Some(migration) if migration.currentVersion < fromVersion =>
+      case Some(migration) if  fromVersion == migration.currentVersion =>
+        manifestClassName
+      case Some(migration) if  fromVersion <= migration.supportedForwardVersion =>
+        migration.transformClassName(fromVersion, manifestClassName)
+      case Some(migration) if fromVersion > migration.supportedForwardVersion  =>
         throw new IllegalStateException(
-          s"Migration version ${migration.currentVersion} is " +
+          s"Migration supported version ${migration.supportedForwardVersion} is " +
             s"behind version $fromVersion of deserialized type [$manifestClassName]"
         )
-      case _ => manifestClassName
+      case None => manifestClassName
     }
 
     val transformMigration = migrations.get(migratedManifest)
@@ -133,13 +137,18 @@ private[lagom] final class PlayJsonSerializer(val system: ExtendedActorSystem, r
         )
     }
 
-    val migratedJson = (transformMigration, json) match {
-      case (Some(migration), js: JsObject) if migration.currentVersion > fromVersion =>
-        migration.transform(fromVersion, js)
-      case (Some(migration), js: JsValue) if migration.currentVersion > fromVersion =>
-        migration.transformValue(fromVersion, js)
-      case _ => json
+    val migratedJson = transformMigration match {
+      case None => json
+      case Some(migration) if fromVersion == migration.currentVersion => json
+      case Some(migration) if fromVersion <= migration.supportedForwardVersion =>
+        json match {
+          case js: JsObject =>
+            migration.transform(fromVersion, js)
+          case js: JsValue =>
+            migration.transformValue(fromVersion, js)
+        }
     }
+
 
     val result = format.reads(migratedJson) match {
       case JsSuccess(obj, _) => obj

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -112,6 +112,35 @@ object TestRegistry3 extends JsonSerializerRegistry {
   )
 }
 
+object TestRegistry4 extends JsonSerializerRegistry {
+  override def serializers =
+    Seq(
+      JsonSerializer(Json.format[MigratedEvent])
+    )
+
+  def currentMigrationVersion: Int = 5
+  def supportedVersion: Int = currentMigrationVersion+1
+
+  import play.api.libs.json._
+  override def migrations = {
+    val transformations = SortedMap(
+      // only need to support the future version for the test (ignore past versions)
+      supportedVersion ->
+        __.json
+          .update((__ \ "newName").json.copyFrom((__ \ "newerName").json.pick))
+          .andThen((__ \ "newerName").json.prune)
+    )
+    Map(
+      JsonMigrations.transform[MigratedEvent](
+        transformations,
+        currentMigrationVersion, // currentVersion
+        supportedVersion // forward-one support
+      )
+    )
+  }
+}
+
+
 object TestRegistryWithCompression extends JsonSerializerRegistry {
   implicit val innerFormat = Json.format[Inner]
 
@@ -271,6 +300,36 @@ class PlayJsonSerializerSpec extends AnyWordSpec with Matchers {
 
         deserialized should be(expectedEvent)
     }
+
+
+    "downcast a future version" in withActorSystem(TestRegistry4) {
+      system =>
+        // Looks like MigratedEvent, except `newName` is called `newerName`. That field needs downcasting.
+        val newerJsonBytes = Json
+          .stringify(
+            JsObject(
+              Seq(
+                "addedField" -> JsNumber(2),
+                "newerName"  -> JsString("some value")
+              )
+            )
+          )
+          .getBytes(StandardCharsets.UTF_8)
+
+        val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
+
+        val futureVersion  = TestRegistry4.supportedVersion
+        val futureManifest = expectedVersionedManifest(classOf[MigratedEvent], futureVersion)
+        val serializeExt = SerializationExtension(system)
+        val serializer   = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
+
+        val deserialized = serializer.fromBinary(newerJsonBytes, futureManifest)
+
+        deserialized should be(expectedEvent)
+    }
+
+
+
 
     "use compression when enabled and payload is bigger than threshold" in withActorSystem(TestRegistryWithCompression) {
       system =>

--- a/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
+++ b/play-json/src/test/scala/com/lightbend/lagom/scaladsl/playjson/PlayJsonSerializerSpec.scala
@@ -119,7 +119,7 @@ object TestRegistry4 extends JsonSerializerRegistry {
     )
 
   def currentMigrationVersion: Int = 5
-  def supportedVersion: Int = currentMigrationVersion+1
+  def supportedVersion: Int        = currentMigrationVersion + 1
 
   import play.api.libs.json._
   override def migrations = {
@@ -134,12 +134,11 @@ object TestRegistry4 extends JsonSerializerRegistry {
       JsonMigrations.transform[MigratedEvent](
         transformations,
         currentMigrationVersion, // currentVersion
-        supportedVersion // forward-one support
+        supportedVersion         // forward-one support
       )
     )
   }
 }
-
 
 object TestRegistryWithCompression extends JsonSerializerRegistry {
   implicit val innerFormat = Json.format[Inner]
@@ -301,35 +300,30 @@ class PlayJsonSerializerSpec extends AnyWordSpec with Matchers {
         deserialized should be(expectedEvent)
     }
 
-
-    "downcast a future version" in withActorSystem(TestRegistry4) {
-      system =>
-        // Looks like MigratedEvent, except `newName` is called `newerName`. That field needs downcasting.
-        val newerJsonBytes = Json
-          .stringify(
-            JsObject(
-              Seq(
-                "addedField" -> JsNumber(2),
-                "newerName"  -> JsString("some value")
-              )
+    "downcast a future version" in withActorSystem(TestRegistry4) { system =>
+      // Looks like MigratedEvent, except `newName` is called `newerName`. That field needs downcasting.
+      val newerJsonBytes = Json
+        .stringify(
+          JsObject(
+            Seq(
+              "addedField" -> JsNumber(2),
+              "newerName"  -> JsString("some value")
             )
           )
-          .getBytes(StandardCharsets.UTF_8)
+        )
+        .getBytes(StandardCharsets.UTF_8)
 
-        val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
+      val expectedEvent = MigratedEvent(addedField = 2, newName = "some value")
 
-        val futureVersion  = TestRegistry4.supportedVersion
-        val futureManifest = expectedVersionedManifest(classOf[MigratedEvent], futureVersion)
-        val serializeExt = SerializationExtension(system)
-        val serializer   = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
+      val futureVersion  = TestRegistry4.supportedVersion
+      val futureManifest = expectedVersionedManifest(classOf[MigratedEvent], futureVersion)
+      val serializeExt   = SerializationExtension(system)
+      val serializer     = serializeExt.findSerializerFor(expectedEvent).asInstanceOf[SerializerWithStringManifest]
 
-        val deserialized = serializer.fromBinary(newerJsonBytes, futureManifest)
+      val deserialized = serializer.fromBinary(newerJsonBytes, futureManifest)
 
-        deserialized should be(expectedEvent)
+      deserialized should be(expectedEvent)
     }
-
-
-
 
     "use compression when enabled and payload is bigger than threshold" in withActorSystem(TestRegistryWithCompression) {
       system =>


### PR DESCRIPTION
Support forward-one migrations.

Refs https://github.com/akka/akka/pull/29514

Needs backporting to `1.6.x`