### PR TITLE
Ensure usage of Sala 2.12.13 and 2.13.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,19 +52,19 @@ jobs:
     - stage: validations-and-test
       script: bin/test-code-style
       name: "Code validations (format, binary compatibilty, whitesource, etc.)"
-    - script: SCALA_VERSION=2.12.10 bin/test-2.1x
+    - script: SCALA_VERSION=2.12.13 bin/test-2.1x
       name: "Run tests for Scala 2.12"
-    - script: SCALA_VERSION=2.12.10 bin/test-2.1x
+    - script: SCALA_VERSION=2.12.13 bin/test-2.1x
       env: TRAVIS_JDK=8
       name: "Run tests for Scala 2.12 and Java 8"
-    - script: SCALA_VERSION=2.13.0 bin/test-2.1x
+    - script: SCALA_VERSION=2.13.5 bin/test-2.1x
       name: "Run tests for Scala 2.13"
-    - script: SCALA_VERSION=2.12.10 bin/test-multi-jvm-2.1x
+    - script: SCALA_VERSION=2.12.13 bin/test-multi-jvm-2.1x
       name: "Run multi-jvm tests for Scala 2.12"
-    - script: SCALA_VERSION=2.12.10 bin/test-multi-jvm-2.1x
+    - script: SCALA_VERSION=2.12.13 bin/test-multi-jvm-2.1x
       env: TRAVIS_JDK=8
       name: "Run multi-jvm tests for Scala 2.12 and Java 8"
-    - script: SCALA_VERSION=2.13.0 bin/test-multi-jvm-2.1x
+    - script: SCALA_VERSION=2.13.5 bin/test-multi-jvm-2.1x
       name: "Run multi-jvm tests for Scala 2.13"
     - script: bin/test-documentation
       name: "Documentation validations and tests"
@@ -76,9 +76,9 @@ jobs:
       name: "Documentation tests (Java 8)"
 
     - stage: test-build-tools
-      script: SCALA_VERSION=2.12.10 bin/test-sbt
+      script: SCALA_VERSION=2.12.13 bin/test-sbt
       name: "Scripted tests for sbt 1"
-    - script: SCALA_VERSION=2.12.10 bin/test-sbt
+    - script: SCALA_VERSION=2.12.13 bin/test-sbt
       env: TRAVIS_JDK=8
       name: "Scripted tests for sbt 1 and Java 8"
     - script: bin/test-maven

--- a/bin/test-sbt
+++ b/bin/test-sbt
@@ -5,7 +5,7 @@
 # shellcheck source=bin/scriptLib
 . "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/scriptLib"
 
-SCALA_VERSION="${SCALA_VERSION:-2.12.10}"
+SCALA_VERSION="${SCALA_VERSION:-2.12.13}"
 
 # disable publishing javadoc for scripted
 runSbtNoisy ";set publishArtifact in (Compile, packageDoc) in ThisBuild := false ;+ server-containers/publishLocal;++$SCALA_VERSION publishScriptedDependencies ;++${SCALA_VERSION} scripted"

--- a/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
+++ b/dev/sbt-plugin/src/main/scala/com/lightbend/lagom/sbt/LagomPlugin.scala
@@ -404,21 +404,21 @@ object LagomPlugin extends AutoPlugin {
   private val serviceLocatorProject = Project("lagom-internal-meta-project-service-locator", file("."))
     .configure(p => p.in(file("target") / "lagom-dynamic-projects" / p.id))
     .settings(
-      scalaVersion := "2.12.10",
+      scalaVersion := "2.12.13",
       libraryDependencies += LagomImport.component("lagom-service-locator")
     )
 
   private val cassandraProject = Project("lagom-internal-meta-project-cassandra", file("."))
     .configure(p => p.in(file("target") / "lagom-dynamic-projects" / p.id))
     .settings(
-      scalaVersion := "2.12.10",
+      scalaVersion := "2.12.13",
       libraryDependencies += LagomImport.component("lagom-cassandra-server")
     )
 
   private val kafkaServerProject = Project("lagom-internal-meta-project-kafka", file("."))
     .configure(p => p.in(file("target") / "lagom-dynamic-projects" / p.id))
     .settings(
-      scalaVersion := "2.12.10",
+      scalaVersion := "2.12.13",
       libraryDependencies += LagomImport.component("lagom-kafka-server")
     )
 

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cross-build/build.sbt
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cross-build/build.sbt
@@ -1,3 +1,3 @@
 import com.lightbend.lagom.sbt._
 enablePlugins(LagomJava)
-scalaVersion := sys.props.get("scala.version").getOrElse("2.12.10")
+scalaVersion := sys.props.get("scala.version").getOrElse("2.12.13")

--- a/dev/sbt-plugin/src/sbt-test/sbt-plugin/cross-build/test
+++ b/dev/sbt-plugin/src/sbt-test/sbt-plugin/cross-build/test
@@ -2,4 +2,4 @@
 # =======================
 
 # Test that a Lagom project can be cross-built.
-> ++2.12.10 compile
+> ++2.12.13 compile

--- a/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
+++ b/dev/sbt-scripted-tools/src/main/scala/com/lightbend/lagom/sbt/scripted/ScriptedTools.scala
@@ -54,7 +54,7 @@ object ScriptedTools extends AutoPlugin {
         )
       case None => Seq.empty
     }),
-    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.10")
+    scalaVersion := sys.props.get("scala.version").getOrElse("2.12.13")
   )
 
   private def validateRequestImpl = Def.inputTask {


### PR DESCRIPTION
This force travis and scripted tests to use Scala 2.12.13 and 2.13.5.

Note, commit 1f5f44b is updating Akka to 2.6.13. This is temporary and will be reverted back to 2.6.10. 
I'm forcing it for now because I don't want to wait for a CRON job. 