### PR TITLE
sbt-plugin: handle AssertionError from zinc compilation (bp #3096)

### DIFF
--- a/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/run/RunSupportCompat.scala
+++ b/dev/sbt-plugin/src/main/scala-sbt-1.0/com/lightbend/lagom/sbt/run/RunSupportCompat.scala
@@ -19,6 +19,7 @@ import com.lightbend.lagom.dev.Reloader.CompileFailure
 import com.lightbend.lagom.dev.Reloader.CompileResult
 import com.lightbend.lagom.dev.Reloader.CompileSuccess
 import com.lightbend.lagom.dev.Reloader.Source
+import scala.util.control.NonFatal
 
 trait RunSupportCompat {
   def taskFailureHandler(incomplete: Incomplete, streams: Option[Streams]): PlayException = {
@@ -32,7 +33,7 @@ trait RunSupportCompat {
             .find(_.severity == xsbti.Severity.Error)
             .map(CompilationException)
             .getOrElse(UnexpectedException(Some("The compilation failed without reporting any problem!"), Some(e)))
-        case e: Exception => UnexpectedException(unexpected = Some(e))
+        case NonFatal(e) => UnexpectedException(unexpected = Some(e))
       }
       .getOrElse {
         UnexpectedException(Some("The compilation task failed without any exception!"))


### PR DESCRIPTION
This is a manual backport of #3096. 

The code was quite different in 1.6.x. The affected code was moved into `RunSupportCompat`, which surprises me that `master` doesn't have the same structure. 