### PR TITLE
Make product deletion sbt 1.4.x compatible

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,14 +230,14 @@ def multiJvm(project: Project): Project = {
 }
 
 def macroCompileSettings: Seq[Setting[_]] = Seq(
-  compile in Test ~= { a =>
+  compile in Test := {
     // Delete classes in "compile" packages after compiling.
     // These are used for compile-time tests and should be recompiled every time.
-    val products = (a.asInstanceOf[sbt.internal.inc.Analysis]).relations.allProducts.toSeq ** new SimpleFileFilter(
+    val products = (crossTarget in Test).value ** new SimpleFileFilter(
       _.getParentFile.getName == "compile"
     )
     IO.delete(products.get)
-    a
+    (compile in Test).value
   }
 )
 


### PR DESCRIPTION
In zinc 1.4.0, the return type of Analysis.relations changes from File
to VirtualFileRef. There is no good way to make the logic in
macroCompileSettings work after the type signature change so this commit
attempts to reproduce the logic without touching the analysis file. I
verified that ServiceClientMacroErrors was recompiled every time I ran
client-scaladsl/test after this change.

# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you added copyright headers to new files?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes #xxxx

## Purpose

What does this PR do?

## Background Context

Why did you take this approach?

## References

Are there any relevant issues / PRs / mailing lists discussions?
