### PR TITLE
Improve EventTag ReadSide storage with Cassandra documentation

### DIFF
--- a/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/java/guide/cluster/PersistentEntityCassandra.md
@@ -70,6 +70,16 @@ With these properties set to `false`, if the keyspaces or tables are missing at 
 
 Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://doc.akka.io/docs/akka-persistence-cassandra/0.100/) plugin. A full configuration reference is available in the plugin's [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.100/core/src/main/resources/reference.conf).
 
+### Important Note Regarding `lagom-persistence-cassandra` Configuration
+
+Using Cassandra for persistent entities relies on `akka-persistence`, which on application startup, must scan from an initial offset timestamp for the first events possibly recorded for those persistent entities. In [akka-persistence configuration](https://doc.akka.io/docs/akka-persistence-cassandra/current/events-by-tag.html), the `first-time-bucket` configuration is configured with lagom under:
+```hocon
+cassandra-query-journal {
+  first-time-bucket = "20160225T00:00"
+}
+```
+Which, for newer applications first launching, can cause a not-so-insignificant delay in reading from the event journal to the latest events. Therefore, make sure to set first-time-bucket to the date of the first deployment of your application when the journal was completely empty.
+
 ## Cassandra Location
 
 Lagom will start an embedded Cassandra server when running in developer mode. You can review the configuration options or how to disable the embedded server in the section on Cassandra Server in [[Running Lagom in development|CassandraServer]].

--- a/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
+++ b/docs/manual/scala/guide/cluster/PersistentEntityCassandra.md
@@ -70,6 +70,16 @@ With these properties set to `false`, if the keyspaces or tables are missing at 
 
 Lagom's Cassandra support is provided by the [`akka-persistence-cassandra`](https://doc.akka.io/docs/akka-persistence-cassandra/0.100/) plugin. A full configuration reference is available in the plugin's [`reference.conf`](https://github.com/akka/akka-persistence-cassandra/blob/v0.100/core/src/main/resources/reference.conf).
 
+### Important Note Regarding `lagom-persistence-cassandra` Configuration
+
+Using Cassandra for persistent entities relies on `akka-persistence`, which on application startup, must scan from an initial offset timestamp for the first events possibly recorded for those persistent entities. In [akka-persistence configuration](https://doc.akka.io/docs/akka-persistence-cassandra/current/events-by-tag.html), the `first-time-bucket` configuration is configured with lagom under:
+```hocon
+cassandra-query-journal {
+  first-time-bucket = "20160225T00:00"
+}
+```
+Which, for newer applications first launching, can cause a not-so-insignificant delay in reading from the event journal to the latest events. Therefore, make sure to set first-time-bucket to the date of the first deployment of your application when the journal was completely empty.
+
 ## Cassandra Location
 
 Lagom will start an embedded Cassandra server when running in developer mode. You can review the configuration options or how to disable the embedded server in the section on Cassandra Server in [[Running Lagom in development|CassandraServer]].


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?

## Fixes

Fixes lacking documentation awareness of lagom's change from akka-persistence-cassandra-core's `first-time-bucket` usage.

## Background Context

Most of the background is summarized with my [forum post](https://discuss.lightbend.com/t/topic-subscriber-extreme-delay-in-receiving-messages-in-development/8451) highlighting a lacking documentation of the known [akka issue for first-time-buckets](https://github.com/akka/akka-persistence-cassandra/issues/867), attempting to apply the same fix had no bearing on the results. Only after searching throughout did the configuration override within lagom show up as being applicable.

## References

- [akka-persistence-cassandra](https://github.com/akka/akka-persistence-cassandra/issues/867): First time bucket is pre-defined as a starting search since `2016...`
