### PR TITLE
Cassandra read side fault tolerance improvements

### DIFF
--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -76,9 +76,11 @@ private[lagom] abstract class CassandraOffsetStore(
   }
 
   private def prepareWriteOffset: Future[PreparedStatement] = {
-    session.prepare(
-      "INSERT INTO offsetStore (eventProcessorId, tag, timeUuidOffset, sequenceOffset) VALUES (?, ?, ?, ?)"
-    ).map(_.setConsistencyLevel(cassandraReadSideSettings.writeConsistency))
+    session
+      .prepare(
+        "INSERT INTO offsetStore (eventProcessorId, tag, timeUuidOffset, sequenceOffset) VALUES (?, ?, ?, ?)"
+      )
+      .map(_.setConsistencyLevel(cassandraReadSideSettings.writeConsistency))
   }
 
   private def readOffset(eventProcessorId: String, tag: String): Future[Offset] = {

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraOffsetStore.scala
@@ -78,7 +78,7 @@ private[lagom] abstract class CassandraOffsetStore(
   private def prepareWriteOffset: Future[PreparedStatement] = {
     session.prepare(
       "INSERT INTO offsetStore (eventProcessorId, tag, timeUuidOffset, sequenceOffset) VALUES (?, ?, ?, ?)"
-    )
+    ).map(_.setConsistencyLevel(cassandraReadSideSettings.writeConsistency))
   }
 
   private def readOffset(eventProcessorId: String, tag: String): Future[Offset] = {

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
@@ -6,6 +6,7 @@ package com.lightbend.lagom.internal.persistence.cassandra
 
 import javax.inject.Inject
 import akka.actor.ActorSystem
+import com.datastax.driver.core.ConsistencyLevel
 
 /**
  * Internal API
@@ -14,4 +15,5 @@ private[lagom] class CassandraReadSideSettings @Inject() (system: ActorSystem) {
   private val cassandraConfig = system.settings.config.getConfig("lagom.persistence.read-side.cassandra")
 
   val autoCreateTables: Boolean = cassandraConfig.getBoolean("tables-autocreate")
+  val writeConsistency: ConsistencyLevel = ConsistencyLevel.valueOf(cassandraConfig.getString("write-consistency"))
 }

--- a/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
+++ b/persistence-cassandra/core/src/main/scala/com/lightbend/lagom/internal/persistence/cassandra/CassandraReadSideSettings.scala
@@ -14,6 +14,6 @@ import com.datastax.driver.core.ConsistencyLevel
 private[lagom] class CassandraReadSideSettings @Inject() (system: ActorSystem) {
   private val cassandraConfig = system.settings.config.getConfig("lagom.persistence.read-side.cassandra")
 
-  val autoCreateTables: Boolean = cassandraConfig.getBoolean("tables-autocreate")
+  val autoCreateTables: Boolean          = cassandraConfig.getBoolean("tables-autocreate")
   val writeConsistency: ConsistencyLevel = ConsistencyLevel.valueOf(cassandraConfig.getString("write-consistency"))
 }

--- a/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraReadSideImpl.scala
+++ b/persistence-cassandra/javadsl/src/main/scala/com/lightbend/lagom/internal/javadsl/persistence/cassandra/CassandraReadSideImpl.scala
@@ -10,7 +10,6 @@ import java.util.concurrent.CompletionStage
 import java.util.function.BiFunction
 import java.util.function.Function
 import java.util.function.Supplier
-
 import javax.inject.Inject
 import javax.inject.Singleton
 import akka.Done
@@ -18,6 +17,7 @@ import akka.actor.ActorSystem
 import com.datastax.driver.core.BoundStatement
 import com.lightbend.lagom.internal.javadsl.persistence.ReadSideImpl
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.javadsl.persistence.ReadSideProcessor.ReadSideHandler
 import com.lightbend.lagom.javadsl.persistence._
 import com.lightbend.lagom.javadsl.persistence.cassandra.CassandraReadSide.ReadSideHandlerBuilder
@@ -32,6 +32,7 @@ import play.api.inject.Injector
 private[lagom] final class CassandraReadSideImpl @Inject() (
     system: ActorSystem,
     session: CassandraSession,
+    cassandraReadSideSettings: CassandraReadSideSettings,
     offsetStore: CassandraOffsetStore,
     readSide: ReadSideImpl,
     injector: Injector
@@ -79,6 +80,7 @@ private[lagom] final class CassandraReadSideImpl @Inject() (
       override def build(): ReadSideHandler[Event] = {
         new CassandraAutoReadSideHandler[Event](
           session,
+          cassandraReadSideSettings,
           offsetStore,
           handlers,
           globalPrepareCallback,

--- a/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/javadsl/src/test/scala/com/lightbend/lagom/javadsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -63,7 +63,8 @@ class CassandraReadSideSpec
   private lazy val testCasReadSideSettings: CassandraReadSideSettings = new CassandraReadSideSettings(system)
   private lazy val offsetStore =
     new JavadslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
-  private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore, null, injector)
+  private lazy val cassandraReadSide =
+    new CassandraReadSideImpl(system, testSession, testCasReadSideSettings, offsetStore, null, injector)
 
   override def processorFactory(): ReadSideProcessor[TestEntity.Evt] =
     new TestEntityReadSide.TestEntityReadSideProcessor(cassandraReadSide, testSession)

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraReadSideHandler.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraReadSideHandler.scala
@@ -68,7 +68,7 @@ private[cassandra] abstract class CassandraReadSideHandler[Event <: AggregateEve
 
         for {
           statements <- invoke(handler, elem)
-          _ <- executeStatements(statements)
+          _          <- executeStatements(statements)
           // important: only commit offset once read view
           // statements has completed successfully
           _ <- executeStatements(offsetStatement(elem.offset) :: Nil)
@@ -117,8 +117,8 @@ private[cassandra] final class CassandraAutoReadSideHandler[Event <: AggregateEv
       element: EventStreamElement[Event]
   ): Future[immutable.Seq[BoundStatement]] =
     handler
-        .asInstanceOf[EventStreamElement[Event] => Future[immutable.Seq[BoundStatement]]]
-        .apply(element)
+      .asInstanceOf[EventStreamElement[Event] => Future[immutable.Seq[BoundStatement]]]
+      .apply(element)
 
   override def globalPrepare(): Future[Done] = {
     globalPrepareCallback.apply()

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraReadSideImpl.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/internal/scaladsl/persistence/cassandra/CassandraReadSideImpl.scala
@@ -8,6 +8,7 @@ import akka.Done
 import akka.actor.ActorSystem
 import com.datastax.driver.core.BoundStatement
 import com.lightbend.lagom.internal.persistence.cassandra.CassandraOffsetStore
+import com.lightbend.lagom.internal.persistence.cassandra.CassandraReadSideSettings
 import com.lightbend.lagom.scaladsl.persistence.ReadSideProcessor.ReadSideHandler
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraReadSide.ReadSideHandlerBuilder
 import com.lightbend.lagom.scaladsl.persistence.cassandra.CassandraReadSide
@@ -26,6 +27,7 @@ import scala.reflect.ClassTag
 private[lagom] final class CassandraReadSideImpl(
     system: ActorSystem,
     session: CassandraSession,
+    cassandraReadSideSettings: CassandraReadSideSettings,
     offsetStore: CassandraOffsetStore
 ) extends CassandraReadSide {
   private val dispatcher = system.settings.config.getString("lagom.persistence.read-side.use-dispatcher")
@@ -59,6 +61,7 @@ private[lagom] final class CassandraReadSideImpl(
       override def build(): ReadSideHandler[Event] = {
         new CassandraAutoReadSideHandler[Event](
           session,
+          cassandraReadSideSettings,
           offsetStore,
           handlers,
           globalPrepareCallback,

--- a/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
+++ b/persistence-cassandra/scaladsl/src/main/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraPersistenceComponents.scala
@@ -63,5 +63,5 @@ trait ReadSideCassandraPersistenceComponents extends ReadSidePersistenceComponen
   lazy val offsetStore: OffsetStore = cassandraOffsetStore
 
   lazy val cassandraReadSide: CassandraReadSide =
-    new CassandraReadSideImpl(actorSystem, cassandraSession, cassandraOffsetStore)
+    new CassandraReadSideImpl(actorSystem, cassandraSession, testCasReadSideSettings, cassandraOffsetStore)
 }

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -59,7 +59,7 @@ class CassandraReadSideSpec
   private lazy val testSession: CassandraSession                      = new CassandraSession(system)
   private lazy val offsetStore =
     new ScaladslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
-  private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, offsetStore)
+  private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, testCasReadSideSettings, offsetStore)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
     new TestEntityReadSide.TestEntityReadSideProcessor(system, cassandraReadSide, testSession)

--- a/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
+++ b/persistence-cassandra/scaladsl/src/test/scala/com/lightbend/lagom/scaladsl/persistence/cassandra/CassandraReadSideSpec.scala
@@ -59,7 +59,8 @@ class CassandraReadSideSpec
   private lazy val testSession: CassandraSession                      = new CassandraSession(system)
   private lazy val offsetStore =
     new ScaladslCassandraOffsetStore(system, testSession, testCasReadSideSettings, ReadSideConfig())
-  private lazy val cassandraReadSide = new CassandraReadSideImpl(system, testSession, testCasReadSideSettings, offsetStore)
+  private lazy val cassandraReadSide =
+    new CassandraReadSideImpl(system, testSession, testCasReadSideSettings, offsetStore)
 
   override def processorFactory(): ReadSideProcessor[Evt] =
     new TestEntityReadSide.TestEntityReadSideProcessor(system, cassandraReadSide, testSession)


### PR DESCRIPTION
References #3206 

Set the configured consistency level on the read side update batch and offset update (instead of getting the default ONE consistency level for those). Also break read side and offset update into separate actions as a partially failing batch could potentially lead to offset being updated but the actual read side projection updates being lost.