### PR TITLE
Update Scala versions

### DIFF
--- a/docs/build.sbt
+++ b/docs/build.sbt
@@ -1,7 +1,7 @@
 import akka.JavaVersion
 import akka.CrossJava
 
-val ScalaVersion = "2.12.10"
+val ScalaVersion = "2.12.13"
 
 val AkkaVersion = sys.props.getOrElse("lagom.build.akka.version", "2.6.10") // sync with project/Dependencies.scala
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,8 +12,8 @@ object Dependencies {
   object Versions {
     // Version numbers
 
-    val Scala212 = "2.12.10"
-    val Scala213 = "2.13.1"
+    val Scala212 = "2.12.13"
+    val Scala213 = "2.13.5"
     val Scala    = Seq(Scala212, Scala213)
     val SbtScala = Seq(Scala212)
 


### PR DESCRIPTION
This should fix #3180 for now. 

At least we will be able to build again. The nowarn fix is not yet on 2.12.x and we should update as soon as it's released (see https://github.com/scala/bug/issues/12336).

I don't think we use `@nowarn` in Lagom. This is failing because of Akka. 