### PR TITLE
Documentation on Consuming message metadata

### DIFF
--- a/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/AnotherServiceImpl.scala
+++ b/docs/manual/scala/guide/broker/code/docs/scaladsl/mb/AnotherServiceImpl.scala
@@ -51,7 +51,7 @@ class AnotherServiceImpl(helloService: HelloService) extends AnotherService {
       .subscribe
       .withMetadata
       .atLeastOnce(
-        Flow[Message[GreetingMessage]].map { msg =>
+        Flow[Message[Option[GreetingMessage]]].map { msg =>
           val greetingMessage = msg.payload
           val messageKey      = msg.messageKeyAsString
           val kafkaHeaders    = msg.get(KafkaMetadataKeys.Headers)


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes Documentation

## Purpose

This PR fixed the documentation example for the MessageBroker API that consumes from Kafka using a Flow.
## Background Context

While trying to Consume from Kafka using the MessageBroker API, I noticed that the document specifies the `Flow` to be  `Flow[Message[GreetingMessage]].map` but when actually trying it out I got a type mismatch:

```
found   : akka.stream.scaladsl.Flow[com.lightbend.lagom.scaladsl.api.broker.Message[GreetingMessage],akka.Done.type,akka.NotUsed]
[error]  required: akka.stream.scaladsl.Flow[com.lightbend.lagom.scaladsl.api.broker.Message[Option[GreetingMessage]]], akka.Done, _]
```
The Message broker API, in the case of with `withMetadata`, requires a `Flow[Option[A]]` instead of a `Flow[A]`

After changing it to a Flow[Option[A]], it works as it should.


## References

Are there any relevant issues / PRs / mailing lists discussions?
