### PR TITLE
3049: Added akka persistence testkit to dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -667,7 +667,6 @@ object Dependencies {
     akkaJackson,
     akkaStream,
     play,
-    akkaPersistenceTestkit,
     akkaPersistenceCassandraLauncher,
     // Upgrades needed to match allowed versions
     sslConfig,
@@ -789,7 +788,6 @@ object Dependencies {
     akkaManagementClusterHttp,
     akkaProtobuf_v3,
     akkaTestkit          % Test,
-    akkaPersistenceTestkit % Test,
     akkaMultiNodeTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
@@ -822,7 +820,6 @@ object Dependencies {
   val `cluster-javadsl` = libraryDependencies ++= Seq(
     akkaTestkit          % Test,
     akkaMultiNodeTestkit % Test,
-    akkaPersistenceTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
     "com.novocode"       % "junit-interface" % "0.11" % Test,
@@ -833,7 +830,6 @@ object Dependencies {
   val `cluster-scaladsl` = libraryDependencies ++= Seq(
     akkaTestkit          % Test,
     akkaMultiNodeTestkit % Test,
-    akkaPersistenceTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
     "com.novocode"       % "junit-interface" % "0.11" % Test,
@@ -910,7 +906,6 @@ object Dependencies {
     akkaSlf4j,
     play,
     akkaTestkit          % Test,
-    akkaPersistenceTestkit % Test,
     akkaMultiNodeTestkit % Test,
     akkaStreamTestkit    % Test,
     scalaTest            % Test,
@@ -926,7 +921,6 @@ object Dependencies {
     akkaPersistence,
     akkaTestkit,
     akkaTestkitTyped,
-    akkaPersistenceTestkit,
     slf4jApi,
     scalaJava8Compat,
     // Upgrades needed to match allowed versions
@@ -936,15 +930,13 @@ object Dependencies {
   val `persistence-javadsl` = libraryDependencies ++= Seq(
     slf4jApi,
     // this mean we have production code depending on testkit
-    akkaTestkit,
-    akkaPersistenceTestkit
+    akkaTestkit
   )
 
   val `persistence-scaladsl` = libraryDependencies ++= Seq(
     slf4jApi,
     // this mean we have production code depending on testkit
-    akkaTestkit,
-    akkaPersistenceTestkit
+    akkaTestkit
   )
   val `persistence-cassandra-core` = libraryDependencies ++= Seq(
     slf4jApi,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -109,20 +109,20 @@ object Dependencies {
   private val cassandraDriverCore =
     ("com.datastax.cassandra" % "cassandra-driver-core" % Versions.CassandraDriver).excludeAll(excludeSlf4j: _*)
 
-  private val akkaActor            = "com.typesafe.akka" %% "akka-actor" % Versions.Akka
-  private val akkaRemote           = "com.typesafe.akka" %% "akka-remote" % Versions.Akka
-  private val akkaCluster          = "com.typesafe.akka" %% "akka-cluster" % Versions.Akka
-  private val akkaClusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding" % Versions.Akka
-  private val akkaClusterTools     = "com.typesafe.akka" %% "akka-cluster-tools" % Versions.Akka
-  private val akkaDistributedData  = "com.typesafe.akka" %% "akka-distributed-data" % Versions.Akka
-  private val akkaJackson          = "com.typesafe.akka" %% "akka-serialization-jackson" % Versions.Akka
-  private val akkaMultiNodeTestkit = "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.Akka
-  private val akkaPersistence      = "com.typesafe.akka" %% "akka-persistence" % Versions.Akka
-  private val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % Versions.Akka
+  private val akkaActor              = "com.typesafe.akka" %% "akka-actor" % Versions.Akka
+  private val akkaRemote             = "com.typesafe.akka" %% "akka-remote" % Versions.Akka
+  private val akkaCluster            = "com.typesafe.akka" %% "akka-cluster" % Versions.Akka
+  private val akkaClusterSharding    = "com.typesafe.akka" %% "akka-cluster-sharding" % Versions.Akka
+  private val akkaClusterTools       = "com.typesafe.akka" %% "akka-cluster-tools" % Versions.Akka
+  private val akkaDistributedData    = "com.typesafe.akka" %% "akka-distributed-data" % Versions.Akka
+  private val akkaJackson            = "com.typesafe.akka" %% "akka-serialization-jackson" % Versions.Akka
+  private val akkaMultiNodeTestkit   = "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.Akka
+  private val akkaPersistence        = "com.typesafe.akka" %% "akka-persistence" % Versions.Akka
+  private val akkaPersistenceQuery   = "com.typesafe.akka" %% "akka-persistence-query" % Versions.Akka
   private val akkaPersistenceTestkit = "com.typesafe.akka" %% "akka-persistence-testkit" % Versions.Akka
-  private val akkaSlf4j            = ("com.typesafe.akka" %% "akka-slf4j" % Versions.Akka).excludeAll(excludeSlf4j: _*)
-  private val akkaStream           = "com.typesafe.akka" %% "akka-stream" % Versions.Akka
-  private val akkaProtobuf_v3      = "com.typesafe.akka" %% "akka-protobuf-v3" % Versions.Akka
+  private val akkaSlf4j              = ("com.typesafe.akka" %% "akka-slf4j" % Versions.Akka).excludeAll(excludeSlf4j: _*)
+  private val akkaStream             = "com.typesafe.akka" %% "akka-stream" % Versions.Akka
+  private val akkaProtobuf_v3        = "com.typesafe.akka" %% "akka-protobuf-v3" % Versions.Akka
 
   // akka typed dependencies
   private val akkaActorTyped           = "com.typesafe.akka" %% "akka-actor-typed"            % Versions.Akka
@@ -282,6 +282,7 @@ object Dependencies {
       akkaManagementClusterBootstrap,
       akkaPersistenceCassandra,
       akkaPersistenceCassandraLauncher,
+      akkaPersistenceTestkit,
       sprayJson,
       "com.typesafe.netty" % "netty-reactive-streams"      % Versions.NettyReactiveStreams,
       "com.typesafe.netty" % "netty-reactive-streams-http" % Versions.NettyReactiveStreams,
@@ -403,7 +404,6 @@ object Dependencies {
       "akka-persistence-typed",
       "akka-actor-testkit-typed", // remove this when https://github.com/akka/akka/pull/27830 is fixed
       "akka-persistence-query",
-      "akka-persistence-testkit",
       "akka-protobuf-v3",
       "akka-remote",
       "akka-slf4j",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -119,6 +119,7 @@ object Dependencies {
   private val akkaMultiNodeTestkit = "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.Akka
   private val akkaPersistence      = "com.typesafe.akka" %% "akka-persistence" % Versions.Akka
   private val akkaPersistenceQuery = "com.typesafe.akka" %% "akka-persistence-query" % Versions.Akka
+  private val akkaPersistenceTestkit = "com.typesafe.akka" %% "akka-persistence-testkit" % Versions.Akka
   private val akkaSlf4j            = ("com.typesafe.akka" %% "akka-slf4j" % Versions.Akka).excludeAll(excludeSlf4j: _*)
   private val akkaStream           = "com.typesafe.akka" %% "akka-stream" % Versions.Akka
   private val akkaProtobuf_v3      = "com.typesafe.akka" %% "akka-protobuf-v3" % Versions.Akka
@@ -402,6 +403,7 @@ object Dependencies {
       "akka-persistence-typed",
       "akka-actor-testkit-typed", // remove this when https://github.com/akka/akka/pull/27830 is fixed
       "akka-persistence-query",
+      "akka-persistence-testkit",
       "akka-protobuf-v3",
       "akka-remote",
       "akka-slf4j",
@@ -665,6 +667,7 @@ object Dependencies {
     akkaJackson,
     akkaStream,
     play,
+    akkaPersistenceTestkit,
     akkaPersistenceCassandraLauncher,
     // Upgrades needed to match allowed versions
     sslConfig,
@@ -786,6 +789,7 @@ object Dependencies {
     akkaManagementClusterHttp,
     akkaProtobuf_v3,
     akkaTestkit          % Test,
+    akkaPersistenceTestkit % Test,
     akkaMultiNodeTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
@@ -818,6 +822,7 @@ object Dependencies {
   val `cluster-javadsl` = libraryDependencies ++= Seq(
     akkaTestkit          % Test,
     akkaMultiNodeTestkit % Test,
+    akkaPersistenceTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
     "com.novocode"       % "junit-interface" % "0.11" % Test,
@@ -828,6 +833,7 @@ object Dependencies {
   val `cluster-scaladsl` = libraryDependencies ++= Seq(
     akkaTestkit          % Test,
     akkaMultiNodeTestkit % Test,
+    akkaPersistenceTestkit % Test,
     scalaTest            % Test,
     junit                % Test,
     "com.novocode"       % "junit-interface" % "0.11" % Test,
@@ -904,6 +910,7 @@ object Dependencies {
     akkaSlf4j,
     play,
     akkaTestkit          % Test,
+    akkaPersistenceTestkit % Test,
     akkaMultiNodeTestkit % Test,
     akkaStreamTestkit    % Test,
     scalaTest            % Test,
@@ -919,6 +926,7 @@ object Dependencies {
     akkaPersistence,
     akkaTestkit,
     akkaTestkitTyped,
+    akkaPersistenceTestkit,
     slf4jApi,
     scalaJava8Compat,
     // Upgrades needed to match allowed versions
@@ -928,13 +936,15 @@ object Dependencies {
   val `persistence-javadsl` = libraryDependencies ++= Seq(
     slf4jApi,
     // this mean we have production code depending on testkit
-    akkaTestkit
+    akkaTestkit,
+    akkaPersistenceTestkit
   )
 
   val `persistence-scaladsl` = libraryDependencies ++= Seq(
     slf4jApi,
     // this mean we have production code depending on testkit
-    akkaTestkit
+    akkaTestkit,
+    akkaPersistenceTestkit
   )
   val `persistence-cassandra-core` = libraryDependencies ++= Seq(
     slf4jApi,


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [X] Have you added copyright headers to new files?
* [X] Have you updated the documentation?
* [X] Have you added tests for any changed functionality?

## Fixes

N/A

## Purpose

Adds the akka-persistence-testkit to the list of dependencies, especially in lagom-maven-dependencies BOM

## Background Context

In response to Include akka-persistence-testkit dependency in lagom-maven-dependencies BOM #3049

## References

Are there any relevant issues / PRs / mailing lists discussions?

Include akka-persistence-testkit dependency in lagom-maven-dependencies BOM #3049