### PR TITLE
chore: run apt-get update before installing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -265,7 +265,9 @@ jobs:
         run: sbt "publishM2; mavenTest"
 
       - name: Install xmllint
-        run: sudo apt-get install -y libxml2-utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
 
       - name: Install xmlstarlet
         run: sudo apt-get install -y xmlstarlet


### PR DESCRIPTION
## Purpose

Make GitHub actions succeed at installing `xmllint`.

## Background Context

Workflows fail currently https://github.com/lagom/lagom/runs/5702995173?check_suite_focus=true