### PR TITLE
remove explicit dependency on log4j in kafka brokers

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1031,7 +1031,6 @@ object Dependencies {
 
   val `kafka-broker-javadsl` = libraryDependencies ++= Seq(
     slf4jApi,
-    "org.apache.logging.log4j"   % "log4j-core"                % "2.15.0",
     scalaTest % Test,
     junit     % Test,
     // Upgrades needed to match whitelist versions
@@ -1039,7 +1038,6 @@ object Dependencies {
   )
 
   val `kafka-broker-scaladsl` = libraryDependencies ++= Seq(
-    "org.apache.logging.log4j"   % "log4j-core"                % "2.15.0",
     scalaTest % Test,
     junit     % Test,
     // Upgrades needed to match whitelist versions

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -482,7 +482,6 @@ object Dependencies {
     "com.101tec"                 % "zkclient"             % "0.11",
     "com.yammer.metrics"         % "metrics-core"         % "2.2.0",
     "jline"                      % "jline"                % "0.9.94",
-    "log4j"                      % "log4j"                % "1.2.17",
     "com.typesafe.scala-logging" %% "scala-logging"       % "3.9.0",
     "net.sf.jopt-simple"         % "jopt-simple"          % "5.0.4",
     "org.apache.commons"         % "commons-math"         % "2.2",
@@ -1032,7 +1031,7 @@ object Dependencies {
 
   val `kafka-broker-javadsl` = libraryDependencies ++= Seq(
     slf4jApi,
-    "log4j"   % "log4j" % "1.2.17",
+    "org.apache.logging.log4j"   % "log4j-core"                % "2.15.0",
     scalaTest % Test,
     junit     % Test,
     // Upgrades needed to match whitelist versions
@@ -1040,7 +1039,7 @@ object Dependencies {
   )
 
   val `kafka-broker-scaladsl` = libraryDependencies ++= Seq(
-    "log4j"   % "log4j" % "1.2.17",
+    "org.apache.logging.log4j"   % "log4j-core"                % "2.15.0",
     scalaTest % Test,
     junit     % Test,
     // Upgrades needed to match whitelist versions


### PR DESCRIPTION
~Let the dev-mode kafka-brokers to use newer log4j version.~

Remove dependency to log4j in dev-mode kafka brokers.

