### PR TITLE
Support a mapping of Lagom topic id to real Kafka topic name

### DIFF
--- a/docs/manual/java/guide/broker/KafkaClient.md
+++ b/docs/manual/java/guide/broker/KafkaClient.md
@@ -38,6 +38,8 @@ Second, we have configuration that is specific to the publisher and the subscrib
 
 Third, the consumer has a few more configuration keys allowing you to decide how often the read-side offset is persisted in the datastore. When tuning these values, you are trading performances (storing the offset every time a message is consumed can be costly), with the risk of having to re-process some message if a failure occurs.
 
+Four, Lagom uses topic id as Kafka topic name by default. But sometime Kafka topics can be differently named by your naming conventions for different environments. For this case you can use a `topic-name-mappings` property for mapping of Lagom topic id to real Kafka topic name.
+
 ### Alpakka Kafka configuration
 
 See the [Alpakka Kafka producer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/producer.html#settings) and [Alpakka Kafka consumer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/consumer.html#settings) to find out about the available configuration parameters.

--- a/docs/manual/scala/guide/broker/KafkaClient.md
+++ b/docs/manual/scala/guide/broker/KafkaClient.md
@@ -28,6 +28,8 @@ Second, we have configuration that is specific to the publisher and the subscrib
 
 Third, the consumer has a few more configuration keys allowing you to decide how often the read-side offset is persisted in the datastore. When tuning these values, you are trading performances (storing the offset every time a message is consumed can be costly), with the risk of having to re-process some message if a failure occurs.
 
+Four, Lagom uses topic id as Kafka topic name by default. But sometime Kafka topics can be differently named by your naming conventions for different environments. For this case you can use a `topic-name-mappings` property for mapping of Lagom topic id to real Kafka topic name.
+
 ### Alpakka Kafka configuration
 
 See the [Alpakka Kafka producer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/producer.html#settings) and [Alpakka Kafka consumer settings](https://doc.akka.io/docs/alpakka-kafka/1.0/consumer.html#settings) to find out about the available configuration parameters.

--- a/service/core/kafka/client/src/main/resources/reference.conf
+++ b/service/core/kafka/client/src/main/resources/reference.conf
@@ -16,6 +16,14 @@ lagom.broker.kafka {
   # This will be ignored if the service-name configuration is non empty.
   brokers = ${lagom.broker.defaults.kafka.brokers}
 
+  # A mapping of Lagom topic id to real Kafka topic name.
+  # For example:
+  # topic-name-mappings {
+  #   topic-id = kafka-topic-name
+  # }
+  topic-name-mappings {
+  }
+
   client {
     default {
       # how long should we wait when retrieving the last known offset

--- a/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
+++ b/service/javadsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaSubscriber.scala
@@ -118,7 +118,9 @@ private[lagom] class JavadslKafkaSubscriber[Payload, SubscriberPayload](
       .withClientId(s"${info.serviceName()}-$consumerId")
   }
 
-  private def subscription = Subscriptions.topics(topicCall.topicId().value)
+  private def subscription = Subscriptions.topics(
+    kafkaConfig.topicNameMapping.getOrElse(topicCall.topicId().value, topicCall.topicId().value)
+  )
 
   override def atMostOnceSource: Source[SubscriberPayload, _] = {
     kafkaConfig.serviceName match {

--- a/service/javadsl/kafka/server/src/test/resources/application.conf
+++ b/service/javadsl/kafka/server/src/test/resources/application.conf
@@ -10,3 +10,7 @@ lagom.broker.kafka.client.producer.failure-exponential-backoff {
 
 #akka.kafka.consumer.wakeup-timeout = 3s
 akka.kafka.client.consumer.max-wakeups = 20
+
+lagom.broker.kafka.topic-name-mappings {
+  test7 = "test7-prod"
+}

--- a/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
+++ b/service/javadsl/kafka/server/src/test/scala/com/lightbend/lagom/internal/javadsl/broker/kafka/JavadslKafkaApiSpec.scala
@@ -95,7 +95,7 @@ class JavadslKafkaApiSpec
         "lagom.cluster.join-self"                       -> "on",
         "lagom.cluster.exit-jvm-when-system-terminated" -> "off",
         "lagom.cluster.bootstrap.enabled"               -> "off",
-        "lagom.services.kafka_native"                   -> s"tcp://localhost:$kafkaPort"
+        "lagom.services.kafka_native"                   -> s"tcp://localhost:$kafkaPort",
       )
       .build()
   }
@@ -359,7 +359,7 @@ class JavadslKafkaApiSpec
 
       def runAssertions(msg: Message[String]): Unit = {
         msg.messageKeyAsString shouldBe "A"
-        msg.get(KafkaMetadataKeys.TOPIC).asScala.value shouldBe "test7"
+        msg.get(KafkaMetadataKeys.TOPIC).asScala.value shouldBe "test7-prod"
         msg.get(KafkaMetadataKeys.HEADERS).asScala should not be None
         msg.get(KafkaMetadataKeys.TIMESTAMP).asScala should not be None
         msg.get(KafkaMetadataKeys.TIMESTAMP_TYPE).asScala should not be None

--- a/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaSubscriber.scala
+++ b/service/scaladsl/kafka/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kafka/ScaladslKafkaSubscriber.scala
@@ -113,7 +113,9 @@ private[lagom] class ScaladslKafkaSubscriber[Payload, SubscriberPayload](
       .withClientId(s"${info.serviceName}-$consumerId")
   }
 
-  private def subscription = Subscriptions.topics(topicCall.topicId.name)
+  private def subscription = Subscriptions.topics(
+    kafkaConfig.topicNameMapping.getOrElse(topicCall.topicId.name, topicCall.topicId.name)
+  )
 
   override def atMostOnceSource: Source[SubscriberPayload, _] = {
     kafkaConfig.serviceName match {

--- a/service/scaladsl/kafka/server/src/test/resources/application.conf
+++ b/service/scaladsl/kafka/server/src/test/resources/application.conf
@@ -8,3 +8,7 @@ lagom.broker.kafka.client.producer.failure-exponential-backoff {
 
 #akka.kafka.consumer.wakeup-timeout = 3s
 akka.kafka.client.consumer.max-wakeups = 20
+
+lagom.broker.kafka.topic-name-mappings {
+  test7 = "test7-prod"
+}

--- a/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
+++ b/service/scaladsl/kafka/server/src/test/scala/com/lightbend/lagom/scaladsl/kafka/broker/ScaladslKafkaApiSpec.scala
@@ -331,7 +331,7 @@ class ScaladslKafkaApiSpec
       messages.size shouldBe 3
       def runAssertions(msg: Message[String]): Unit = {
         msg.messageKeyAsString shouldBe "A"
-        msg.get(KafkaMetadataKeys.Topic).value shouldBe "test7"
+        msg.get(KafkaMetadataKeys.Topic).value shouldBe "test7-prod"
         msg.get(KafkaMetadataKeys.Headers) should not be None
         msg.get(KafkaMetadataKeys.Timestamp) should not be None
         msg.get(KafkaMetadataKeys.TimestampType) should not be None


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Purpose

Customization name of Kafka topics.

## References

More than a hundred Kafka instances in our test environments and impossibility sharing one instance for many environments. 😞 
