### PR TITLE
enrich AskTimeoutException with entity context

### DIFF
--- a/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
+++ b/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
@@ -10,6 +10,7 @@ import static com.lightbend.lagom.internal.persistence.testkit.PersistenceTestCo
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -121,7 +122,12 @@ public class PersistentEntityRefTest {
       try {
         reply.toCompletableFuture().get(20, SECONDS);
       } catch (ExecutionException e) {
-        throw e.getCause();
+        Throwable cause = e.getCause();
+        assertTrue(
+            cause
+                .getMessage()
+                .startsWith("Ask timed out on [PersistentEntityRef(10)] after [1 ms]."));
+        throw cause;
       }
     }
   }

--- a/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
+++ b/persistence-cassandra/javadsl/src/test/java/com/lightbend/lagom/javadsl/persistence/PersistentEntityRefTest.java
@@ -123,10 +123,11 @@ public class PersistentEntityRefTest {
         reply.toCompletableFuture().get(20, SECONDS);
       } catch (ExecutionException e) {
         Throwable cause = e.getCause();
-        assertTrue(
-            cause
-                .getMessage()
-                .startsWith("Ask timed out on [PersistentEntityRef(10)] after [1 ms]."));
+        assertEquals(
+            "Ask timed out on [PersistentEntityRef(10)] after [1 ms]. "
+                + "Message of type [class com.lightbend.lagom.javadsl.persistence.TestEntity$Add]. "
+                + "A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply.",
+            cause.getMessage());
         throw cause;
       }
     }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
@@ -137,7 +137,9 @@ class PersistentEntityRefSpec
         for (i <- 0 until 100) yield ref.ask(TestEntity.Add("c"))
 
       import scala.concurrent.ExecutionContext.Implicits.global
-      Future.sequence(replies).failed.futureValue(Timeout(20.seconds)) shouldBe an[AskTimeoutException]
+      val result = Future.sequence(replies).failed.futureValue(Timeout(20.seconds))
+      result shouldBe an[AskTimeoutException]
+      result.getMessage should startWith("Ask timed out on [PersistentEntityRef(10)] after [1 ms].")
     }
 
     "fail future on invalid command" in {

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/PersistentEntityRefSpec.scala
@@ -139,7 +139,11 @@ class PersistentEntityRefSpec
       import scala.concurrent.ExecutionContext.Implicits.global
       val result = Future.sequence(replies).failed.futureValue(Timeout(20.seconds))
       result shouldBe an[AskTimeoutException]
-      result.getMessage should startWith("Ask timed out on [PersistentEntityRef(10)] after [1 ms].")
+      val expectedMsg =
+        "Ask timed out on [PersistentEntityRef(10)] after [1 ms]. " +
+          "Message of type [class com.lightbend.lagom.scaladsl.persistence.TestEntity$Add]. " +
+          "A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply."
+      result.getMessage shouldBe expectedMsg
     }
 
     "fail future on invalid command" in {

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRef.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRef.scala
@@ -4,8 +4,11 @@
 
 package com.lightbend.lagom.scaladsl.persistence
 
-import akka.actor.{ActorRef, ActorSystem, NoSerializationVerificationNeeded}
-import akka.pattern.{AskTimeoutException, ask => akkaAsk}
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.NoSerializationVerificationNeeded
+import akka.pattern.AskTimeoutException
+import akka.pattern.{ ask => akkaAsk }
 import akka.util.Timeout
 
 import java.io.NotSerializableException

--- a/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRef.scala
+++ b/persistence/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/PersistentEntityRef.scala
@@ -4,16 +4,13 @@
 
 package com.lightbend.lagom.scaladsl.persistence
 
-import scala.concurrent.duration._
-import scala.concurrent.Future
-import akka.actor.ActorRef
-import java.io.NotSerializableException
-import akka.actor.NoSerializationVerificationNeeded
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem, NoSerializationVerificationNeeded}
+import akka.pattern.{AskTimeoutException, ask => akkaAsk}
 import akka.util.Timeout
-import akka.pattern.{ ask => akkaAsk }
-import org.slf4j.LoggerFactory
-import scala.util.Failure
+
+import java.io.NotSerializableException
+import scala.concurrent.Future
+import scala.concurrent.duration._
 
 /**
  * Commands are sent to a [[PersistentEntity]] using a
@@ -27,8 +24,6 @@ final class PersistentEntityRef[Command](
 ) extends NoSerializationVerificationNeeded {
   private implicit val timeout = Timeout(askTimeout)
 
-  private val logger = LoggerFactory.getLogger(getClass)
-
   /**
    * Send the `command` to the [[PersistentEntity]]. The returned
    * `Future` will be completed with the reply from the `PersistentEntity`.
@@ -39,7 +34,6 @@ final class PersistentEntityRef[Command](
    * The timeout can defined in configuration or overridden using [[#withAskTimeout]].
    */
   def ask[Cmd <: Command with PersistentEntity.ReplyType[_]](command: Cmd): Future[command.ReplyType] = {
-    import scala.compat.java8.FutureConverters._
     import system.dispatcher
     val result = (region ? CommandEnvelope(entityId, command))
       .flatMap {
@@ -48,14 +42,14 @@ final class PersistentEntityRef[Command](
           Future.failed(exc)
         case result => Future.successful(result)
       }
+      .recoverWith {
+        case cause: AskTimeoutException =>
+          val message =
+            s"Ask timed out on [$this] after [${timeout.duration.toMillis} ms]. Message of type [${command.getClass}]. " +
+              "A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply."
 
-    result.onComplete {
-      case Failure(ex) =>
-        logger.error(
-          s"${ex.getClass.getName} when sending command [${command.getClass}] to entity identified by [$entityId]"
-        )
-      case _ =>
-    }
+          Future.failed(new AskTimeoutException(message, cause))
+      }
 
     result.asInstanceOf[Future[command.ReplyType]]
   }


### PR DESCRIPTION
Rework of #3121 

Instead of logging, the `AskTimeoutException` is wrapped on a new one containing the entity context. 