### PR TITLE
fix: map future using execution context prepare

### DIFF
--- a/service/core/server/src/main/scala/com/lightbend/lagom/internal/server/ServiceRouter.scala
+++ b/service/core/server/src/main/scala/com/lightbend/lagom/internal/server/ServiceRouter.scala
@@ -7,7 +7,6 @@ package com.lightbend.lagom.internal.server
 import java.net.URI
 import java.util.Base64
 import java.util.concurrent.CompletionException
-
 import akka.NotUsed
 import akka.stream._
 import akka.stream.scaladsl.Flow
@@ -44,6 +43,7 @@ import play.api.routing.Router.Routes
 import play.api.routing.HandlerDef
 import play.api.routing.Router
 import play.api.routing.SimpleRouter
+import play.utils.ExecCtxUtils
 
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
@@ -252,7 +252,7 @@ private[lagom] abstract class ServiceRouter(httpConfiguration: HttpConfiguration
               )
               .withHeaders(toResponseHeaders(transformedResponseHeader): _*)
         }
-    }
+    }(ExecCtxUtils.prepare(ec))
   }
 
   private def logException(exc: Throwable, descriptor: Descriptor, call: Call[_, _]): Unit = {


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you added copyright headers to new files?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Fixes #3300 

## Purpose

Lagom should obey the same behaviour with play framework when using `mapFuture`.

## Background Context

Make lagom be able to do context propagation


