### PR TITLE
[1.6.x] Sync exception logging level between Scala and Java server implementations

### DIFF
--- a/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
+++ b/service/scaladsl/server/src/main/scala/com/lightbend/lagom/internal/scaladsl/server/ScaladslServiceRouter.scala
@@ -93,8 +93,8 @@ class ScaladslServiceRouter(
 
   protected override def maybeLogException(exc: Throwable, log: => Logger, call: Call[_, _]) = {
     exc match {
-      case _: NotFound | _: Forbidden | _: BadRequest => // no logging
-      case e @ (_: UnsupportedMediaType | _: PayloadTooLarge | _: NotAcceptable) =>
+      case _: NotFound | _: Unauthorized | _: Forbidden | _: BadRequest => // no logging
+      case e @ (_: UnsupportedMediaType | _: PayloadTooLarge | _: NotAcceptable | _: TooManyRequests) =>
         log.warn(e.getMessage)
       case e =>
         log.error(s"Exception in ${call.callId}", e)


### PR DESCRIPTION
## References

Current `JavadslServiceRouter`

https://github.com/lagom/lagom/blob/c0c2fdb5d610b8092da840f8c60f9631038418ac/service/javadsl/server/src/main/scala/com/lightbend/lagom/internal/javadsl/server/JavadslServerBuilder.scala#L231-L239