### PR TITLE
fix a bug of run-on-role

### DIFF
--- a/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistry.scala
+++ b/projection/core/src/main/scala/com/lightbend/lagom/internal/projection/ProjectionRegistry.scala
@@ -55,8 +55,6 @@ private[lagom] class ProjectionRegistry(system: ActorSystem) {
   ): Unit = {
     projectionRegistryRef ! ProjectionRegistryActor.RegisterProjection(projectionName, shardNames)
 
-    clusterShardingSettings.withRole(runInRole)
-
     clusterDistribution.start(
       projectionName,
       WorkerCoordinator.props(
@@ -66,7 +64,9 @@ private[lagom] class ProjectionRegistry(system: ActorSystem) {
         projectionRegistryRef
       ),
       shardNames,
-      ClusterDistributionSettings(system).copy(clusterShardingSettings = clusterShardingSettings)
+      ClusterDistributionSettings(system).copy(
+        clusterShardingSettings = clusterShardingSettings.withRole(runInRole)
+      )
     )
   }
 


### PR DESCRIPTION
# Pull Request Checklist

* [X] Have you read through the [contributor guidelines](https://github.com/lagom/lagom/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] ~Have you added copyright headers to new files?~
* [ ] ~Have you updated the documentation?~
* [ ] ~Have you added tests for any changed functionality?~

## Purpose

ProjectionRegistry should pass the value of ‘run-on-role’ to ClusterSharding.

## Background Context

During the testing for `run-on-role`, it didn’t work as expected even though set configuration correctly because the return value of 'clusterShardingSettings.withRole' method that has 'runInRole' isn't used below.  
