### PR TITLE
Remove MaxMetaspaceSize limit

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,5 +1,4 @@
 -Xms2G
 -Xss2M
 -XX:MaxInlineLevel=18
--XX:MaxMetaspaceSize=1G
 -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ def common: Seq[Setting[_]] = releaseSettings ++ bintraySettings ++ evictionSett
   licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))),
   homepage := Some(url("https://www.lagomframework.com/")),
   sonatypeProfileName := "com.lightbend",
+  Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.ScalaLibrary,
   headerLicense := Some(
     HeaderLicense.Custom(
       // When updating, keep in sync with docs/build.sbt configuration

--- a/docs/.jvmopts
+++ b/docs/.jvmopts
@@ -2,5 +2,4 @@
 -Xmx2G
 -Xss2M
 -XX:MaxInlineLevel=18
--XX:MaxMetaspaceSize=1G
 -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2


### PR DESCRIPTION
This is a forward port of some changes I added in #3184. 

The build in #3184 was consistently failing with OOM because of the metaspace limit. We didn't observe it in `master` though, but I don't see a reason for having this limit in our builds.