### PR TITLE
sbt 1.4 friendly version of Lombok

### DIFF
--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-persistence-typed-migration-java/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/akka-persistence-typed-migration-java/build.sbt
@@ -5,7 +5,7 @@ lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false
 
 val h2Driver = "com.h2database" % "h2" % "1.4.199"
-val lombok = "org.projectlombok" % "lombok" % "1.18.8"
+val lombok = "org.projectlombok" % "lombok" % "1.18.18"
 val hibernateEntityManager = "org.hibernate" % "hibernate-entitymanager" % "5.4.2.Final"
 val jpaApi  = "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final"
 val validationApi = "javax.validation" % "validation-api" % "1.1.0.Final"

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/projections-happy-path/build.sbt
@@ -1,4 +1,4 @@
-val lombok = "org.projectlombok" % "lombok" % "1.18.8"
+val lombok = "org.projectlombok" % "lombok" % "1.18.18"
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.3" % "provided"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.1.2" % Test
 

--- a/docs/manual/java/concepts/code/lagom-immutables.sbt
+++ b/docs/manual/java/concepts/code/lagom-immutables.sbt
@@ -3,6 +3,6 @@ libraryDependencies += lagomJavadslImmutables
 //#lagom-immutables
 
 //#lagom-immutables-lombok
-val lombok = "org.projectlombok" % "lombok" % "1.18.8"
+val lombok = "org.projectlombok" % "lombok" % "1.18.18"
 libraryDependencies += lombok
 //#lagom-immutables-lombok


### PR DESCRIPTION
Just released lombok 1.18.18 adds support for sbt's 1.4 virtual filesystem. I know this project still is on sbt 1.3, just avoiding future headaches.