### PR TITLE
#3058 - service reader fails to read descriptor with default method with parameters

### DIFF
--- a/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
+++ b/service/javadsl/api/src/main/scala/com/lightbend/lagom/internal/javadsl/api/ServiceReader.scala
@@ -55,9 +55,14 @@ object ServiceReader {
           // Now using unreflect special, we get the default method from the declaring class, rather than the proxy
           .unreflectSpecial(method, method.getDeclaringClass)
     } else {
-      val lookup     = MethodHandles.lookup
-      val returnType = MethodType.methodType(classOf[Descriptor])
-      method => lookup.findSpecial(method.getDeclaringClass, method.getName, returnType, method.getDeclaringClass)
+      val lookup = MethodHandles.lookup
+      method =>
+        lookup.findSpecial(
+          method.getDeclaringClass,
+          method.getName,
+          MethodType.methodType(method.getReturnType, method.getParameterTypes),
+          method.getDeclaringClass
+        )
     }
   }
 

--- a/service/javadsl/api/src/test/java/com/lightbend/lagom/api/mock/DefaultMethodWithParamsService.java
+++ b/service/javadsl/api/src/test/java/com/lightbend/lagom/api/mock/DefaultMethodWithParamsService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package com.lightbend.lagom.api.mock;
+
+import com.lightbend.lagom.javadsl.api.Descriptor;
+import com.lightbend.lagom.javadsl.api.Service;
+import com.lightbend.lagom.javadsl.api.ServiceCall;
+import com.lightbend.lagom.javadsl.api.transport.Method;
+
+import java.util.UUID;
+
+import static com.lightbend.lagom.javadsl.api.Service.named;
+import static com.lightbend.lagom.javadsl.api.Service.restCall;
+
+public interface DefaultMethodWithParamsService extends Service {
+
+  ServiceCall<UUID, String> hello(String name);
+
+  default String serviceName(String param) {
+    return param;
+  }
+
+  @Override
+  default Descriptor descriptor() {
+    return named(serviceName("my-service"))
+        .withCalls(restCall(Method.GET, "/hello/:name", this::hello));
+  }
+}

--- a/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
+++ b/service/javadsl/api/src/test/scala/com/lightbend/lagom/internal/api/ServiceReaderSpec.scala
@@ -46,6 +46,19 @@ class ServiceReaderSpec extends AnyWordSpec with Matchers with Inside {
       endpoint.responseSerializer should ===(MessageSerializers.STRING)
     }
 
+    "read a Java service descriptor with default method with parameters" in {
+      val descriptor = serviceDescriptor[DefaultMethodWithParamsService]
+
+      descriptor.calls().size() should ===(1)
+      val endpoint = descriptor.calls().get(0)
+
+      endpoint.callId() should ===(new RestCallId(Method.GET, "/hello/:name"))
+      inside(endpoint.requestSerializer) {
+        case simple: SimpleSerializer[_] => simple.`type` should ===(classOf[UUID])
+      }
+      endpoint.responseSerializer should ===(MessageSerializers.STRING)
+    }
+
     "fail to read a Java service descriptor from a public interface because the path parameter could not be serialized" in {
       intercept[IllegalPathParameterException] {
         val descriptor = serviceDescriptor[InvalidPathParameterService]


### PR DESCRIPTION
## Fixes

Fixes #3058

## References

See (https://github.com/lagom/lagom/pull/3057) that reproduces this bug
